### PR TITLE
Update test-harness import, documentation, and streamId path

### DIFF
--- a/qa/test-harness/README.md
+++ b/qa/test-harness/README.md
@@ -4,6 +4,41 @@
 
 This folder contains the automated regression test harness application built for the ODE. The test harness sends a file to the ODE, listens for messages to be published to Kafka, then validates the output.
 
+## Requirements
+
+- Python 3.6+ (_preferred_) or Python 2.7
+
+## Installation
+
+This test harness is a python script that should work with both Python 2.7 and Python 3.6+. Using virtualenv with Python 3.7 will give the most consistent experience.
+
+#### Option 1: (Recommended) Using python3 with virtualenv
+
+1. [Install python3](https://realpython.com/installing-python/)
+2. [Install virtualenv](https://virtualenv.pypa.io/en/stable/installation/)
+3. Create a virtualenv repository:
+```
+virtualenv -p python3 testharness
+```
+4. Activate virtualenv:
+```
+source ./testharness/bin/activate
+```
+5. Install the required python modules using pip:
+```
+pip install -r requirements.txt
+```
+5. _Run the test script using the **Usage** instructions below._
+6. Deactivate virtualenv
+```
+deactivate
+```
+
+#### Option 2: Using system python
+
+1. Install the required python modules using `pip install -r requirements.txt` or `pip3 install -r requirements.txt`
+2.  _Run the test script using the **Usage** instructions below._
+
 ## Usage
 
 **Important Note**: Before you begin either of the options below, you must set the [DOCKER_HOST_IP](https://github.com/usdot-jpo-ode/jpo-ode/wiki/Docker-management#obtaining-docker_host_ip) environment variable.

--- a/qa/test-harness/README.md
+++ b/qa/test-harness/README.md
@@ -6,11 +6,11 @@ This folder contains the automated regression test harness application built for
 
 ## Requirements
 
-- Python 3.6+ (_preferred_) or Python 2.7
+- Python 3.6+
 
 ## Installation
 
-This test harness is a python script that should work with both Python 2.7 and Python 3.6+. Using virtualenv with Python 3.7 will give the most consistent experience.
+This test harness is a python script designed for Python 3.6+. Using virtualenv with Python 3.7 will give the most consistent experience.
 
 #### Option 1: (Recommended) Using python3 with virtualenv
 
@@ -36,7 +36,7 @@ deactivate
 
 #### Option 2: Using system python
 
-1. Install the required python modules using `pip install -r requirements.txt` or `pip3 install -r requirements.txt`
+1. Install the required python modules using `pip install -r requirements.txt`.
 2.  _Run the test script using the **Usage** instructions below._
 
 ## Usage

--- a/qa/test-harness/config/bsmLogDuringEvent.ini
+++ b/qa/test-harness/config/bsmLogDuringEvent.ini
@@ -98,7 +98,7 @@ Path = metadata.serialId
 Type = string
 
 [streamId]
-Path = metadata.serialId
+Path = metadata.serialId.streamId
 Type = string
 
 [bundleSize]

--- a/qa/test-harness/config/bsmTx.ini
+++ b/qa/test-harness/config/bsmTx.ini
@@ -98,7 +98,7 @@ Path = metadata.serialId
 Type = string
 
 [streamId]
-Path = metadata.serialId
+Path = metadata.serialId.streamId
 Type = string
 
 [bundleSize]

--- a/qa/test-harness/config/dnMsg.ini
+++ b/qa/test-harness/config/dnMsg.ini
@@ -93,7 +93,7 @@ Path = metadata.serialId
 Type = string
 
 [streamId]
-Path = metadata.serialId
+Path = metadata.serialId.streamId
 Type = string
 
 [bundleSize]

--- a/qa/test-harness/config/driverAlert.ini
+++ b/qa/test-harness/config/driverAlert.ini
@@ -93,7 +93,7 @@ Path = metadata.serialId
 Type = string
 
 [streamId]
-Path = metadata.serialId
+Path = metadata.serialId.streamId
 Type = string
 
 [bundleSize]

--- a/qa/test-harness/config/rxMsg_TIM_GeneratedBy_TMC_VIA_SNMP-bsmcheck.ini
+++ b/qa/test-harness/config/rxMsg_TIM_GeneratedBy_TMC_VIA_SNMP-bsmcheck.ini
@@ -98,7 +98,7 @@ Path = metadata.serialId
 Type = string
 
 [streamId]
-Path = metadata.serialId
+Path = metadata.serialId.streamId
 Type = string
 
 [bundleSize]

--- a/qa/test-harness/config/rxMsg_TIM_GeneratedBy_TMC_VIA_SNMP-timcheck.ini
+++ b/qa/test-harness/config/rxMsg_TIM_GeneratedBy_TMC_VIA_SNMP-timcheck.ini
@@ -93,7 +93,7 @@ Path = metadata.serialId
 Type = string
 
 [streamId]
-Path = metadata.serialId
+Path = metadata.serialId.streamId
 Type = string
 
 [bundleSize]

--- a/qa/test-harness/config/rxMsg_TIM_and_BSM-bsmcheck.ini
+++ b/qa/test-harness/config/rxMsg_TIM_and_BSM-bsmcheck.ini
@@ -99,7 +99,7 @@ Path = metadata.serialId
 Type = string
 
 [streamId]
-Path = metadata.serialId
+Path = metadata.serialId.streamId
 Type = string
 
 [bundleSize]

--- a/qa/test-harness/config/rxMsg_TIM_and_BSM-timcheck.ini
+++ b/qa/test-harness/config/rxMsg_TIM_and_BSM-timcheck.ini
@@ -93,7 +93,7 @@ Path = metadata.serialId
 Type = string
 
 [streamId]
-Path = metadata.serialId
+Path = metadata.serialId.streamId
 Type = string
 
 [bundleSize]

--- a/qa/test-harness/requirements.txt
+++ b/qa/test-harness/requirements.txt
@@ -1,1 +1,4 @@
 git+https://github.com/usdot-jpo-ode/ode-output-validator-library@master#egg=odevalidator
+python-dateutil
+kafka-python
+requests

--- a/qa/test-harness/test-harness.py
+++ b/qa/test-harness/test-harness.py
@@ -8,7 +8,7 @@ import time
 from argparse import ArgumentParser
 from kafka import KafkaConsumer
 from pathlib import Path
-from odevalidator.validator import TestCase
+from odevalidator import TestCase
 
 KAFKA_CONSUMER_TIMEOUT = 10000
 KAFKA_PORT = '9092'


### PR DESCRIPTION
#### Changes:

- Updated import to use namespaceless import (`from odevalidator import TestCase` instead of `from odevalidator.validator import TestCase`)
- Improved documentation to include setup/installation instructions
- Added virtualenv instructions to documentation
- Fixed streamId path issue