### PR TITLE
Further Kafka update and required property

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       KAFKA_DELETE_TOPIC_ENABLED: "true"
       KAFKA_CLEANUP_POLICY: "delete" # delete old logs
       KAFKA_LOG_RETENTION_HOURS: 2
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 3000
       KAFKA_RETENTION_MS: 7200000    # delete old logs after 2 hours
       KAFKA_SEGMENT_MS:   7200000    # roll segment logs every 2 hours.
                                      # This configuration controls the period of time after

--- a/docker/kafka/Dockerfile
+++ b/docker/kafka/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER 572682
 
 RUN apk add --update unzip wget curl docker jq coreutils
 
-ENV KAFKA_VERSION="0.11.0.2" SCALA_VERSION="2.11"
+ENV KAFKA_VERSION="1.0.0" SCALA_VERSION="2.11"
 ADD download-kafka.sh /tmp/download-kafka.sh
 RUN chmod a+x /tmp/download-kafka.sh && sync && /tmp/download-kafka.sh && tar xfz /tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz -C /opt && rm /tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz
 


### PR DESCRIPTION
The previous pull request #205 was not sufficient and there is an even newer version of kafka - the 1.0.0 release. This updates the ODE to that version as well as adding the required property to the docker-compose file.

From the Kafka documentation:
>A new config, group.initial.rebalance.delay.ms, was introduced. This config specifies the time, in milliseconds, that the GroupCoordinator will delay the initial consumer rebalance. The rebalance will be further delayed by the value of group.initial.rebalance.delay.ms as new members join the group, up to a maximum of max.poll.interval.ms. The default value for this is 3 seconds. During development and testing it might be desirable to set this to 0 in order to not delay test execution time.