### PR TITLE
ODE-735 Dist Type fix

### DIFF
--- a/jpo-ode-common/src/main/java/us/dot/its/jpo/ode/util/CodecUtils.java
+++ b/jpo-ode-common/src/main/java/us/dot/its/jpo/ode/util/CodecUtils.java
@@ -146,6 +146,10 @@ public class CodecUtils {
    public static String toHex(byte[] bytes) {
       return bytes != null ? DatatypeConverter.printHexBinary(bytes) : "";
    }
+   
+   public static String toHex(byte b) {
+      return DatatypeConverter.printHexBinary(new byte[]{b});
+   }
 
    public static byte[] fromHex(String hex) {
       return DatatypeConverter.parseHexBinary(hex);

--- a/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/DdsAdvisoryDetails.java
+++ b/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/DdsAdvisoryDetails.java
@@ -2,7 +2,6 @@ package us.dot.its.jpo.ode.plugin.j2735;
 
 import us.dot.its.jpo.ode.plugin.asn1.Asn1Object;
 import us.dot.its.jpo.ode.plugin.ieee1609dot2.Ieee1609Dot2DataTag;
-import us.dot.its.jpo.ode.util.CodecUtils;
 
 public class DdsAdvisoryDetails extends Asn1Object {
    private static final long serialVersionUID = 8964772115424427026L;
@@ -12,12 +11,6 @@ public class DdsAdvisoryDetails extends Asn1Object {
       map,           //  (1),
       tim,           //  (2),
       ev             //  (3),
-   }
-
-   public enum DistributionType {
-      none, //(0),  "00000000", not intended for redistribution
-      rsu,  //(1),  "00000001", intended for redistribution over DSRC
-      ip    //(2),  "00000010"  intended for redistribution over IP
    }
    
    String asdmID;                   //         DSRC.TemporaryID,
@@ -43,7 +36,7 @@ public class DdsAdvisoryDetails extends Asn1Object {
       super();
       this.asdmID = asdmID;
       this.asdmType = asdmType.ordinal();
-      this.distType = Integer.toHexString(Integer.valueOf(distType));
+      this.distType = distType;
       this.startTime = startTime;
       this.stopTime = stopTime;
       this.advisoryMessage = advisoryMessage2;

--- a/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/DdsAdvisoryDetails.java
+++ b/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/DdsAdvisoryDetails.java
@@ -2,6 +2,7 @@ package us.dot.its.jpo.ode.plugin.j2735;
 
 import us.dot.its.jpo.ode.plugin.asn1.Asn1Object;
 import us.dot.its.jpo.ode.plugin.ieee1609dot2.Ieee1609Dot2DataTag;
+import us.dot.its.jpo.ode.util.CodecUtils;
 
 public class DdsAdvisoryDetails extends Asn1Object {
    private static final long serialVersionUID = 8964772115424427026L;
@@ -21,7 +22,7 @@ public class DdsAdvisoryDetails extends Asn1Object {
    
    String asdmID;                   //         DSRC.TemporaryID,
    int asdmType;                    //    AdvisoryBroadcastType,
-   int distType;                    //0, 1 or 2    ,
+   String distType;                    //0, 1 or 2    ,
    J2735DFullTime startTime;        //OPTIONAL,
    J2735DFullTime stopTime;         //OPTIONAL,
    String advisoryMessageBytes;          //  OCTET STRING (SIZE(0..1400))  -- Encoded advisory message
@@ -37,12 +38,12 @@ public class DdsAdvisoryDetails extends Asn1Object {
       return asdmID;
    }
    
-   public DdsAdvisoryDetails(String asdmID, AdvisoryBroadcastType asdmType, int distType, J2735DFullTime startTime,
+   public DdsAdvisoryDetails(String asdmID, AdvisoryBroadcastType asdmType, String distType, J2735DFullTime startTime,
          J2735DFullTime stopTime, Ieee1609Dot2DataTag advisoryMessage2) {
       super();
       this.asdmID = asdmID;
       this.asdmType = asdmType.ordinal();
-      this.distType = distType;
+      this.distType = Integer.toHexString(Integer.valueOf(distType));
       this.startTime = startTime;
       this.stopTime = stopTime;
       this.advisoryMessage = advisoryMessage2;
@@ -57,10 +58,10 @@ public class DdsAdvisoryDetails extends Asn1Object {
    public void setAsdmType(int asdmType) {
       this.asdmType = asdmType;
    }
-   public int getDistType() {
+   public String getDistType() {
       return distType;
    }
-   public void setDistType(int distType) {
+   public void setDistType(String distType) {
       this.distType = distType;
    }
    public J2735DFullTime getStartTime() {
@@ -87,6 +88,8 @@ public class DdsAdvisoryDetails extends Asn1Object {
    public void setAdvisoryMessage(Ieee1609Dot2DataTag advisoryMessage) {
       this.advisoryMessage = advisoryMessage;
    }
+
+
    @Override
    public int hashCode() {
       final int prime = 31;
@@ -95,11 +98,13 @@ public class DdsAdvisoryDetails extends Asn1Object {
       result = prime * result + ((advisoryMessageBytes == null) ? 0 : advisoryMessageBytes.hashCode());
       result = prime * result + ((asdmID == null) ? 0 : asdmID.hashCode());
       result = prime * result + asdmType;
-      result = prime * result + distType;
+      result = prime * result + ((distType == null) ? 0 : distType.hashCode());
       result = prime * result + ((startTime == null) ? 0 : startTime.hashCode());
       result = prime * result + ((stopTime == null) ? 0 : stopTime.hashCode());
       return result;
    }
+
+
    @Override
    public boolean equals(Object obj) {
       if (this == obj)
@@ -126,7 +131,10 @@ public class DdsAdvisoryDetails extends Asn1Object {
          return false;
       if (asdmType != other.asdmType)
          return false;
-      if (distType != other.distType)
+      if (distType == null) {
+         if (other.distType != null)
+            return false;
+      } else if (!distType.equals(other.distType))
          return false;
       if (startTime == null) {
          if (other.startTime != null)
@@ -140,6 +148,7 @@ public class DdsAdvisoryDetails extends Asn1Object {
          return false;
       return true;
    }
+   
    
    
 }

--- a/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/DdsAdvisorySituationData.java
+++ b/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/DdsAdvisorySituationData.java
@@ -8,7 +8,6 @@ import us.dot.its.jpo.ode.plugin.SituationDataWarehouse;
 import us.dot.its.jpo.ode.plugin.asn1.Asn1Object;
 import us.dot.its.jpo.ode.plugin.ieee1609dot2.Ieee1609Dot2DataTag;
 import us.dot.its.jpo.ode.plugin.j2735.DdsAdvisoryDetails.AdvisoryBroadcastType;
-import us.dot.its.jpo.ode.plugin.j2735.DdsAdvisoryDetails.DistributionType;
 import us.dot.its.jpo.ode.util.CodecUtils;
 import us.dot.its.jpo.ode.util.DateTimeUtils;
 
@@ -35,7 +34,7 @@ public class DdsAdvisorySituationData extends Asn1Object {
    }
 
    public DdsAdvisorySituationData(String startTime, String stopTime, Ieee1609Dot2DataTag advisoryMessage,
-         DdsGeoRegion serviceRegion, SituationDataWarehouse.SDW.TimeToLive ttl, String groupID) throws ParseException {
+         DdsGeoRegion serviceRegion, SituationDataWarehouse.SDW.TimeToLive ttl, String groupID, byte[] distroType) throws ParseException {
       this();
 
       J2735DFullTime dStartTime = dFullTimeFromIsoTimeString(startTime);
@@ -45,9 +44,9 @@ public class DdsAdvisorySituationData extends Asn1Object {
       byte[] fourRandomBytes = new byte[4];
       new Random(System.currentTimeMillis()).nextBytes(fourRandomBytes);
       String id = CodecUtils.toHex(fourRandomBytes);
-      String distroType = Integer.toString(DistributionType.ip.ordinal());
+      String stringDistroType = CodecUtils.toHex(distroType);
       this.setAsdmDetails(
-            new DdsAdvisoryDetails(id, AdvisoryBroadcastType.tim, distroType, dStartTime, dStopTime, advisoryMessage));
+            new DdsAdvisoryDetails(id, AdvisoryBroadcastType.tim, stringDistroType, dStartTime, dStopTime, advisoryMessage));
 
       this.setRequestID(id);
       this.setServiceRegion(serviceRegion);

--- a/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/DdsAdvisorySituationData.java
+++ b/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/DdsAdvisorySituationData.java
@@ -45,7 +45,7 @@ public class DdsAdvisorySituationData extends Asn1Object {
       byte[] fourRandomBytes = new byte[4];
       new Random(System.currentTimeMillis()).nextBytes(fourRandomBytes);
       String id = CodecUtils.toHex(fourRandomBytes);
-      int distroType = DistributionType.rsu.ordinal();
+      String distroType = Integer.toString(DistributionType.ip.ordinal());
       this.setAsdmDetails(
             new DdsAdvisoryDetails(id, AdvisoryBroadcastType.tim, distroType, dStartTime, dStopTime, advisoryMessage));
 

--- a/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/DdsAdvisorySituationData.java
+++ b/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/DdsAdvisorySituationData.java
@@ -13,6 +13,11 @@ import us.dot.its.jpo.ode.util.DateTimeUtils;
 
 public class DdsAdvisorySituationData extends Asn1Object {
    private static final long serialVersionUID = 2755274323293805425L;
+   
+   // Distribution Type field values
+   public static final byte NONE = (byte) 0x00;
+   public static final byte RSU = (byte) 0x01;
+   public static final byte IP = (byte) 0x02;
 
    int dialogID = 0x9C;    // SemiDialogID -- 0x9C Advisory Situation Data Deposit
    int seqID = 0x05;       // SemiSequenceID -- 0x05 Data
@@ -34,7 +39,7 @@ public class DdsAdvisorySituationData extends Asn1Object {
    }
 
    public DdsAdvisorySituationData(String startTime, String stopTime, Ieee1609Dot2DataTag advisoryMessage,
-         DdsGeoRegion serviceRegion, SituationDataWarehouse.SDW.TimeToLive ttl, String groupID, byte[] distroType) throws ParseException {
+         DdsGeoRegion serviceRegion, SituationDataWarehouse.SDW.TimeToLive ttl, String groupID, byte distroType) throws ParseException {
       this();
 
       J2735DFullTime dStartTime = dFullTimeFromIsoTimeString(startTime);

--- a/jpo-ode-plugins/src/test/java/us/dot/its/jpo/ode/plugin/j2735/DdsAdvisoryDetailsTest.java
+++ b/jpo-ode-plugins/src/test/java/us/dot/its/jpo/ode/plugin/j2735/DdsAdvisoryDetailsTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import mockit.Tested;
 import us.dot.its.jpo.ode.plugin.ieee1609dot2.Ieee1609Dot2DataTag;
 import us.dot.its.jpo.ode.plugin.j2735.DdsAdvisoryDetails.AdvisoryBroadcastType;
+import us.dot.its.jpo.ode.util.CodecUtils;
 
 public class DdsAdvisoryDetailsTest {
 
@@ -17,7 +18,7 @@ public class DdsAdvisoryDetailsTest {
    public void testSettersGetters() {
       testDdsAdvisoryDetails.setAsdmID("testAsdmID");
       testDdsAdvisoryDetails.setAsdmType(1);
-      testDdsAdvisoryDetails.setDistType("2");
+      testDdsAdvisoryDetails.setDistType(CodecUtils.toHex(DdsAdvisorySituationData.IP));
       testDdsAdvisoryDetails.setStartTime(new J2735DFullTime());
       testDdsAdvisoryDetails.setStopTime(new J2735DFullTime());
       testDdsAdvisoryDetails.setAdvisoryMessageBytes("testAdvisoryMessageBytes");
@@ -25,7 +26,7 @@ public class DdsAdvisoryDetailsTest {
       
       assertEquals("testAsdmID", testDdsAdvisoryDetails.getAsdmID());
       assertEquals(1, testDdsAdvisoryDetails.getAsdmType());
-      assertEquals("2", testDdsAdvisoryDetails.getDistType());
+      assertEquals("02", testDdsAdvisoryDetails.getDistType());
       assertNotNull(testDdsAdvisoryDetails.getStartTime());
       assertNotNull(testDdsAdvisoryDetails.getStopTime());
       assertEquals("testAdvisoryMessageBytes", testDdsAdvisoryDetails.getAdvisoryMessageBytes());
@@ -34,11 +35,13 @@ public class DdsAdvisoryDetailsTest {
 
    @Test
    public void testHashCodeAndEquals() {
-      DdsAdvisoryDetails ddsad1 = new DdsAdvisoryDetails("asdmID", AdvisoryBroadcastType.tim, "1", new J2735DFullTime(),
+      String distType = CodecUtils.toHex(DdsAdvisorySituationData.RSU);
+      
+      DdsAdvisoryDetails ddsad1 = new DdsAdvisoryDetails("asdmID", AdvisoryBroadcastType.tim, distType, new J2735DFullTime(),
             new J2735DFullTime(), new Ieee1609Dot2DataTag());
-      DdsAdvisoryDetails ddsad2 = new DdsAdvisoryDetails("asdmID", AdvisoryBroadcastType.tim, "1", new J2735DFullTime(),
+      DdsAdvisoryDetails ddsad2 = new DdsAdvisoryDetails("asdmID", AdvisoryBroadcastType.tim, distType, new J2735DFullTime(),
             new J2735DFullTime(), new Ieee1609Dot2DataTag());
-      DdsAdvisoryDetails ddsad3 = new DdsAdvisoryDetails("asdmID", AdvisoryBroadcastType.map, "1", new J2735DFullTime(),
+      DdsAdvisoryDetails ddsad3 = new DdsAdvisoryDetails("asdmID", AdvisoryBroadcastType.map, distType, new J2735DFullTime(),
             new J2735DFullTime(), new Ieee1609Dot2DataTag());
 
       assertEquals("Expected identical hashcodes", ddsad1.hashCode(), ddsad2.hashCode());

--- a/jpo-ode-plugins/src/test/java/us/dot/its/jpo/ode/plugin/j2735/DdsAdvisoryDetailsTest.java
+++ b/jpo-ode-plugins/src/test/java/us/dot/its/jpo/ode/plugin/j2735/DdsAdvisoryDetailsTest.java
@@ -1,0 +1,51 @@
+package us.dot.its.jpo.ode.plugin.j2735;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import mockit.Tested;
+import us.dot.its.jpo.ode.plugin.ieee1609dot2.Ieee1609Dot2DataTag;
+import us.dot.its.jpo.ode.plugin.j2735.DdsAdvisoryDetails.AdvisoryBroadcastType;
+
+public class DdsAdvisoryDetailsTest {
+
+   @Tested
+   DdsAdvisoryDetails testDdsAdvisoryDetails;
+
+   @Test
+   public void testSettersGetters() {
+      testDdsAdvisoryDetails.setAsdmID("testAsdmID");
+      testDdsAdvisoryDetails.setAsdmType(1);
+      testDdsAdvisoryDetails.setDistType("2");
+      testDdsAdvisoryDetails.setStartTime(new J2735DFullTime());
+      testDdsAdvisoryDetails.setStopTime(new J2735DFullTime());
+      testDdsAdvisoryDetails.setAdvisoryMessageBytes("testAdvisoryMessageBytes");
+      testDdsAdvisoryDetails.setAdvisoryMessage(new Ieee1609Dot2DataTag());
+      
+      assertEquals("testAsdmID", testDdsAdvisoryDetails.getAsdmID());
+      assertEquals(1, testDdsAdvisoryDetails.getAsdmType());
+      assertEquals("2", testDdsAdvisoryDetails.getDistType());
+      assertNotNull(testDdsAdvisoryDetails.getStartTime());
+      assertNotNull(testDdsAdvisoryDetails.getStopTime());
+      assertEquals("testAdvisoryMessageBytes", testDdsAdvisoryDetails.getAdvisoryMessageBytes());
+      assertNotNull(testDdsAdvisoryDetails.getAdvisoryMessage());
+   }
+
+   @Test
+   public void testHashCodeAndEquals() {
+      DdsAdvisoryDetails ddsad1 = new DdsAdvisoryDetails("asdmID", AdvisoryBroadcastType.tim, "1", new J2735DFullTime(),
+            new J2735DFullTime(), new Ieee1609Dot2DataTag());
+      DdsAdvisoryDetails ddsad2 = new DdsAdvisoryDetails("asdmID", AdvisoryBroadcastType.tim, "1", new J2735DFullTime(),
+            new J2735DFullTime(), new Ieee1609Dot2DataTag());
+      DdsAdvisoryDetails ddsad3 = new DdsAdvisoryDetails("asdmID", AdvisoryBroadcastType.map, "1", new J2735DFullTime(),
+            new J2735DFullTime(), new Ieee1609Dot2DataTag());
+
+      assertEquals("Expected identical hashcodes", ddsad1.hashCode(), ddsad2.hashCode());
+      assertNotEquals("Expected different hashcodes", ddsad2.hashCode(), ddsad3.hashCode());
+      
+      assertTrue("Expected objects to be equal", ddsad1.equals(ddsad2));
+      assertFalse("Expected objects to not be equal", ddsad2.equals(ddsad3));
+   }
+
+}

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/traveler/TimController.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/traveler/TimController.java
@@ -311,8 +311,8 @@ public class TimController {
             ieee.setContent(ieeeContent );
             ieeeDataTag.setIeee1609Dot2Data(ieee);
             
-            byte sendToRsu = travelerInputData.getRsus() != null ? (byte)1:(byte)0;
-            byte[] distroType = new byte[]{(byte) ((byte)(2) | sendToRsu)};
+            byte sendToRsu = travelerInputData.getRsus() != null ? DdsAdvisorySituationData.RSU:DdsAdvisorySituationData.NONE;
+            byte distroType = (byte) (DdsAdvisorySituationData.IP | sendToRsu);
             
             // take deliverystart and stop times from SNMP object, if present
             // else take from SDW object

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/traveler/TimController.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/traveler/TimController.java
@@ -311,16 +311,19 @@ public class TimController {
             ieee.setContent(ieeeContent );
             ieeeDataTag.setIeee1609Dot2Data(ieee);
             
+            byte sendToRsu = travelerInputData.getRsus() != null ? (byte)1:(byte)0;
+            byte[] distroType = new byte[]{(byte) ((byte)(2) | sendToRsu)};
+            
             // take deliverystart and stop times from SNMP object, if present
             // else take from SDW object
             SNMP snmp = travelerInputData.getSnmp();
             if (null != snmp) {
 
                asd = new DdsAdvisorySituationData(snmp.getDeliverystart(), snmp.getDeliverystop(), ieeeDataTag,
-                     GeoRegionBuilder.ddsGeoRegion(sdw.getServiceRegion()), sdw.getTtl(), sdw.getGroupID());
+                     GeoRegionBuilder.ddsGeoRegion(sdw.getServiceRegion()), sdw.getTtl(), sdw.getGroupID(), distroType);
             } else {
                asd = new DdsAdvisorySituationData(sdw.getDeliverystart(), sdw.getDeliverystop(), ieeeDataTag,
-                     GeoRegionBuilder.ddsGeoRegion(sdw.getServiceRegion()), sdw.getTtl(), sdw.getGroupID());
+                     GeoRegionBuilder.ddsGeoRegion(sdw.getServiceRegion()), sdw.getTtl(), sdw.getGroupID(), distroType);
             }
             
             

--- a/jpo-ode-svcs/src/test/java/us/dot/its/jpo/ode/traveler/AsdMessageTest.java
+++ b/jpo-ode-svcs/src/test/java/us/dot/its/jpo/ode/traveler/AsdMessageTest.java
@@ -35,7 +35,7 @@ public class AsdMessageTest {
     @Injectable
     String groupID = "01234567";
     @Injectable
-    byte[] distroType = new byte[]{(byte) 1}; 
+    byte distroType = DdsAdvisorySituationData.NONE; 
 
     @Mocked
     ZonedDateTime mockZonedDateTimeStart;

--- a/jpo-ode-svcs/src/test/java/us/dot/its/jpo/ode/traveler/AsdMessageTest.java
+++ b/jpo-ode-svcs/src/test/java/us/dot/its/jpo/ode/traveler/AsdMessageTest.java
@@ -34,6 +34,8 @@ public class AsdMessageTest {
     SituationDataWarehouse.SDW.TimeToLive ttl = SituationDataWarehouse.SDW.TimeToLive.oneminute;
     @Injectable
     String groupID = "01234567";
+    @Injectable
+    byte[] distroType = new byte[]{(byte) 1}; 
 
     @Mocked
     ZonedDateTime mockZonedDateTimeStart;


### PR DESCRIPTION
This fix addresses the distribution type encoding problem mentioned in issue #233 and ticket ODE-735.

Changes:
- Distribution type is now forced into a hex string to guarantee correct encoding by asn1_codec
- Distribution type now more closely reflects the specification: a bitwise OR of the IP bit and the RSU bit (SDW/IP bit is always set, RSU bit is only set when RSU[] array is present in the input JSON)
- Added new single-byte byte-->hexstring method.
- Minor unit tests