### PR TITLE
Added checking conditions to satisfy Sonar

### DIFF
--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/importer/ImporterProcessor.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/importer/ImporterProcessor.java
@@ -75,19 +75,31 @@ public class ImporterProcessor {
 
       // ODE-559
       boolean success = true;
+      InputStream inputStream = null;
+      BufferedInputStream bis = null;
+      
       try {
-         InputStream inputStream = new FileInputStream(filePath.toFile());
+         inputStream = new FileInputStream(filePath.toFile());
          if (Files.probeContentType(filePath).equals("application/gzip")) { 
             inputStream = new GZIPInputStream(inputStream);
          }
-         BufferedInputStream bis = new BufferedInputStream(inputStream, odeProperties.getImportProcessorBufferSize());
+         bis = new BufferedInputStream(inputStream, odeProperties.getImportProcessorBufferSize());
          codecPublisher.publishFile(filePath, bis, fileType);
-         bis.close();
-         inputStream.close();
       } catch (Exception e) {
          success = false;
          logger.error("Failed to open or process file: " + filePath, e);
          EventLogger.logger.error("Failed to open or process file: " + filePath, e);  
+      } finally {
+         try {
+            if (bis != null) {
+               bis.close();
+            }
+            if (inputStream != null) {
+               inputStream.close();
+            }
+         } catch (IOException e) {
+            logger.error("Failed to close file stream: {}", e);
+         }
       }
       
       try {


### PR DESCRIPTION
Sonar reported the streams should be closed in a finally block, but this makes for some ugly scoping and checking. I was trying to do this with try-with-resources blocks like so:
```
      try (InputStream inputStream = new FileInputStream(filePath.toFile());){
         
         if (Files.probeContentType(filePath).equals("application/gzip")) { 
            inputStream = new GZIPInputStream(inputStream);
         }
         //...
      }
```

But this way won't work because `inputStream` cannot be reassigned once declared. @hmusavi any thoughts? The functionality should be the same either way.
