### PR TITLE
Replaced filewatcher with periodic directory processor

### DIFF
--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/OdeProperties.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/OdeProperties.java
@@ -44,6 +44,7 @@ public class OdeProperties implements EnvironmentAware {
    // File import properties
    private String uploadLocationRoot = "uploads";
    private String uploadLocationObuLogLog = "bsmlog";
+   private Integer fileWatcherPeriod = 5; // time to wait between processing inbox directory for new files
 
    /*
     * USDOT Situation Data Clearinghouse (SDC)/ Situation Data Warehouse (SDW),
@@ -681,5 +682,13 @@ public class OdeProperties implements EnvironmentAware {
 
    public void setKafkaTopicDriverAlertJson(String kafkaTopicDriverAlertJson) {
       this.kafkaTopicDriverAlertJson = kafkaTopicDriverAlertJson;
+   }
+
+   public Integer getFileWatcherPeriod() {
+      return fileWatcherPeriod;
+   }
+
+   public void setFileWatcherPeriod(Integer fileWatcherPeriod) {
+      this.fileWatcherPeriod = fileWatcherPeriod;
    }
 }

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/importer/ImporterDirectoryWatcher.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/importer/ImporterDirectoryWatcher.java
@@ -9,6 +9,9 @@ import java.nio.file.WatchEvent;
 import java.nio.file.WatchEvent.Kind;
 import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,11 +34,16 @@ public class ImporterDirectoryWatcher implements Runnable {
    private Path backup;
    private Path failed;
 
-   public ImporterDirectoryWatcher(OdeProperties odeProperties, Path dir, Path backupDir, Path failureDir, ImporterFileType fileType) {
+   private ScheduledExecutorService executor;
+
+   private Integer timePeriod;
+
+   public ImporterDirectoryWatcher(OdeProperties odeProperties, Path dir, Path backupDir, Path failureDir, ImporterFileType fileType, Integer timePeriod) {
       this.inbox = dir;
       this.backup = backupDir;
       this.failed = failureDir;
       this.watching = true;
+      this.timePeriod = timePeriod;
 
       try {
          OdeFileUtils.createDirectoryRecursively(inbox);
@@ -49,37 +57,38 @@ public class ImporterDirectoryWatcher implements Runnable {
       }
 
       this.importerProcessor = new ImporterProcessor(odeProperties, fileType);
+      
+      executor = Executors.newScheduledThreadPool(1);
    }
 
    @Override
    public void run() {
 
-      // Begin by processing all files already in the inbox
-      logger.info("Processing existing files in {}", inbox);
-      importerProcessor.processDirectory(inbox, backup, failed);
-
-      // Create a generic watch service
-      WatchService watcher = null;
-      try {
-         watcher = inbox.getFileSystem().newWatchService();
-
-         WatchKey keyForTrackedDir = inbox.register(watcher, ENTRY_MODIFY);
-         if (keyForTrackedDir == null) {
-            throw new IOException("Watch key null");
-         }
-      } catch (IOException e) {
-         logger.error("Watch service failed to create: {}", e);
-         return;
-      }
-
-      logger.info("Watch service active on {}", inbox);
+      logger.info("Processing inbox directory {} every {} seconds.", inbox, timePeriod);
 
       // Watch directory for file events
-      while (isWatching()) {
-         pollDirectory(watcher);
+      executor.scheduleWithFixedDelay(() -> {
+         importerProcessor.processDirectory(inbox, backup, failed);
+      }, 0, timePeriod, TimeUnit.SECONDS);
+      
+      try {
+         // This line will only execute in the event that .scheduleWithFixedDelay() throws an error
+         executor.awaitTermination(timePeriod, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+         Thread.currentThread().interrupt();
+         logger.error("Directory watcher polling loop interrupted!", e);
       }
+
+      // ODE-646: the old method of watching the directory used file
+      // event notifications and was unreliable for large quantities of files
+      
+      // while (isWatching()) {
+      // //pollDirectory(watcher);
+      // pollDirectoryNew();
+      // }
    }
 
+   @Deprecated // TODO - replaced by periodic checking
    public void pollDirectory(WatchService watcher) {
       // wait for key to be signaled
       WatchKey wk;

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/importer/ImporterProcessor.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/importer/ImporterProcessor.java
@@ -38,7 +38,7 @@ public class ImporterProcessor {
    public void processDirectory(Path dir, Path backupDir, Path failureDir) {
       int count = 0;
       // Process files already in the directory
-      logger.debug("Started processing files at location: {}", dir);
+      //logger.debug("Started processing files at location: {}", dir);
       try (DirectoryStream<Path> stream = Files.newDirectoryStream(dir)) {
 
          for (Path entry : stream) {
@@ -51,7 +51,7 @@ public class ImporterProcessor {
             }
          }
 
-         logger.debug("Finished processing {} files at location: {}", count, dir);
+         //logger.debug("Finished processing {} files at location: {}", count, dir);
       } catch (Exception e) {
          logger.error("Error processing files.", e);
       }

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/traveler/TimController.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/traveler/TimController.java
@@ -195,6 +195,8 @@ public class TimController {
       PDU pdu = new ScopedPDU();
       pdu.add(new VariableBinding(new OID("1.0.15628.4.1.4.1.11.1")));
       pdu.setType(PDU.GETBULK);
+      pdu.setMaxRepetitions(100);
+      pdu.setNonRepeaters(0);
       
       ResponseEvent response = null;
       try {

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/upload/FileUploadController.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/upload/FileUploadController.java
@@ -48,7 +48,7 @@ public class FileUploadController {
       logger.debug("UPLOADER - Backup directory: {}", backupPath);
 
       // Create the importers that watch folders for new/modified files
-      threadPool.submit(new ImporterDirectoryWatcher(odeProperties, logPath, backupPath, failurePath, ImporterFileType.OBU_LOG_FILE));
+      threadPool.submit(new ImporterDirectoryWatcher(odeProperties, logPath, backupPath, failurePath, ImporterFileType.OBU_LOG_FILE, odeProperties.getFileWatcherPeriod()));
 
       // Create unfiltered exporters
       threadPool.submit(new StompStringExporter(odeProperties, UNFILTERED_OUTPUT_TOPIC, template, odeProperties.getKafkaTopicOdeBsmJson()));

--- a/jpo-ode-svcs/src/test/java/us/dot/its/jpo/ode/importer/ImporterDirectoryWatcherTest.java
+++ b/jpo-ode-svcs/src/test/java/us/dot/its/jpo/ode/importer/ImporterDirectoryWatcherTest.java
@@ -1,16 +1,10 @@
 package us.dot.its.jpo.ode.importer;
 
-import static org.junit.Assert.fail;
-
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.StandardWatchEventKinds;
-import java.nio.file.WatchEvent;
-import java.nio.file.WatchEvent.Kind;
-import java.nio.file.WatchKey;
-import java.nio.file.WatchService;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -19,201 +13,62 @@ import mockit.Capturing;
 import mockit.Expectations;
 import mockit.Injectable;
 import mockit.Mocked;
+import mockit.Tested;
 import us.dot.its.jpo.ode.OdeProperties;
 import us.dot.its.jpo.ode.importer.ImporterDirectoryWatcher.ImporterFileType;
 
 public class ImporterDirectoryWatcherTest {
 
+   @Tested
    ImporterDirectoryWatcher testImporterDirectoryWatcher;
 
    @Injectable
    OdeProperties injectableOdeProperties;
-   @Mocked
-   Path mockDir;
+   @Injectable
+   Path inbox;
    @Injectable
    Path failureDir;
    @Injectable
    Path backupDir;
-
-   @Mocked
-   WatchKey mockWatchKey;
-   @Mocked
-   WatchService mockWatchService;
-   @Mocked
-   WatchEvent<Path> mockWatchEvent;
+   @Injectable
+   ImporterFileType injectableImporterFileType = ImporterFileType.OBU_LOG_FILE;
+   @Injectable
+   Integer timePeriod = 5;
 
    @Capturing
    OdeFileUtils capturingOdeFileUtils;
    @Capturing
    ImporterProcessor capturingImporterProcessor;
+   @Capturing
+   Executors capturingExecutors;
+
+   @Mocked
+   ScheduledExecutorService mockScheduledExecutorService;
 
    @Before
-   public void createTestObject() {
-      try {
-         new Expectations() {
-            {
-               OdeFileUtils.createDirectoryRecursively((Path) any);
-               times = 3;
-            }
-         };
-      } catch (IOException e) {
-         fail("Unexpected exception in expectations block: " + e);
-      }
-      testImporterDirectoryWatcher = new ImporterDirectoryWatcher(injectableOdeProperties, mockDir, backupDir, failureDir, ImporterFileType.OBU_LOG_FILE);
-      testImporterDirectoryWatcher.setWatching(false);
-   }
-   
-   @Test
-   public void testConstructorOdeUtilsException() {
-      try {
-         new Expectations() {
-            {
-               OdeFileUtils.createDirectoryRecursively((Path) any);
-               result = new IOException("acceptionIsKindofAWord");
-            }
-         };
-      } catch (IOException e) {
-         fail("Unexpected exception in expectations block: " + e);
-      }
-      new ImporterDirectoryWatcher(injectableOdeProperties, mockDir, backupDir, failureDir, ImporterFileType.OBU_LOG_FILE);
+   public void testConstructor() throws IOException {
+      new Expectations() {
+         {
+            OdeFileUtils.createDirectoryRecursively((Path) any);
+            times = 3;
+
+            Executors.newScheduledThreadPool(1);
+            result = mockScheduledExecutorService;
+         }
+      };
    }
 
-   @Test(timeout = 4000)
-   public void runShouldCatchException() {
-      try {
-         new Expectations() {
-            {
-               mockDir.register((WatchService) any, (Kind<?>) any);
-               result = null;
-            }
-         };
-      } catch (IOException e) {
-         fail("Unexpected exception in expectations block: " + e);
-      }
+   @Test
+   public void testRun() throws InterruptedException {
+      new Expectations() {
+         {
+            mockScheduledExecutorService.scheduleWithFixedDelay((Runnable) any, anyLong, anyLong, TimeUnit.SECONDS);
+
+            mockScheduledExecutorService.awaitTermination(anyLong, TimeUnit.SECONDS);
+         }
+      };
+
       testImporterDirectoryWatcher.run();
-   }
-
-   @Test(timeout = 4000)
-   public void shouldRunNoProblems() {
-      try {
-         new Expectations() {
-            {
-               mockDir.register((WatchService) any, (Kind<?>) any);
-               result = mockWatchKey;
-            }
-         };
-      } catch (IOException e) {
-         fail("Unexpected exception in expectations block: " + e);
-      }
-      testImporterDirectoryWatcher.run();
-   }
-
-   @Test
-   public void pollDirectoryShouldInterruptThreadOnWatcherError() {
-      try {
-         new Expectations(Thread.class) {
-            {
-               mockWatchService.take();
-               result = new InterruptedException("testException123");
-               Thread.currentThread().interrupt();
-               times = 1;
-            }
-         };
-      } catch (InterruptedException e) {
-         fail("Unexpected exception in expectations block: " + e);
-      }
-
-      testImporterDirectoryWatcher.pollDirectory(mockWatchService);
-   }
-
-   @Test
-   public void pollDirectoryOverflowShouldContinue() {
-      List<WatchEvent<Path>> pollEventsList = new ArrayList<WatchEvent<Path>>();
-      pollEventsList.add(mockWatchEvent);
-      try {
-         new Expectations() {
-            {
-               mockWatchService.take();
-               result = mockWatchKey;
-
-               mockWatchKey.pollEvents();
-               result = pollEventsList;
-
-               mockWatchKey.reset();
-               result = true;
-
-               mockWatchEvent.kind();
-               result = StandardWatchEventKinds.OVERFLOW;
-               
-               capturingImporterProcessor.processAndBackupFile((Path) any, (Path) any, (Path) any);
-               times = 0;
-            }
-         };
-      } catch (InterruptedException e) {
-         fail("Unexpected exception in expectations block: " + e);
-      }
-
-      testImporterDirectoryWatcher.pollDirectory(mockWatchService);
-   }
-
-   @Test
-   public void pollDirectoryEntryModifyShouldProcessFile() {
-      List<WatchEvent<Path>> pollEventsList = new ArrayList<WatchEvent<Path>>();
-      pollEventsList.add(mockWatchEvent);
-      try {
-         new Expectations() {
-            {
-               mockWatchService.take();
-               result = mockWatchKey;
-
-               mockWatchKey.pollEvents();
-               result = pollEventsList;
-
-               mockWatchKey.reset();
-               result = false;
-
-               mockWatchEvent.kind();
-               result = StandardWatchEventKinds.ENTRY_MODIFY;
-
-               capturingImporterProcessor.processAndBackupFile((Path) any, (Path) any, (Path) any);
-               times = 1;
-            }
-         };
-      } catch (InterruptedException e) {
-         fail("Unexpected exception in expectations block: " + e);
-      }
-
-      testImporterDirectoryWatcher.pollDirectory(mockWatchService);
-   }
-   
-   @Test
-   public void pollDirectoryUnknownKindShouldThrowError() {
-      List<WatchEvent<Path>> pollEventsList = new ArrayList<WatchEvent<Path>>();
-      pollEventsList.add(mockWatchEvent);
-      try {
-         new Expectations() {
-            {
-               mockWatchService.take();
-               result = mockWatchKey;
-
-               mockWatchKey.pollEvents();
-               result = pollEventsList;
-
-               mockWatchKey.reset();
-               result = false;
-
-               mockWatchEvent.kind();
-               result = StandardWatchEventKinds.ENTRY_DELETE;
-
-               capturingImporterProcessor.processAndBackupFile((Path) any, (Path) any, (Path) any);
-               times = 0;
-            }
-         };
-      } catch (InterruptedException e) {
-         fail("Unexpected exception in expectations block: " + e);
-      }
-
-      testImporterDirectoryWatcher.pollDirectory(mockWatchService);
    }
 
 }

--- a/jpo-ode-svcs/src/test/java/us/dot/its/jpo/ode/importer/ImporterDirectoryWatcherTestOld.java
+++ b/jpo-ode-svcs/src/test/java/us/dot/its/jpo/ode/importer/ImporterDirectoryWatcherTestOld.java
@@ -1,0 +1,223 @@
+package us.dot.its.jpo.ode.importer;
+
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchEvent.Kind;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import mockit.Capturing;
+import mockit.Expectations;
+import mockit.Injectable;
+import mockit.Mocked;
+import us.dot.its.jpo.ode.OdeProperties;
+import us.dot.its.jpo.ode.importer.ImporterDirectoryWatcher.ImporterFileType;
+
+@Ignore
+public class ImporterDirectoryWatcherTestOld {
+
+   ImporterDirectoryWatcher testImporterDirectoryWatcher;
+
+   @Injectable
+   OdeProperties injectableOdeProperties;
+   @Mocked
+   Path mockDir;
+   @Injectable
+   Path failureDir;
+   @Injectable
+   Path backupDir;
+   @Injectable 
+   Integer timePeriod = 5;
+
+   @Mocked
+   WatchKey mockWatchKey;
+   @Mocked
+   WatchService mockWatchService;
+   @Mocked
+   WatchEvent<Path> mockWatchEvent;
+
+   @Capturing
+   OdeFileUtils capturingOdeFileUtils;
+   @Capturing
+   ImporterProcessor capturingImporterProcessor;
+
+   @Before
+   public void createTestObject() {
+      try {
+         new Expectations() {
+            {
+               OdeFileUtils.createDirectoryRecursively((Path) any);
+               times = 3;
+            }
+         };
+      } catch (IOException e) {
+         fail("Unexpected exception in expectations block: " + e);
+      }
+      testImporterDirectoryWatcher = new ImporterDirectoryWatcher(injectableOdeProperties, mockDir, backupDir, failureDir, ImporterFileType.OBU_LOG_FILE, timePeriod);
+      testImporterDirectoryWatcher.setWatching(false);
+   }
+   
+   @Test
+   public void testConstructorOdeUtilsException() {
+      try {
+         new Expectations() {
+            {
+               OdeFileUtils.createDirectoryRecursively((Path) any);
+               result = new IOException("acceptionIsKindofAWord");
+            }
+         };
+      } catch (IOException e) {
+         fail("Unexpected exception in expectations block: " + e);
+      }
+      new ImporterDirectoryWatcher(injectableOdeProperties, mockDir, backupDir, failureDir, ImporterFileType.OBU_LOG_FILE, timePeriod);
+   }
+
+   @Test(timeout = 4000)
+   public void runShouldCatchException() {
+      try {
+         new Expectations() {
+            {
+               mockDir.register((WatchService) any, (Kind<?>) any);
+               result = null;
+            }
+         };
+      } catch (IOException e) {
+         fail("Unexpected exception in expectations block: " + e);
+      }
+      testImporterDirectoryWatcher.run();
+   }
+
+   @Test(timeout = 4000)
+   public void shouldRunNoProblems() {
+      try {
+         new Expectations() {
+            {
+               mockDir.register((WatchService) any, (Kind<?>) any);
+               result = mockWatchKey;
+            }
+         };
+      } catch (IOException e) {
+         fail("Unexpected exception in expectations block: " + e);
+      }
+      testImporterDirectoryWatcher.run();
+   }
+
+   @Test @Ignore
+   public void pollDirectoryShouldInterruptThreadOnWatcherError() {
+      try {
+         new Expectations(Thread.class) {
+            {
+               mockWatchService.take();
+               result = new InterruptedException("testException123");
+               Thread.currentThread().interrupt();
+               times = 1;
+            }
+         };
+      } catch (InterruptedException e) {
+         fail("Unexpected exception in expectations block: " + e);
+      }
+
+      testImporterDirectoryWatcher.pollDirectory(mockWatchService);
+   }
+
+   @Test @Ignore
+   public void pollDirectoryOverflowShouldContinue() {
+      List<WatchEvent<Path>> pollEventsList = new ArrayList<WatchEvent<Path>>();
+      pollEventsList.add(mockWatchEvent);
+      try {
+         new Expectations() {
+            {
+               mockWatchService.take();
+               result = mockWatchKey;
+
+               mockWatchKey.pollEvents();
+               result = pollEventsList;
+
+               mockWatchKey.reset();
+               result = true;
+
+               mockWatchEvent.kind();
+               result = StandardWatchEventKinds.OVERFLOW;
+               
+               capturingImporterProcessor.processAndBackupFile((Path) any, (Path) any, (Path) any);
+               times = 0;
+            }
+         };
+      } catch (InterruptedException e) {
+         fail("Unexpected exception in expectations block: " + e);
+      }
+
+      testImporterDirectoryWatcher.pollDirectory(mockWatchService);
+   }
+
+   @Test @Ignore
+   public void pollDirectoryEntryModifyShouldProcessFile() {
+      List<WatchEvent<Path>> pollEventsList = new ArrayList<WatchEvent<Path>>();
+      pollEventsList.add(mockWatchEvent);
+      try {
+         new Expectations() {
+            {
+               mockWatchService.take();
+               result = mockWatchKey;
+
+               mockWatchKey.pollEvents();
+               result = pollEventsList;
+
+               mockWatchKey.reset();
+               result = false;
+
+               mockWatchEvent.kind();
+               result = StandardWatchEventKinds.ENTRY_MODIFY;
+
+               capturingImporterProcessor.processAndBackupFile((Path) any, (Path) any, (Path) any);
+               times = 1;
+            }
+         };
+      } catch (InterruptedException e) {
+         fail("Unexpected exception in expectations block: " + e);
+      }
+
+      testImporterDirectoryWatcher.pollDirectory(mockWatchService);
+   }
+   
+   @Test @Ignore
+   public void pollDirectoryUnknownKindShouldThrowError() {
+      List<WatchEvent<Path>> pollEventsList = new ArrayList<WatchEvent<Path>>();
+      pollEventsList.add(mockWatchEvent);
+      try {
+         new Expectations() {
+            {
+               mockWatchService.take();
+               result = mockWatchKey;
+
+               mockWatchKey.pollEvents();
+               result = pollEventsList;
+
+               mockWatchKey.reset();
+               result = false;
+
+               mockWatchEvent.kind();
+               result = StandardWatchEventKinds.ENTRY_DELETE;
+
+               capturingImporterProcessor.processAndBackupFile((Path) any, (Path) any, (Path) any);
+               times = 0;
+            }
+         };
+      } catch (InterruptedException e) {
+         fail("Unexpected exception in expectations block: " + e);
+      }
+
+      testImporterDirectoryWatcher.pollDirectory(mockWatchService);
+   }
+
+}


### PR DESCRIPTION
Replaced uploads directory watcher with a periodic processor. Now the ODE will process the uploads directory every 5 seconds (but will wait for previous iteration to finish, preventing overlaps). Should guarantee all files get processed and moved.

Tested this with a large bunch of files including the one unparsable file and it worked smoothly, the unparsable was moved to the failed directory without holding up the rest of the processing.

Edit: this should be sufficient to fix the ODE's handling of issue #184