### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: java
 
+dist: trusty
+
 jdk: oraclejdk8
 
 sudo: false


### PR DESCRIPTION
Update to use trusty as the build environment instead of the default
https://github.com/usdot-jpo-ode/jpo-ode/blob/hotfix/issue-359/.travis.yml