### PR TITLE
ODE-632, ODE-642 - File processing and TIM updates

### DIFF
--- a/docs/ODESwagger.yaml
+++ b/docs/ODESwagger.yaml
@@ -543,6 +543,7 @@ definitions:
         type: string
   SNMP:
     type: object
+    description: Optional field, needed for SNMP deposit to RSU.
     properties:
       rsuid:
         type: string
@@ -556,16 +557,17 @@ definitions:
         type: string
       deliverystart:
         type: string
-        description: ISO string for message delivery start time
+        description: ISO string for message delivery start time. Takes priority over "deliverystart" field in SDW.
       deliverystop:
         type: string
-        description: ISO string for message delivery stop time
+        description: ISO string for message delivery stop time. Takes priority over "deliverystop" field in SDW.
       enable:
         type: string
       status:
         type: string
   RSU:
     type: object
+    summary: Optional field, needed for SNMP deposit to RSU.
     properties:
       rsuTarget:
         type: string
@@ -585,9 +587,15 @@ definitions:
   SDW:
     type: object
     properties:
+      deliverystart:
+        type: string
+        description: Optional field, ISO string for message delivery start time. Identical to "deliverystart" field in SNMP for when RSU deposit not desired.
+      deliverystop:
+        type: string
+        description: Optional field, ISO string for message delivery stop time. Identical to "deliverystop" field in SNMP for when RSU deposit not desired.
       groupID:
         type: string
-        description: Eight-digit hex code of the groupID to use, for example "A123B456".
+        description: Eight-digit hex code of the groupID to use, for example "A123B456". GroupID is used
       ttl:
         type: string
         description: Message time to live.

--- a/docs/ODESwagger.yaml
+++ b/docs/ODESwagger.yaml
@@ -585,6 +585,9 @@ definitions:
   SDW:
     type: object
     properties:
+      groupID:
+        type: string
+        description: Eight-digit hex code of the groupID to use, for example "A123B456".
       ttl:
         type: string
         description: Message time to live.

--- a/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/SituationDataWarehouse.java
+++ b/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/SituationDataWarehouse.java
@@ -20,6 +20,8 @@ public class SituationDataWarehouse {
       private OdeGeoRegion serviceRegion;
       private TimeToLive ttl = null;
       private String groupID = null;
+      private String deliverystart;
+      private String deliverystop;
 
       public OdeGeoRegion getServiceRegion() {
          return serviceRegion;
@@ -44,6 +46,22 @@ public class SituationDataWarehouse {
 
       public void setGroupID(String groupID) {
          this.groupID = groupID;
+      }
+
+      public String getDeliverystop() {
+         return deliverystop;
+      }
+
+      public void setDeliverystop(String deliverystop) {
+         this.deliverystop = deliverystop;
+      }
+
+      public String getDeliverystart() {
+         return deliverystart;
+      }
+
+      public void setDeliverystart(String deliverystart) {
+         this.deliverystart = deliverystart;
       }
    }
    private SituationDataWarehouse() {

--- a/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/SituationDataWarehouse.java
+++ b/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/SituationDataWarehouse.java
@@ -19,6 +19,7 @@ public class SituationDataWarehouse {
 
       private OdeGeoRegion serviceRegion;
       private TimeToLive ttl = null;
+      private String groupID = null;
 
       public OdeGeoRegion getServiceRegion() {
          return serviceRegion;
@@ -35,6 +36,14 @@ public class SituationDataWarehouse {
 
       public void setTtl(TimeToLive ttl) {
          this.ttl = ttl;
+      }
+
+      public String getGroupID() {
+         return groupID;
+      }
+
+      public void setGroupID(String groupID) {
+         this.groupID = groupID;
       }
    }
    private SituationDataWarehouse() {

--- a/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/DdsAdvisorySituationData.java
+++ b/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/DdsAdvisorySituationData.java
@@ -1,6 +1,5 @@
 package us.dot.its.jpo.ode.plugin.j2735;
 
-import java.nio.ByteBuffer;
 import java.text.ParseException;
 import java.time.ZonedDateTime;
 import java.util.Random;
@@ -15,51 +14,52 @@ import us.dot.its.jpo.ode.util.DateTimeUtils;
 public class DdsAdvisorySituationData extends Asn1Object {
    private static final long serialVersionUID = 2755274323293805425L;
 
-   int dialogID = 0x9C;             //SemiDialogID -- 0x9C Advisory Situation Data Deposit
-   int seqID = 0x05;                //SemiSequenceID -- 0x05 Data
-   String groupID;                  //GroupID -- unique ID used to identify an organization
-   String requestID;                //DSRC.TemporaryID -- random 4 byte ID generated for data transfer
-   String recordID;                 //DSRC.TemporaryID -- used by the provider to overwrite existing record(s)
-   int timeToLive;                  //TimeToLive -- indicates how long the SDW should persist the record(s)
-   DdsGeoRegion serviceRegion;     //  GeoRegion,                 -- NW and SE corners of the region applicable
+   int dialogID = 0x9C;    // SemiDialogID -- 0x9C Advisory Situation Data Deposit
+   int seqID = 0x05;       // SemiSequenceID -- 0x05 Data
+   String groupID;         // GroupID -- unique ID used to identify an organization
+   String requestID;       // DSRC.TemporaryID -- random 4 byte ID generated for data
+                           // transfer
+   String recordID;        // DSRC.TemporaryID -- used by the provider to overwrite
+                           // existing record(s)
+   int timeToLive;         // TimeToLive -- indicates how long the SDW should persist
+                            // the record(s)
+   DdsGeoRegion serviceRegion; // GeoRegion, -- NW and SE corners of the region
+                               // applicable
    DdsAdvisoryDetails asdmDetails;
-   
+
    public DdsAdvisorySituationData() {
       super();
-      byte gid[] = {0, 0, 0, 0};
+      byte[] gid = { 0, 0, 0, 0 };
       groupID = CodecUtils.toHex(gid);
    }
 
-   public DdsAdvisorySituationData(
-         String startTime,
-         String stopTime,
-         J2735MessageFrame advisoryMessage,
-         DdsGeoRegion serviceRegion,
-         SituationDataWarehouse.SDW.TimeToLive ttl) throws ParseException {
+   public DdsAdvisorySituationData(String startTime, String stopTime, J2735MessageFrame advisoryMessage,
+         DdsGeoRegion serviceRegion, SituationDataWarehouse.SDW.TimeToLive ttl, String groupID) throws ParseException {
       this();
-      
+
       J2735DFullTime dStartTime = dFullTimeFromIsoTimeString(startTime);
-      
+
       J2735DFullTime dStopTime = dFullTimeFromIsoTimeString(stopTime);
 
       byte[] fourRandomBytes = new byte[4];
       new Random(System.currentTimeMillis()).nextBytes(fourRandomBytes);
       String id = CodecUtils.toHex(fourRandomBytes);
       int distroType = DistributionType.rsu.ordinal();
-      this.setAsdmDetails(new DdsAdvisoryDetails(
-            id, 
-            AdvisoryBroadcastType.tim,
-            distroType,
-            dStartTime,
-            dStopTime,
-            advisoryMessage));
+      this.setAsdmDetails(
+            new DdsAdvisoryDetails(id, AdvisoryBroadcastType.tim, distroType, dStartTime, dStopTime, advisoryMessage));
 
       this.setRequestID(id);
       this.setServiceRegion(serviceRegion);
-      if (ttl != null)
+      if (ttl != null) {
          this.setTimeToLive(ttl.ordinal());
-      else
+      } else {
          this.setTimeToLive(SituationDataWarehouse.SDW.TimeToLive.thirtyminutes.ordinal());
+      }
+      if (groupID != null) {
+         this.setGroupID(groupID);
+      } else {
+         this.setGroupID(CodecUtils.toHex(new byte[] { 0, 0, 0, 0 }));
+      }
    }
 
    private J2735DFullTime dFullTimeFromIsoTimeString(String isoTime) throws ParseException {
@@ -70,59 +70,75 @@ public class DdsAdvisorySituationData extends Asn1Object {
       dStartTime.setDay(zdtTime.getDayOfMonth());
       dStartTime.setHour(zdtTime.getHour());
       dStartTime.setMinute(zdtTime.getMinute());
-//      dStartTime.setSecond(zdtTime.getSecond());
-//      dStartTime.setOffset(zdtTime.getOffset().getTotalSeconds());
+      // dStartTime.setSecond(zdtTime.getSecond());
+      // dStartTime.setOffset(zdtTime.getOffset().getTotalSeconds());
       return dStartTime;
    }
 
    public int getDialogID() {
       return dialogID;
    }
+
    public void setDialogID(int dialogID) {
       this.dialogID = dialogID;
    }
+
    public int getSeqID() {
       return seqID;
    }
+
    public void setSeqID(int seqID) {
       this.seqID = seqID;
    }
+
    public String getGroupID() {
       return groupID;
    }
+
    public void setGroupID(String groupID) {
       this.groupID = groupID;
    }
+
    public String getRequestID() {
       return requestID;
    }
+
    public void setRequestID(String requestID) {
       this.requestID = requestID;
    }
+
    public String getRecordID() {
       return recordID;
    }
+
    public void setRecordID(String recordID) {
       this.recordID = recordID;
    }
+
    public int getTimeToLive() {
       return timeToLive;
    }
+
    public void setTimeToLive(int timeToLive) {
       this.timeToLive = timeToLive;
    }
+
    public DdsGeoRegion getServiceRegion() {
       return serviceRegion;
    }
+
    public void setServiceRegion(DdsGeoRegion serviceRegion) {
       this.serviceRegion = serviceRegion;
    }
+
    public DdsAdvisoryDetails getAsdmDetails() {
       return asdmDetails;
    }
+
    public void setAsdmDetails(DdsAdvisoryDetails asdmDetails) {
       this.asdmDetails = asdmDetails;
    }
+
    @Override
    public int hashCode() {
       final int prime = 31;
@@ -137,6 +153,7 @@ public class DdsAdvisorySituationData extends Asn1Object {
       result = prime * result + timeToLive;
       return result;
    }
+
    @Override
    public boolean equals(Object obj) {
       if (this == obj)
@@ -180,5 +197,4 @@ public class DdsAdvisorySituationData extends Asn1Object {
       return true;
    }
 
-   
 }

--- a/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/DdsAdvisorySituationData.java
+++ b/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/DdsAdvisorySituationData.java
@@ -63,15 +63,26 @@ public class DdsAdvisorySituationData extends Asn1Object {
    }
 
    private J2735DFullTime dFullTimeFromIsoTimeString(String isoTime) throws ParseException {
-      ZonedDateTime zdtTime = DateTimeUtils.isoDateTime(isoTime);
+
       J2735DFullTime dStartTime = new J2735DFullTime();
-      dStartTime.setYear(zdtTime.getYear());
-      dStartTime.setMonth(zdtTime.getMonthValue());
-      dStartTime.setDay(zdtTime.getDayOfMonth());
-      dStartTime.setHour(zdtTime.getHour());
-      dStartTime.setMinute(zdtTime.getMinute());
-      // dStartTime.setSecond(zdtTime.getSecond());
-      // dStartTime.setOffset(zdtTime.getOffset().getTotalSeconds());
+      
+      // use time if present, if not use undefined flag values
+      if (null != isoTime) {
+         ZonedDateTime zdtTime = DateTimeUtils.isoDateTime(isoTime);
+         dStartTime.setYear(zdtTime.getYear());
+         dStartTime.setMonth(zdtTime.getMonthValue());
+         dStartTime.setDay(zdtTime.getDayOfMonth());
+         dStartTime.setHour(zdtTime.getHour());
+         dStartTime.setMinute(zdtTime.getMinute());
+         // dStartTime.setSecond(zdtTime.getSecond());
+         // dStartTime.setOffset(zdtTime.getOffset().getTotalSeconds());
+      } else {
+         dStartTime.setYear(0);
+         dStartTime.setMonth(0);
+         dStartTime.setDay(0);
+         dStartTime.setHour(31);
+         dStartTime.setMinute(60);
+      }
       return dStartTime;
    }
 

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/importer/ImporterProcessor.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/importer/ImporterProcessor.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 
 import us.dot.its.jpo.ode.OdeProperties;
 import us.dot.its.jpo.ode.coder.FileAsn1CodecPublisher;
+import us.dot.its.jpo.ode.eventlog.EventLogger;
 // Removed for ODE-559
 //import us.dot.its.jpo.ode.coder.FileDecoderPublisher;
 import us.dot.its.jpo.ode.importer.ImporterDirectoryWatcher.ImporterFileType;
@@ -34,7 +35,7 @@ public class ImporterProcessor {
       this.fileType = fileType;
    }
 
-   public void processDirectory(Path dir, Path backupDir) {
+   public void processDirectory(Path dir, Path backupDir, Path failureDir) {
       int count = 0;
       // Process files already in the directory
       logger.debug("Started processing files at location: {}", dir);
@@ -42,10 +43,10 @@ public class ImporterProcessor {
 
          for (Path entry : stream) {
             if (entry.toFile().isDirectory()) {
-               processDirectory(entry, backupDir);
+               processDirectory(entry, backupDir, failureDir);
             } else {
                logger.debug("Found a file to process: {}", entry.getFileName());
-               processAndBackupFile(entry, backupDir);
+               processAndBackupFile(entry, backupDir, failureDir);
                count++;
             }
          }
@@ -56,7 +57,7 @@ public class ImporterProcessor {
       }
    }
 
-   public void processAndBackupFile(Path filePath, Path backupDir) {
+   public void processAndBackupFile(Path filePath, Path backupDir, Path failureDir) {
 
       /*
        * ODE-559 vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
@@ -72,15 +73,26 @@ public class ImporterProcessor {
       // ODE-559 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
       // ODE-559
+      boolean success = true;
       try (InputStream inputStream = new FileInputStream(filePath.toFile())) {
          BufferedInputStream bis = new BufferedInputStream(inputStream, odeProperties.getImportProcessorBufferSize());
          codecPublisher.publishFile(filePath, bis, fileType);
       } catch (Exception e) {
-         logger.error("Unable to open or process file: " + filePath, e);
+         success = false;
+         logger.error("Failed to open or process file: " + filePath, e);
+         EventLogger.logger.error("Failed to open or process file: " + filePath, e);  
       }
       
       try {
-         OdeFileUtils.backupFile(filePath, backupDir);
+         if (success) {
+            OdeFileUtils.backupFile(filePath, backupDir);
+            logger.info("File moved to backup: {}", backupDir);
+            EventLogger.logger.info("File moved to backup: {}", backupDir);  
+         } else {
+            OdeFileUtils.moveFile(filePath, failureDir);
+            logger.info("File moved to failure directory: {}", failureDir);  
+            EventLogger.logger.info("File moved to failure directory: {}", failureDir);
+         }
       } catch (IOException e) {
          logger.error("Unable to backup file: " + filePath, e);
       }

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/importer/OdeFileUtils.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/importer/OdeFileUtils.java
@@ -66,4 +66,27 @@ public class OdeFileUtils {
          throw new IOException("Unable to move file to backup: " + e);
       }
    }
+   
+   /**
+    * Attempts to move and overwrite a file to destination directory. Throws exception if directory doesn't exist or move failed.
+    * @param file
+    * @param destination
+    * @throws IOException 
+    */
+   public static void moveFile(Path file, Path destination) throws IOException {
+   // Check that the destination directory actually exists before moving the
+      // file
+      if (!destination.toFile().exists()) {
+         throw new IOException("Directory does not exist: " + destination);
+      }
+
+      Path targetPath = Paths.get(destination.toString(), file.getFileName().toString());
+
+      // Attempt to move the file to the backup directory
+      try {
+         Files.move(file, targetPath, StandardCopyOption.REPLACE_EXISTING);
+      } catch (IOException e) {
+         throw new IOException("Unable to move file to backup: " + e);
+      }
+   }
 }

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/traveler/TimController.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/traveler/TimController.java
@@ -296,7 +296,7 @@ public class TimController {
          return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(jsonKeyValue(ERRSTR, errMsg));
       }
 
-      return ResponseEntity.status(HttpStatus.OK).body("Success");
+      return ResponseEntity.status(HttpStatus.OK).body(jsonKeyValue("Success", "true"));
    }
 
    /**
@@ -336,14 +336,14 @@ public class TimController {
                   travelerinputData.getSnmp().getDeliverystop(), 
                   null,
                   GeoRegionBuilder.ddsGeoRegion(sdw.getServiceRegion()),
-                  sdw.getTtl());
+                  sdw.getTtl(), sdw.getGroupID());
          ObjectNode asdBodyObj = JsonUtils.toObjectNode(asd.toJson());
          ObjectNode asdmDetails = (ObjectNode) asdBodyObj.get("asdmDetails");
          //Remove 'advisoryMessageBytes' and add 'advisoryMessage'
          asdmDetails.remove("advisoryMessageBytes");
          asdmDetails.set("advisoryMessage", JsonUtils.newNode().set("MessageFrame", mfBodyObj));
          
-         dataBodyObj = (ObjectNode) JsonUtils.newNode().set("AdvisorySituationData", asdBodyObj);
+         dataBodyObj.set("AdvisorySituationData", asdBodyObj);
          
          //Create valid payload from scratch
          payload = new OdeAsdPayload(asd);

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/upload/FileUploadController.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/upload/FileUploadController.java
@@ -42,11 +42,13 @@ public class FileUploadController {
       Path logPath = Paths.get(odeProperties.getUploadLocationRoot(),
           odeProperties.getUploadLocationObuLog());
       logger.debug("UPLOADER - BSM log file upload directory: {}", logPath);
+      Path failurePath = Paths.get(odeProperties.getUploadLocationRoot(), "failed");
+      logger.debug("UPLOADER - Failure directory: {}", failurePath);
       Path backupPath = Paths.get(odeProperties.getUploadLocationRoot(), "backup");
       logger.debug("UPLOADER - Backup directory: {}", backupPath);
 
       // Create the importers that watch folders for new/modified files
-      threadPool.submit(new ImporterDirectoryWatcher(odeProperties, logPath, backupPath, ImporterFileType.OBU_LOG_FILE));
+      threadPool.submit(new ImporterDirectoryWatcher(odeProperties, logPath, backupPath, failurePath, ImporterFileType.OBU_LOG_FILE));
 
       // Create unfiltered exporters
       threadPool.submit(new StompStringExporter(odeProperties, UNFILTERED_OUTPUT_TOPIC, template, odeProperties.getKafkaTopicOdeBsmJson()));

--- a/jpo-ode-svcs/src/test/java/us/dot/its/jpo/ode/importer/ImporterDirectoryWatcherTest.java
+++ b/jpo-ode-svcs/src/test/java/us/dot/its/jpo/ode/importer/ImporterDirectoryWatcherTest.java
@@ -31,6 +31,8 @@ public class ImporterDirectoryWatcherTest {
    @Mocked
    Path mockDir;
    @Injectable
+   Path failureDir;
+   @Injectable
    Path backupDir;
 
    @Mocked
@@ -51,13 +53,13 @@ public class ImporterDirectoryWatcherTest {
          new Expectations() {
             {
                OdeFileUtils.createDirectoryRecursively((Path) any);
-               times = 2;
+               times = 3;
             }
          };
       } catch (IOException e) {
          fail("Unexpected exception in expectations block: " + e);
       }
-      testImporterDirectoryWatcher = new ImporterDirectoryWatcher(injectableOdeProperties, mockDir, backupDir, ImporterFileType.OBU_LOG_FILE);
+      testImporterDirectoryWatcher = new ImporterDirectoryWatcher(injectableOdeProperties, mockDir, backupDir, failureDir, ImporterFileType.OBU_LOG_FILE);
       testImporterDirectoryWatcher.setWatching(false);
    }
    
@@ -73,7 +75,7 @@ public class ImporterDirectoryWatcherTest {
       } catch (IOException e) {
          fail("Unexpected exception in expectations block: " + e);
       }
-      new ImporterDirectoryWatcher(injectableOdeProperties, mockDir, backupDir, ImporterFileType.OBU_LOG_FILE);
+      new ImporterDirectoryWatcher(injectableOdeProperties, mockDir, backupDir, failureDir, ImporterFileType.OBU_LOG_FILE);
    }
 
    @Test(timeout = 4000)
@@ -143,7 +145,7 @@ public class ImporterDirectoryWatcherTest {
                mockWatchEvent.kind();
                result = StandardWatchEventKinds.OVERFLOW;
                
-               capturingImporterProcessor.processAndBackupFile((Path) any, (Path) any);
+               capturingImporterProcessor.processAndBackupFile((Path) any, (Path) any, (Path) any);
                times = 0;
             }
          };
@@ -173,7 +175,7 @@ public class ImporterDirectoryWatcherTest {
                mockWatchEvent.kind();
                result = StandardWatchEventKinds.ENTRY_MODIFY;
 
-               capturingImporterProcessor.processAndBackupFile((Path) any, (Path) any);
+               capturingImporterProcessor.processAndBackupFile((Path) any, (Path) any, (Path) any);
                times = 1;
             }
          };
@@ -203,7 +205,7 @@ public class ImporterDirectoryWatcherTest {
                mockWatchEvent.kind();
                result = StandardWatchEventKinds.ENTRY_DELETE;
 
-               capturingImporterProcessor.processAndBackupFile((Path) any, (Path) any);
+               capturingImporterProcessor.processAndBackupFile((Path) any, (Path) any, (Path) any);
                times = 0;
             }
          };

--- a/jpo-ode-svcs/src/test/java/us/dot/its/jpo/ode/importer/ImporterProcessorTest.java
+++ b/jpo-ode-svcs/src/test/java/us/dot/its/jpo/ode/importer/ImporterProcessorTest.java
@@ -7,7 +7,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -24,7 +23,6 @@ import mockit.Mocked;
 import mockit.Tested;
 import us.dot.its.jpo.ode.OdeProperties;
 import us.dot.its.jpo.ode.coder.FileAsn1CodecPublisher;
-import us.dot.its.jpo.ode.coder.FileDecoderPublisher;
 import us.dot.its.jpo.ode.importer.ImporterDirectoryWatcher.ImporterFileType;
 
 public class ImporterProcessorTest {
@@ -53,6 +51,8 @@ public class ImporterProcessorTest {
    Path injectableDir;
    @Injectable
    Path injectableBackupDir;
+   @Injectable
+   Path injectableFailureDir;
    
 
    @Test
@@ -69,7 +69,7 @@ public class ImporterProcessorTest {
          fail("Unexpected exception in expectations block: " + e);
       }
 
-      testImporterProcessor.processDirectory(injectableDir, injectableBackupDir);
+      testImporterProcessor.processDirectory(injectableDir, injectableBackupDir, injectableFailureDir);
    }
  
    @Test
@@ -93,7 +93,7 @@ public class ImporterProcessorTest {
          fail("Unexpected exception in expectations block: " + e);
       }
 
-      testImporterProcessor.processDirectory(injectableDir, injectableBackupDir);
+      testImporterProcessor.processDirectory(injectableDir, injectableBackupDir, injectableFailureDir);
    }
 
    @Test
@@ -109,7 +109,7 @@ public class ImporterProcessorTest {
       } catch (FileNotFoundException e) {
          fail("Unexpected exception in expectations block: " + e);
       }
-      testImporterProcessor.processAndBackupFile(mockFile, injectableBackupDir);
+      testImporterProcessor.processAndBackupFile(mockFile, injectableBackupDir, injectableFailureDir);
    }
 
    @Ignore // TODO - injectable odeProperties returns buffer size 0 causing IllegalArgumentException to be thrown
@@ -127,7 +127,7 @@ public class ImporterProcessorTest {
       } catch (Exception e) {
          fail("Unexpected exception in expectations block: " + e);
       }
-      testImporterProcessor.processAndBackupFile(Paths.get("testFile.txt"), injectableBackupDir);
+      testImporterProcessor.processAndBackupFile(Paths.get("testFile.txt"), injectableBackupDir, injectableFailureDir);
    }
 
 

--- a/jpo-ode-svcs/src/test/java/us/dot/its/jpo/ode/traveler/AsdMessageTest.java
+++ b/jpo-ode-svcs/src/test/java/us/dot/its/jpo/ode/traveler/AsdMessageTest.java
@@ -33,6 +33,8 @@ public class AsdMessageTest {
     @Injectable
     SituationDataWarehouse.SDW.TimeToLive ttl = 
     SituationDataWarehouse.SDW.TimeToLive.oneminute;
+    @Injectable
+    String groupID = "01234567";
 
     @Mocked
     ZonedDateTime mockZonedDateTimeStart;


### PR DESCRIPTION
Changes:
- Added optional groupID field to TIM JSON
- Made SDW, RSU, and SNMP fields optional in TIM JSON&ast;
- Files that fail to parse are now moved to `uploads/failed` and logged by EventLogger (handling for issue #184)

&ast;The ODE will only perform DDS deposit if SDW present, and RSU deposit if both RSU & SNMP fields are present. If not, it will only publish TIMs to Kafka.