### PR TITLE
Load Testing Script

### DIFF
--- a/qa/load-testing/README.md
+++ b/qa/load-testing/README.md
@@ -1,0 +1,9 @@
+# Load Tester
+
+Add --count or -c argument to define the number of times to upload a file.
+
+```bash
+usage: main.py [-h] -c COUNT
+
+python main.py -c 100
+```

--- a/qa/load-testing/create-testfiles.sh
+++ b/qa/load-testing/create-testfiles.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+if [ $# != 3 ]; then
+  echo "Missing parameters. Requires 3: 'script.sh SOURCEFILE DESTDIR NUMCOPIES'"
+  exit 1
+fi
+
+mkdir -p $2
+
+BASENAME=$(basename $1 .gz)
+echo "$BASENAME"
+echo "$1"
+
+
+for (( i = 0; i <= $3; i++))
+do
+  echo "Creating $BASENAME$i.gz in $2"
+  cp "$1" "./$2/$BASENAME$i.gz"
+done

--- a/qa/load-testing/main.py
+++ b/qa/load-testing/main.py
@@ -1,24 +1,42 @@
 from argparse import ArgumentParser
+import glob
 import os
 import requests
+import time
 
 DOCKER_HOST_IP=os.getenv('DOCKER_HOST_IP')
 assert DOCKER_HOST_IP != None, "Failed to get DOCKER_HOST_IP from environment variable"
 UPLOAD_URL = "http://%s:8080/upload/bsmlog" % DOCKER_HOST_IP
-UPLOAD_FILE = "../../data/bsmLogDuringEvent.gz"
 
-def upload_file():
-    with open(UPLOAD_FILE, 'rb') as file:
+def get_list_of_files_in_directory(directory):
+    files_and_directories = glob.glob(directory+"/**/*", recursive=True)
+    files_only = []
+    for filepath in files_and_directories:
+        if os.path.isfile(filepath):
+            files_only.append(filepath)
+    return files_only
+
+def upload_file(filepath):
+    with open(filepath, 'rb') as file:
         return requests.post(UPLOAD_URL, files={'name':'file', 'file':file}, timeout=2)
 
 def main():
     parser = ArgumentParser()
-    parser.add_argument("-c", "--count", dest="count", help="Number of times to repeat upload.", metavar="COUNT", required=True)
+    parser.add_argument("--dir", dest="dir", help="Directory containing files to upload.", metavar="DIR", required=True)
     args = parser.parse_args()
 
-    for i in range(int(args.count)):
-        upload_response = upload_file()
-        print("Upload response received: %s %s" % (upload_response.status_code, upload_response.text))
+    file_list = get_list_of_files_in_directory(args.dir)
+
+    num_files = len(file_list)
+    i = 1
+
+    start_time = time.time()
+    for filepath in file_list:
+        upload_start_time = time.time()
+        upload_response = upload_file(filepath)
+        time_now = time.time()
+        print("[%d/%d] Upload response received: %s %s. \t Upload time taken: %.3f \t Total time elapsed: %.3f" % (i, num_files, upload_response.status_code, upload_response.text, (time_now - upload_start_time), (time_now - start_time)))
+        i += 1
 
 if __name__ == "__main__":
     main()

--- a/qa/load-testing/main.py
+++ b/qa/load-testing/main.py
@@ -1,0 +1,24 @@
+from argparse import ArgumentParser
+import os
+import requests
+
+DOCKER_HOST_IP=os.getenv('DOCKER_HOST_IP')
+assert DOCKER_HOST_IP != None, "Failed to get DOCKER_HOST_IP from environment variable"
+UPLOAD_URL = "http://%s:8080/upload/bsmlog" % DOCKER_HOST_IP
+UPLOAD_FILE = "../../data/bsmLogDuringEvent.gz"
+
+def upload_file():
+    with open(UPLOAD_FILE, 'rb') as file:
+        return requests.post(UPLOAD_URL, files={'name':'file', 'file':file}, timeout=2)
+
+def main():
+    parser = ArgumentParser()
+    parser.add_argument("-c", "--count", dest="count", help="Number of times to repeat upload.", metavar="COUNT", required=True)
+    args = parser.parse_args()
+
+    for i in range(int(args.count)):
+        upload_response = upload_file()
+        print("Upload response received: %s %s" % (upload_response.status_code, upload_response.text))
+
+if __name__ == "__main__":
+    main()

--- a/qa/load-testing/run-1000.sh
+++ b/qa/load-testing/run-1000.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+./create-testfiles.sh ../../data/bsmLogDuringEvent.gz testfiles 1000
+python main.py --dir testfiles
+rm -rf testfiles
+echo "==== LOAD TEST COMPLETE! ===="


### PR DESCRIPTION
Adds a little python script that will upload a file on a loop. Specify `-c` or `--count` for the number of times to upload a file.

Initial findings are that memory is not consumed heavily, but CPU becomes heavily bogged down.