### PR TITLE
Issue #200 Fix

### DIFF
--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/coder/TimDecoderHelper.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/coder/TimDecoderHelper.java
@@ -231,11 +231,11 @@ public class TimDecoderHelper {
       TimLogLocation locationDetails = ((TimLogFileParser) fileParser).getLocation();
       ReceivedMessageDetails timSpecificMetadata = new ReceivedMessageDetails(
             new OdeLogMsgMetadataLocation(
-               LatitudeBuilder.genericLatitude(locationDetails.getLatitude()).stripTrailingZeros().toString(),
-               LongitudeBuilder.genericLongitude(locationDetails.getLongitude()).stripTrailingZeros().toString(),
-               ElevationBuilder.genericElevation(locationDetails.getElevation()).stripTrailingZeros().toString(),
-               SpeedOrVelocityBuilder.genericSpeedOrVelocity(locationDetails.getSpeed()).stripTrailingZeros().toString(),
-               HeadingBuilder.genericHeading(locationDetails.getHeading()).stripTrailingZeros().toString()
+               LatitudeBuilder.genericLatitude(locationDetails.getLatitude()).stripTrailingZeros().toPlainString(),
+               LongitudeBuilder.genericLongitude(locationDetails.getLongitude()).stripTrailingZeros().toPlainString(),
+               ElevationBuilder.genericElevation(locationDetails.getElevation()).stripTrailingZeros().toPlainString(),
+               SpeedOrVelocityBuilder.genericSpeedOrVelocity(locationDetails.getSpeed()).stripTrailingZeros().toPlainString(),
+               HeadingBuilder.genericHeading(locationDetails.getHeading()).stripTrailingZeros().toPlainString()
                   ), null);
       
       if (fileParser instanceof RxMsgFileParser) {

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/coder/TimDecoderHelper.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/coder/TimDecoderHelper.java
@@ -231,11 +231,11 @@ public class TimDecoderHelper {
       TimLogLocation locationDetails = ((TimLogFileParser) fileParser).getLocation();
       ReceivedMessageDetails timSpecificMetadata = new ReceivedMessageDetails(
             new OdeLogMsgMetadataLocation(
-               LatitudeBuilder.genericLatitude(locationDetails.getLatitude()).toString(),
-               LongitudeBuilder.genericLongitude(locationDetails.getLongitude()).toString(),
-               ElevationBuilder.genericElevation(locationDetails.getElevation()).toString(),
-               SpeedOrVelocityBuilder.genericSpeedOrVelocity(locationDetails.getSpeed()).toString(),
-               HeadingBuilder.genericHeading(locationDetails.getHeading()).toString()
+               LatitudeBuilder.genericLatitude(locationDetails.getLatitude()).stripTrailingZeros().toString(),
+               LongitudeBuilder.genericLongitude(locationDetails.getLongitude()).stripTrailingZeros().toString(),
+               ElevationBuilder.genericElevation(locationDetails.getElevation()).stripTrailingZeros().toString(),
+               SpeedOrVelocityBuilder.genericSpeedOrVelocity(locationDetails.getSpeed()).stripTrailingZeros().toString(),
+               HeadingBuilder.genericHeading(locationDetails.getHeading()).stripTrailingZeros().toString()
                   ), null);
       
       if (fileParser instanceof RxMsgFileParser) {


### PR DESCRIPTION
This is a fix for issue #200. BigDecimal values that have trailing zeros (i.e. 85.1234500) are treated as a string for XML serialization, but values without trailing zeros get represented as a number. This changes it so all these fields will be represented as a number and so will not have quotes.

Note that this will probably come up again when the TIM-->human readable converter is finished.