### PR TITLE
Kafka Version Update

### DIFF
--- a/docker/kafka/Dockerfile
+++ b/docker/kafka/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER 572682
 
 RUN apk add --update unzip wget curl docker jq coreutils
 
-ENV KAFKA_VERSION="0.10.1.0" SCALA_VERSION="2.11"
+ENV KAFKA_VERSION="0.11.0.2" SCALA_VERSION="2.11"
 ADD download-kafka.sh /tmp/download-kafka.sh
 RUN chmod a+x /tmp/download-kafka.sh && sync && /tmp/download-kafka.sh && tar xfz /tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz -C /opt && rm /tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz
 


### PR DESCRIPTION
This was causing a build failure on the rackspace instance. Looked like [this](https://github.com/wurstmeister/kafka-docker/issues/50) issue, the Kafka artifact server had moved.