### PR TITLE
InterruptedException best practices fix

### DIFF
--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/udp/isd/IsdDepositor.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/udp/isd/IsdDepositor.java
@@ -85,8 +85,11 @@ public class IsdDepositor extends AbstractSubscriberDepositor {
             throw new IOException("Received invalid packet.");
          }
 
-      } catch (IOException | InterruptedException | ExecutionException e) {
+      } catch (IOException | ExecutionException e) {
          logger.error("Error sending ISD Acceptance message to SDC", e);
+      } catch (InterruptedException e) {
+         logger.error("Error caused ISD Depositor thread interruption", e);
+         Thread.currentThread().interrupt();
       } catch (TimeoutException e) {
          logger.error("Did not receive ISD data receipt within alotted "
                + +odeProperties.getDataReceiptExpirationSeconds() + " seconds " + e);

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/udp/trust/TrustManager.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/udp/trust/TrustManager.java
@@ -97,10 +97,10 @@ public class TrustManager {
             endTrustSession(requestId);
             logger.error("Did not receive Service Response within alotted "
                   + +odeProperties.getServiceRespExpirationSeconds() + " seconds.", e);
-
          } catch (InterruptedException | ExecutionException | UdpUtilException e) {
             endTrustSession(requestId);
             logger.error("Trust establishment interrupted.", e);
+            Thread.currentThread().interrupt();
          }
          --retriesLeft;
       }


### PR DESCRIPTION
Sonar wants us to either re-throw the exception or kill the thread, I think killing the thread is probably the cleaner option.