### PR TITLE
ODE-592 Added message frames to RSU-bound TIMs

### DIFF
--- a/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/oss/OssTravelerMessageBuilder.java
+++ b/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/oss/OssTravelerMessageBuilder.java
@@ -8,12 +8,14 @@ import java.time.ZonedDateTime;
 import com.oss.asn1.Coder;
 import com.oss.asn1.EncodeFailedException;
 import com.oss.asn1.EncodeNotSupportedException;
+import com.oss.asn1.OpenType;
 
 import us.dot.its.jpo.ode.j2735.J2735;
 import us.dot.its.jpo.ode.j2735.dsrc.Circle;
 import us.dot.its.jpo.ode.j2735.dsrc.ComputedLane;
 import us.dot.its.jpo.ode.j2735.dsrc.ComputedLane.OffsetXaxis;
 import us.dot.its.jpo.ode.j2735.dsrc.ComputedLane.OffsetYaxis;
+import us.dot.its.jpo.ode.j2735.dsrc.DSRCmsgID;
 import us.dot.its.jpo.ode.j2735.dsrc.DeltaAngle;
 import us.dot.its.jpo.ode.j2735.dsrc.DescriptiveName;
 import us.dot.its.jpo.ode.j2735.dsrc.DirectionOfUse;
@@ -28,6 +30,7 @@ import us.dot.its.jpo.ode.j2735.dsrc.HeadingSlice;
 import us.dot.its.jpo.ode.j2735.dsrc.LaneDataAttribute;
 import us.dot.its.jpo.ode.j2735.dsrc.LaneDataAttributeList;
 import us.dot.its.jpo.ode.j2735.dsrc.LaneID;
+import us.dot.its.jpo.ode.j2735.dsrc.MessageFrame;
 import us.dot.its.jpo.ode.j2735.dsrc.MinuteOfTheYear;
 import us.dot.its.jpo.ode.j2735.dsrc.MsgCRC;
 import us.dot.its.jpo.ode.j2735.dsrc.MsgCount;
@@ -156,6 +159,16 @@ public class OssTravelerMessageBuilder {
       Coder coder = J2735.getPERUnalignedCoder();
       ByteArrayOutputStream sink = new ByteArrayOutputStream();
       coder.encode(travelerInfo, sink);
+      byte[] bytes = sink.toByteArray();
+      return CodecUtils.toHex(bytes);
+   }
+   
+   public String encodeTravelerInformationToMessageFrameHex() throws EncodeFailedException, EncodeNotSupportedException {
+      Coder coder = J2735.getPERUnalignedCoder();
+      coder.enableAutomaticEncoding();
+      ByteArrayOutputStream sink = new ByteArrayOutputStream();
+      MessageFrame mf = new MessageFrame(new DSRCmsgID(31), new OpenType(travelerInfo));
+      coder.encode(mf, sink);
       byte[] bytes = sink.toByteArray();
       return CodecUtils.toHex(bytes);
    }

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/traveler/TimController.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/traveler/TimController.java
@@ -267,10 +267,13 @@ public class TimController {
       }
 
       // Encode TIM
-      String rsuSRMPayload = null;
+      String timHexString = null;
+      String messageFrameHexString = null;
       try {
-         rsuSRMPayload = builder.encodeTravelerInformationToHex();
-         logger.debug("Encoded Hex TIM: {}", rsuSRMPayload);
+         timHexString = builder.encodeTravelerInformationToHex();
+         logger.debug("Encoded Hex TIM: {}", timHexString);
+         messageFrameHexString = builder.encodeTravelerInformationToMessageFrameHex();
+         logger.debug("Encoded Hex TIM in message frame: {}", messageFrameHexString);
       } catch (Exception e) {
          String errMsg = "Failed to encode TIM.";
          logger.error(errMsg, e);
@@ -287,7 +290,7 @@ public class TimController {
 
          try {
             rsuResponse = createAndSend(travelerinputData.getSnmp(), curRsu, travelerinputData.getTim().getIndex(),
-                  rsuSRMPayload);
+                  messageFrameHexString);
 
             if (null == rsuResponse || null == rsuResponse.getResponse()) {
                // Timeout
@@ -317,7 +320,7 @@ public class TimController {
       // Deposit to DDS
       String ddsMessage = "";
       try {
-         depositToDDS(travelerinputData, rsuSRMPayload);
+         depositToDDS(travelerinputData, timHexString);
          ddsMessage = "\"dds_deposit\":{\"success\":\"true\"}";
          logger.info("DDS deposit successful.");
       } catch (Exception e) {

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/traveler/TimPduCreator.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/traveler/TimPduCreator.java
@@ -84,8 +84,6 @@ public class TimPduCreator {
         VariableBinding rsuSRMEnable = new VariableBinding(new OID("1.0.15628.4.1.4.1.10.".concat(Integer.toString(index))), new Integer32(snmp.getEnable()));
         VariableBinding rsuSRMStatus = new VariableBinding(new OID("1.0.15628.4.1.4.1.11.".concat(Integer.toString(index))), new Integer32(snmp.getStatus()));
         
-        logger.info("PAYLOAD LENGTH: {}", new OctetString(DatatypeConverter.parseHexBinary(payload)).getBERPayloadLength());
-        
         ScopedPDU pdu = new ScopedPDU();
         pdu.add(rsuSRMPsid);
         pdu.add(rsuSRMDsrcMsgId);


### PR DESCRIPTION
- TIMs being sent to RSUs are now wrapped in a message frame before sending. 
- TIMs sent to the SDC remain a J2735 ASN TravelerInformation object. 
- Probe data messages are not ASN objects and do not require wrapping.

This is in response to issue #171.