### PR TITLE
Fix small Markdown rendering issue with README

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,13 +461,14 @@ travis env set SONAR_SECURITY_TOKEN <key> -pr <user-account>/<repo-name>
  -->
 
 ## Quality Assurance
-ODE provides an automated test harness that can be used for regression and user acceptance testing. 
-The test harness is pprovided in the [qa/test-harness](ga/test-harness) directory under jpo-ode root folder. 
+ODE provides an automated test harness that can be used for regression and user acceptance testing.
+The test harness is pprovided in the [qa/test-harness](ga/test-harness) directory under jpo-ode root folder.
 The test harness uses the ODE [Validator Library](https://github.com/usdot-jpo-ode/ode-output-validator-library) repository as a submodule.
 
 For more information, please see: https://github.com/usdot-jpo-ode/jpo-ode/wiki/Using-the-ODE-test-harness
 
 <a name="known-bugs"/>
+
 ## 9. Known Bugs
 
 Date: 07/2017


### PR DESCRIPTION
## Notes 

Missing newline means that on `master`, one of the section headings renders like this: 
<img width="188" alt="master" src="https://user-images.githubusercontent.com/3209501/58028961-47a90400-7ae1-11e9-84c5-3e7ebc6d7891.png">

On this branch, section heading renders like this:

<img width="215" alt="fix" src="https://user-images.githubusercontent.com/3209501/58029009-5b546a80-7ae1-11e9-89d5-3add5ee079d3.png">

