### PR TITLE
TIM time to live field fix

### DIFF
--- a/data/TIM_Message_Testing_Files/tim_region_multiRSU_8-29-17.json
+++ b/data/TIM_Message_Testing_Files/tim_region_multiRSU_8-29-17.json
@@ -99,6 +99,7 @@
     "status": "4"
   },
   "sdw": {
+    "ttl": "oneminute",
     "serviceRegion": {
       "nwCorner": {
         "latitude": "44.998459",

--- a/data/TIM_Message_Testing_Files/tim_region_singleRSU_8-29-17.json
+++ b/data/TIM_Message_Testing_Files/tim_region_singleRSU_8-29-17.json
@@ -87,6 +87,7 @@
     "status": "4"
   },
   "sdw": {
+    "ttl": "oneday",
     "serviceRegion": {
       "nwCorner": {
         "latitude": "44.998459",

--- a/data/TIM_Message_Testing_Files/tim_region_singleRSU_8-29-17_hexCRC.json
+++ b/data/TIM_Message_Testing_Files/tim_region_singleRSU_8-29-17_hexCRC.json
@@ -87,6 +87,7 @@
     "status": "4"
   },
   "sdw": {
+    "ttl": "thirtyminutes",
     "serviceRegion": {
       "nwCorner": {
         "latitude": "44.998459",

--- a/docs/ODESwagger.yaml
+++ b/docs/ODESwagger.yaml
@@ -582,7 +582,8 @@ definitions:
     properties:
       ttl:
         type: string
-        description: Time to live, one of: oneminute, thirtyminutes, oneday, oneweek, onemonth, oneyear.
+        description: Message time to live.
+        enum: [oneminute,thirtyminutes,oneday,oneweek,onemonth,oneyear]
       serviceRegion:
         properties:
           nwCorner:

--- a/docs/ODESwagger.yaml
+++ b/docs/ODESwagger.yaml
@@ -580,20 +580,25 @@ definitions:
   SDW:
     type: object
     properties:
-      nwCorner:
-        type: object
+      ttl:
+        type: string
+        description: Time to live, one of: oneminute, thirtyminutes, oneday, oneweek, onemonth, oneyear.
+      serviceRegion:
         properties:
-          latitude:
-            type: string
-          longitude:
-            type: string
-      seCorner:
-        type: object
-        properties:
-          latitude:
-            type: string
-          longitude:
-            type: string
+          nwCorner:
+            type: object
+            properties:
+              latitude:
+                type: string
+              longitude:
+                type: string
+          seCorner:
+            type: object
+            properties:
+              latitude:
+                type: string
+              longitude:
+                type: string
   PDM:
     type: object
     properties:

--- a/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/SituationDataWarehouse.java
+++ b/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/SituationDataWarehouse.java
@@ -1,5 +1,7 @@
 package us.dot.its.jpo.ode.plugin;
 
+import com.google.gson.annotations.SerializedName;
+
 import us.dot.its.jpo.ode.model.OdeObject;
 import us.dot.its.jpo.ode.plugin.j2735.J2735GeoRegion;
 
@@ -9,11 +11,22 @@ public class SituationDataWarehouse {
       private static final long serialVersionUID = -7731139391317960325L;
 
       public enum TimeToLive {
-         ONEMINUTE, THIRTYMINUTES, ONEDAY, ONEWEEK, ONEMONTH, ONEYEAR
+         @SerializedName("oneminute")
+         ONEMINUTE, 
+         @SerializedName("thirtyminutes")
+         THIRTYMINUTES, 
+         @SerializedName("oneday")
+         ONEDAY, 
+         @SerializedName("oneweek")
+         ONEWEEK, 
+         @SerializedName("onemonth")
+         ONEMONTH, 
+         @SerializedName("oneyear")
+         ONEYEAR
       }
 
       private J2735GeoRegion serviceRegion;
-      private TimeToLive ttl = TimeToLive.THIRTYMINUTES;
+      private TimeToLive ttl = null;
 
       public J2735GeoRegion getServiceRegion() {
          return serviceRegion;
@@ -24,6 +37,7 @@ public class SituationDataWarehouse {
       }
 
       public TimeToLive getTtl() {
+         if (ttl == null) return TimeToLive.THIRTYMINUTES;
          return ttl;
       }
 


### PR DESCRIPTION
Previously this field was ignored. Now users can set it to one of oneminute, thirtyminutes, oneday, oneweek, onemonth, oneyear.