### PR TITLE
Initial push for publishing Driver Alert messages into a kafka stream

### DIFF
--- a/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeDriverAlertData.java
+++ b/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeDriverAlertData.java
@@ -1,0 +1,19 @@
+package us.dot.its.jpo.ode.model;
+
+/**
+ * Created by anthonychen on 11/4/17.
+ */
+public class OdeDriverAlertData extends OdeObject {
+
+    private static final long serialVersionUID = 2057040404896561615L;
+    private String alert;
+
+    public OdeDriverAlertData() {
+            super();
+        }
+
+    public OdeDriverAlertData(OdeMsgMetadata metadata, String alert) {
+        this.alert = alert;
+    }
+
+}

--- a/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeDriverAlertData.java
+++ b/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeDriverAlertData.java
@@ -3,17 +3,17 @@ package us.dot.its.jpo.ode.model;
 /**
  * Created by anthonychen on 11/4/17.
  */
-public class OdeDriverAlertData extends OdeObject {
+public class OdeDriverAlertData extends OdeData {
 
     private static final long serialVersionUID = 2057040404896561615L;
-    private String alert;
 
     public OdeDriverAlertData() {
             super();
         }
 
-    public OdeDriverAlertData(OdeMsgMetadata metadata, String alert) {
-        this.alert = alert;
+    public OdeDriverAlertData(OdeMsgMetadata metadata, OdeMsgPayload payload) {
+        super(metadata, payload);
     }
+
 
 }

--- a/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeDriverAlertMetadata.java
+++ b/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeDriverAlertMetadata.java
@@ -1,0 +1,24 @@
+package us.dot.its.jpo.ode.model;
+
+/**
+ * Created by anthonychen on 11/4/17.
+ */
+public class OdeDriverAlertMetadata extends OdeLogMetadata{
+
+
+    private static final long serialVersionUID = -8601265839394150140L;
+
+    public OdeDriverAlertMetadata() {
+        super();
+    }
+
+    public OdeDriverAlertMetadata(OdeMsgPayload payload) {
+        super(payload);
+    }
+
+    public OdeDriverAlertMetadata(OdeMsgPayload payload, SerialId serialId, String receivedAt) {
+
+    }
+
+
+}

--- a/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeDriverAlertPayload.java
+++ b/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeDriverAlertPayload.java
@@ -1,0 +1,26 @@
+package us.dot.its.jpo.ode.model;
+
+
+/**
+ * Created by anthonychen on 11/4/17.
+ */
+public class OdeDriverAlertPayload extends OdeMsgPayload {
+
+
+        private static final long serialVersionUID = 7061315628111448390L;
+        private String alert;
+
+        public OdeDriverAlertPayload(String alert) {
+            this.alert = alert;
+        }
+
+        public String getAlert() {
+            return this.alert;
+        }
+
+        public void setAlert(String alert) {
+            this.alert = alert;
+        }
+
+
+}

--- a/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeDriverAlertPayload.java
+++ b/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeDriverAlertPayload.java
@@ -10,6 +10,7 @@ public class OdeDriverAlertPayload extends OdeMsgPayload {
         private static final long serialVersionUID = 7061315628111448390L;
         private String alert;
 
+
         public OdeDriverAlertPayload(String alert) {
             this.alert = alert;
         }

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/OdeProperties.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/OdeProperties.java
@@ -1,13 +1,6 @@
 package us.dot.its.jpo.ode;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
-
+import groovy.lang.MissingPropertyException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,11 +8,17 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.core.env.Environment;
-
-import groovy.lang.MissingPropertyException;
 import us.dot.its.jpo.ode.context.AppContext;
 import us.dot.its.jpo.ode.eventlog.EventLogger;
 import us.dot.its.jpo.ode.plugin.OdePlugin;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 @ConfigurationProperties("ode")
 @PropertySource("classpath:application.properties")
@@ -90,6 +89,10 @@ public class OdeProperties implements EnvironmentAware {
    private String kafkaTopicOdeTimRxJson= "topic.OdeTimRxJson";
    private String kafkaTopicOdeTimBroadcastPojo= "topic.OdeTimBroadcastPojo";
    private String kafkaTopicOdeTimBroadcastJson= "topic.OdeTimBroadcastJson";
+   private String kafkaTopicFilteredOdeTimJson = "topic.FilteredOdeTimJson";
+
+   // DriverAlerts
+   private String kafkaTopicDriverAlertJson = "topic.OdeDriverAlertJson";
 
    //VSD
    private String kafkaTopicVsdPojo = "AsnVsdPojo";
@@ -664,4 +667,19 @@ public class OdeProperties implements EnvironmentAware {
       this.kafkaTopicOdeTimBroadcastJson = kafkaTopicOdeTimBroadcastJson;
    }
 
+   public String getKafkaTopicFilteredOdeTimJson() {
+      return kafkaTopicFilteredOdeTimJson;
+   }
+
+   public void setKafkaTopicFilteredOdeTimJson(String kafkaTopicFilteredOdeTimJson) {
+      this.kafkaTopicFilteredOdeTimJson = kafkaTopicFilteredOdeTimJson;
+   }
+
+   public String getKafkaTopicDriverAlertJson() {
+      return kafkaTopicDriverAlertJson;
+   }
+
+   public void setKafkaTopicDriverAlertJson(String kafkaTopicDriverAlertJson) {
+      this.kafkaTopicDriverAlertJson = kafkaTopicDriverAlertJson;
+   }
 }

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/coder/stream/LogFileToAsn1CodecPublisher.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/coder/stream/LogFileToAsn1CodecPublisher.java
@@ -7,8 +7,10 @@ import us.dot.its.jpo.ode.coder.OdeLogMetadataCreatorHelper;
 import us.dot.its.jpo.ode.coder.StringPublisher;
 import us.dot.its.jpo.ode.importer.ImporterDirectoryWatcher.ImporterFileType;
 import us.dot.its.jpo.ode.importer.parser.DriverAlertFileParser;
+import us.dot.its.jpo.ode.importer.parser.TimLogFileParser;
 import us.dot.its.jpo.ode.importer.parser.FileParser.ParserStatus;
 import us.dot.its.jpo.ode.importer.parser.LogFileParser;
+import us.dot.its.jpo.ode.coder.TimDecoderHelper;
 import us.dot.its.jpo.ode.model.*;
 import us.dot.its.jpo.ode.model.Asn1Encoding.EncodingRule;
 import us.dot.its.jpo.ode.util.JsonUtils;
@@ -83,6 +85,10 @@ public class LogFileToAsn1CodecPublisher implements Asn1CodecPublisher {
          metadata.getSerialId().setBundleId(bundleId.get()).addRecordId(1);
          OdeLogMetadataCreatorHelper.updateLogMetadata(metadata, fileParser);
 
+         if (fileParser instanceof TimLogFileParser) {
+           ReceivedMessageDetails receivedMsgDetails = TimDecoderHelper.buildReceivedMessageDetails((TimLogFileParser) fileParser);
+            metadata.setReceivedMessageDetails(receivedMsgDetails);
+         }
 
          Asn1Encoding msgEncoding = new Asn1Encoding("root", "Ieee1609Dot2Data", EncodingRule.COER);
          Asn1Encoding unsecuredDataEncoding = new Asn1Encoding("unsecuredData", "MessageFrame",

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/coder/stream/LogFileToAsn1CodecPublisher.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/coder/stream/LogFileToAsn1CodecPublisher.java
@@ -66,14 +66,15 @@ public class LogFileToAsn1CodecPublisher implements Asn1CodecPublisher {
 
       if (fileParser instanceof DriverAlertFileParser){
          logger.debug("Publishing a driver alert.");
-         OdeDriverAlertPayload driverAlertData = new OdeDriverAlertPayload(((DriverAlertFileParser) fileParser).getAlert());
-         OdeDriverAlertMetadata driverAlertMetadata= new OdeDriverAlertMetadata(driverAlertData);
+         OdeDriverAlertPayload driverAlertPayload = new OdeDriverAlertPayload(((DriverAlertFileParser) fileParser).getAlert());
+         OdeDriverAlertMetadata driverAlertMetadata= new OdeDriverAlertMetadata(driverAlertPayload);
          driverAlertMetadata.getSerialId().setBundleId(bundleId.get()).addRecordId(1);
          OdeLogMetadataCreatorHelper.updateLogMetadata(driverAlertMetadata, fileParser);
 
-         OdeAsn1Data driverAlertOdeData = new OdeAsn1Data(driverAlertMetadata, driverAlertData);
+         OdeDriverAlertData driverAlertData = new OdeDriverAlertData(driverAlertMetadata, driverAlertPayload);
 
-         publisher.publish(JsonUtils.toJson(driverAlertOdeData, false),
+
+         publisher.publish(JsonUtils.toJson(driverAlertData, false),
                  publisher.getOdeProperties().getKafkaTopicDriverAlertJson());
 
       } else {

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/importer/parser/DriverAlertFileParser.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/importer/parser/DriverAlertFileParser.java
@@ -1,14 +1,14 @@
 package us.dot.its.jpo.ode.importer.parser;
 
+import us.dot.its.jpo.ode.util.CodecUtils;
+
 import java.io.BufferedInputStream;
 import java.nio.ByteOrder;
 import java.util.Arrays;
 
-import us.dot.its.jpo.ode.util.CodecUtils;
-
 public class DriverAlertFileParser extends TimLogFileParser {
 
-   private byte[] alert;
+   private String alert;
 
    public DriverAlertFileParser(long bundleId) {
       super(bundleId);
@@ -65,12 +65,12 @@ public class DriverAlertFileParser extends TimLogFileParser {
       return status;
    }
 
-   public byte[] getAlert() {
+   public String getAlert() {
       return alert;
    }
 
    public void setAlert(byte[] alert) {
-      this.alert = alert;
+      this.alert = new String(alert);
    }
 
 }

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/importer/parser/LogFileParser.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/importer/parser/LogFileParser.java
@@ -1,19 +1,18 @@
 package us.dot.its.jpo.ode.importer.parser;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import us.dot.its.jpo.ode.util.DateTimeUtils;
+
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.time.ZonedDateTime;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import us.dot.its.jpo.ode.util.DateTimeUtils;
 
 public class LogFileParser implements FileParser {
    private static final Logger logger = LoggerFactory.getLogger(LogFileParser.class);
 
    public enum RecordType {
-      bsmLogDuringEvent, rxMsg, dnMsg, bsmTx, unsupported
+      bsmLogDuringEvent, rxMsg, dnMsg, bsmTx, driverAlert, unsupported
    }
 
    public static final int BUFFER_SIZE = 4096;
@@ -25,7 +24,7 @@ public class LogFileParser implements FileParser {
    protected ParserStatus status;
 
    protected long bundleId;
-   protected byte[] readBuffer = new byte[BUFFER_SIZE];
+   protected transient byte[] readBuffer = new byte[BUFFER_SIZE];
    protected int step = 0;
 
    protected String filename;
@@ -55,6 +54,9 @@ public class LogFileParser implements FileParser {
       } else if (fileName.startsWith(RecordType.dnMsg.name())) {
          logger.debug("Parsing as \"Distress Notifications\" log file type.");
          fileParser = new DistressMsgFileParser(bundleId).setRecordType(RecordType.dnMsg);
+      } else if (fileName.startsWith(RecordType.driverAlert.name())) {
+         logger.debug("Parsing as \"Driver Alert\" log file type.");
+         fileParser = new DriverAlertFileParser(bundleId).setRecordType(RecordType.driverAlert);
       } else {
          throw new IllegalArgumentException("Unknown log file prefix: " + fileName);
       }

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/upload/FileUploadController.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/upload/FileUploadController.java
@@ -1,10 +1,5 @@
 package us.dot.its.jpo.ode.upload;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,19 +7,19 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-
 import us.dot.its.jpo.ode.OdeProperties;
 import us.dot.its.jpo.ode.exporter.StompStringExporter;
 import us.dot.its.jpo.ode.importer.ImporterDirectoryWatcher;
 import us.dot.its.jpo.ode.importer.ImporterDirectoryWatcher.ImporterFileType;
 import us.dot.its.jpo.ode.storage.StorageFileNotFoundException;
 import us.dot.its.jpo.ode.storage.StorageService;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 @Controller
 public class FileUploadController {
@@ -57,6 +52,7 @@ public class FileUploadController {
       threadPool.submit(new StompStringExporter(odeProperties, UNFILTERED_OUTPUT_TOPIC, template, odeProperties.getKafkaTopicOdeBsmJson()));
       threadPool.submit(new StompStringExporter(odeProperties, UNFILTERED_OUTPUT_TOPIC, template, odeProperties.getKafkaTopicOdeDNMsgJson()));
       threadPool.submit(new StompStringExporter(odeProperties, UNFILTERED_OUTPUT_TOPIC, template, odeProperties.getKafkaTopicOdeTimJson()));
+      threadPool.submit(new StompStringExporter(odeProperties, UNFILTERED_OUTPUT_TOPIC, template, odeProperties.getKafkaTopicDriverAlertJson()));
 
       // Create filtered exporters
       threadPool.submit(new StompStringExporter(odeProperties, FILTERED_OUTPUT_TOPIC, template, odeProperties.getKafkaTopicFilteredOdeBsmJson()));

--- a/jpo-ode-svcs/src/test/java/us/dot/its/jpo/ode/importer/parser/DriverAlertFileParserTest.java
+++ b/jpo-ode-svcs/src/test/java/us/dot/its/jpo/ode/importer/parser/DriverAlertFileParserTest.java
@@ -1,18 +1,16 @@
 package us.dot.its.jpo.ode.importer.parser;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import mockit.Injectable;
+import mockit.Tested;
+import org.junit.Test;
+import us.dot.its.jpo.ode.importer.parser.FileParser.FileParserException;
+import us.dot.its.jpo.ode.importer.parser.FileParser.ParserStatus;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 
-import org.apache.tomcat.util.buf.HexUtils;
-import org.junit.Test;
-
-import mockit.Injectable;
-import mockit.Tested;
-import us.dot.its.jpo.ode.importer.parser.FileParser.FileParserException;
-import us.dot.its.jpo.ode.importer.parser.FileParser.ParserStatus;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class DriverAlertFileParserTest {
 
@@ -421,8 +419,8 @@ public class DriverAlertFileParserTest {
       try {
          assertEquals(expectedStatus, testDriverAlertFileParser.parseFile(testInputStream, "testLogFile.bin"));
          assertEquals(expectedLength, testDriverAlertFileParser.getLength());
-         assertEquals(HexUtils.toHexString(expectedPayload),
-               HexUtils.toHexString(testDriverAlertFileParser.getAlert()));
+         assertEquals(new String(expectedPayload),
+               testDriverAlertFileParser.getAlert());
          assertEquals(expectedStep, testDriverAlertFileParser.getStep());
       } catch (FileParserException e) {
          fail("Unexpected exception: " + e);

--- a/jpo-ode-svcs/src/test/java/us/dot/its/jpo/ode/upload/FileUploadControllerTest.java
+++ b/jpo-ode-svcs/src/test/java/us/dot/its/jpo/ode/upload/FileUploadControllerTest.java
@@ -58,7 +58,7 @@ public class FileUploadControllerTest {
             result = mockExecutorService;
 
             mockExecutorService.submit((Runnable) any);
-            times =5;
+            times =6;
          }
       };
       testFileUploadController = new FileUploadController(mockStorageService, mockOdeProperties,


### PR DESCRIPTION
Probably needs a little refactoring, but this feature currently pushes the following Json into a Driver Alert Kafka Topic

```{"alert":[68,78,80,87],"location":{"latitude":404739938,"longitude":-1049692256,"elevation":15070,"speed":51,"heading":26467},"status":"COMPLETE","bundleId":2,"step":0,"filename":"driverAlert_1493923473_fe80_3A_3A226_3Aadff_3Afe05_3A2561.csv","recordType":"driverAlert","utcTimeInSec":1507216177,"mSec":627,"validSignature":false,"length":4}```

