### PR TITLE
Issue 369 

### DIFF
--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/rsu/RsuDepositor.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/rsu/RsuDepositor.java
@@ -135,7 +135,7 @@ public class RsuDepositor extends Thread {
 					}
 					logger.info("TIM deposit response {}", responseList);					
 				}
-				sleep(100);
+				Thread.sleep(100);
 			}
 		}
 		catch (InterruptedException e) {

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/rsu/RsuDepositor.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/rsu/RsuDepositor.java
@@ -1,0 +1,153 @@
+/*******************************************************************************
+ * Copyright 2020 572682
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
+
+package us.dot.its.jpo.ode.rsu;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.snmp4j.event.ResponseEvent;
+
+import us.dot.its.jpo.ode.OdeProperties;
+import us.dot.its.jpo.ode.eventlog.EventLogger;
+import us.dot.its.jpo.ode.plugin.ServiceRequest;
+import us.dot.its.jpo.ode.plugin.RoadSideUnit.RSU;
+import us.dot.its.jpo.ode.snmp.SnmpSession;
+import us.dot.its.jpo.ode.traveler.TimTransmogrifier;
+
+public class RsuDepositor extends Thread {
+	private Logger logger = LoggerFactory.getLogger(this.getClass());
+	private volatile boolean running = true;
+	private OdeProperties odeProperties; 
+	private ArrayList<RsuDepositorEntry> depositorEntries = new ArrayList<RsuDepositorEntry>();
+	
+
+
+	class RsuDepositorEntry{
+		public RsuDepositorEntry(ServiceRequest request, String encodedMsg) {
+			this.request = request;
+			this.encodedMsg = encodedMsg;
+		}
+		ServiceRequest request;
+		String encodedMsg;		
+	}
+	
+	public RsuDepositor(OdeProperties odeProperties) {
+		this.odeProperties = odeProperties;		
+	}
+
+	public OdeProperties getOdeProperties() {
+		return odeProperties;
+	}
+
+	public void setOdeProperties(OdeProperties odeProperties) {
+		this.odeProperties = odeProperties;
+	}
+	
+	public void shutdown() {
+		running = false;
+	}
+	
+	public boolean isRunning()
+	{
+		return running;
+	}
+	
+	public void run() {
+		try {
+			while (running)
+			{
+				RsuDepositorEntry[] entryList = new RsuDepositorEntry[0];
+				synchronized(depositorEntries)
+				{
+					entryList = new RsuDepositorEntry[depositorEntries.size()];
+					entryList = depositorEntries.toArray(entryList);
+					depositorEntries.clear();
+				}
+
+				for (RsuDepositorEntry entry : entryList) {
+					HashMap<String, String> responseList = new HashMap<>();
+					for (RSU curRsu : entry.request.getRsus()) {
+
+						TimTransmogrifier.updateRsuCreds(curRsu, odeProperties);
+
+						ResponseEvent rsuResponse = null;
+
+						String httpResponseStatus;
+						try {
+							rsuResponse = SnmpSession.createAndSend(entry.request.getSnmp(), curRsu, entry.encodedMsg, entry.request.getOde().getVerb());
+							if (null == rsuResponse || null == rsuResponse.getResponse()) {
+								// Timeout
+								httpResponseStatus = "Timeout";
+							} else if (rsuResponse.getResponse().getErrorStatus() == 0) {
+								// Success
+								httpResponseStatus = "Success";
+							} else if (rsuResponse.getResponse().getErrorStatus() == 5) {
+								// Error, message already exists
+								httpResponseStatus = "Message already exists at ".concat(Integer.toString(curRsu.getRsuIndex()));
+							} else {
+								// Misc error
+								httpResponseStatus = "Error code " + rsuResponse.getResponse().getErrorStatus() + " "
+										+ rsuResponse.getResponse().getErrorStatusText();
+							}
+						} catch (IOException | ParseException e) {
+							String msg = "Exception caught in TIM RSU deposit loop.";
+							EventLogger.logger.error(msg, e);
+							logger.error(msg, e);
+							httpResponseStatus = e.getClass().getName() + ": " + e.getMessage();
+						}
+						responseList.put(curRsu.getRsuTarget(), httpResponseStatus);
+
+						if (null == rsuResponse || null == rsuResponse.getResponse()) {
+							// Timeout
+							logger.error("Error on RSU SNMP deposit to {}: timed out.", curRsu.getRsuTarget());
+						} else if (rsuResponse.getResponse().getErrorStatus() == 0) {
+							// Success
+							logger.info("RSU SNMP deposit to {} successful.", curRsu.getRsuTarget());
+						} else if (rsuResponse.getResponse().getErrorStatus() == 5) {
+							// Error, message already exists
+							Integer destIndex = curRsu.getRsuIndex();
+							logger.error("Error on RSU SNMP deposit to {}: message already exists at index {}.", curRsu.getRsuTarget(),
+									destIndex);
+						} else {
+							// Misc error
+							logger.error("Error on RSU SNMP deposit to {}: {}", curRsu.getRsuTarget(), "Error code "
+									+ rsuResponse.getResponse().getErrorStatus() + " " + rsuResponse.getResponse().getErrorStatusText());
+						}
+
+					}
+					logger.info("TIM deposit response {}", responseList);					
+				}
+				sleep(100);
+			}
+		}
+		catch (InterruptedException e) {
+			logger.error("RsuDepositor thread interrupted", e);
+		}
+	}
+	
+	public void deposit(ServiceRequest request, String encodedMsg) {
+		synchronized(depositorEntries)
+		{
+			depositorEntries.add(new RsuDepositorEntry(request, encodedMsg));			
+		}
+	}
+
+}

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/services/asn1/Asn1CommandManager.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/services/asn1/Asn1CommandManager.java
@@ -48,6 +48,7 @@ import us.dot.its.jpo.ode.plugin.ServiceRequest;
 import us.dot.its.jpo.ode.plugin.SituationDataWarehouse.SDW;
 import us.dot.its.jpo.ode.plugin.j2735.DdsAdvisorySituationData;
 import us.dot.its.jpo.ode.plugin.j2735.builders.GeoRegionBuilder;
+import us.dot.its.jpo.ode.rsu.RsuDepositor;
 import us.dot.its.jpo.ode.snmp.SnmpSession;
 import us.dot.its.jpo.ode.traveler.TimTransmogrifier;
 import us.dot.its.jpo.ode.util.JsonUtils;
@@ -82,6 +83,8 @@ public class Asn1CommandManager {
 
    private String depositTopic;
    private DdsDepositor<DdsStatusMessage> depositor;
+   private RsuDepositor rsuDepositor;
+      
 
    public Asn1CommandManager(OdeProperties odeProperties) {
 
@@ -91,6 +94,8 @@ public class Asn1CommandManager {
 
       try {
          this.depositor = new DdsDepositor<>(odeProperties);
+         this.rsuDepositor = new RsuDepositor(odeProperties);
+         this.rsuDepositor.start();
          this.stringMessageProducer = MessageProducer.defaultStringMessageProducer(odeProperties.getKafkaBrokers(),
                odeProperties.getKafkaProducerType(), odeProperties.getKafkaTopicsDisabledSet());
          this.setDepositTopic(odeProperties.getKafkaTopicSdwDepositorInput());
@@ -124,59 +129,10 @@ public class Asn1CommandManager {
       }
    }
 
-   public Map<String, String> sendToRsus(ServiceRequest request, String encodedMsg) {
+   public void sendToRsus(ServiceRequest request, String encodedMsg) {
 
-      HashMap<String, String> responseList = new HashMap<>();
-      for (RSU curRsu : request.getRsus()) {
-
-         TimTransmogrifier.updateRsuCreds(curRsu, odeProperties);
-
-         ResponseEvent rsuResponse = null;
-
-         String httpResponseStatus;
-         try {
-            rsuResponse = SnmpSession.createAndSend(request.getSnmp(), curRsu, encodedMsg, request.getOde().getVerb());
-            if (null == rsuResponse || null == rsuResponse.getResponse()) {
-               // Timeout
-               httpResponseStatus = "Timeout";
-            } else if (rsuResponse.getResponse().getErrorStatus() == 0) {
-               // Success
-               httpResponseStatus = "Success";
-            } else if (rsuResponse.getResponse().getErrorStatus() == 5) {
-               // Error, message already exists
-               httpResponseStatus = "Message already exists at ".concat(Integer.toString(curRsu.getRsuIndex()));
-            } else {
-               // Misc error
-               httpResponseStatus = "Error code " + rsuResponse.getResponse().getErrorStatus() + " "
-                     + rsuResponse.getResponse().getErrorStatusText();
-            }
-         } catch (IOException | ParseException e) {
-            String msg = "Exception caught in TIM RSU deposit loop.";
-            EventLogger.logger.error(msg, e);
-            logger.error(msg, e);
-            httpResponseStatus = e.getClass().getName() + ": " + e.getMessage();
-         }
-         responseList.put(curRsu.getRsuTarget(), httpResponseStatus);
-
-         if (null == rsuResponse || null == rsuResponse.getResponse()) {
-            // Timeout
-            logger.error("Error on RSU SNMP deposit to {}: timed out.", curRsu.getRsuTarget());
-         } else if (rsuResponse.getResponse().getErrorStatus() == 0) {
-            // Success
-            logger.info("RSU SNMP deposit to {} successful.", curRsu.getRsuTarget());
-         } else if (rsuResponse.getResponse().getErrorStatus() == 5) {
-            // Error, message already exists
-            Integer destIndex = curRsu.getRsuIndex();
-            logger.error("Error on RSU SNMP deposit to {}: message already exists at index {}.", curRsu.getRsuTarget(),
-                  destIndex);
-         } else {
-            // Misc error
-            logger.error("Error on RSU SNMP deposit to {}: {}", curRsu.getRsuTarget(), "Error code "
-                  + rsuResponse.getResponse().getErrorStatus() + " " + rsuResponse.getResponse().getErrorStatusText());
-         }
-
-      }
-      return responseList;
+      rsuDepositor.deposit(request, encodedMsg);
+      return;
    }
 
    public String sendForSignature(String message) {

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/services/asn1/Asn1EncodedDataRouter.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/services/asn1/Asn1EncodedDataRouter.java
@@ -193,8 +193,7 @@ public class Asn1EncodedDataRouter extends AbstractSubscriberProcessor<String, S
 
          if (null != request.getSnmp() && null != request.getRsus() && null != hexEncodedTim) {
             logger.info("Sending message to RSUs...");
-            Map<String, String> rsuResponseList = asn1CommandManager.sendToRsus(request, hexEncodedTim);
-            logger.info("TIM deposit response {}", rsuResponseList);
+            asn1CommandManager.sendToRsus(request, hexEncodedTim);           
          }
 
          if (request.getSdw() != null) {
@@ -277,9 +276,7 @@ public class Asn1EncodedDataRouter extends AbstractSubscriberProcessor<String, S
         // only send message to rsu if snmp, rsus, and message frame fields are present
         if (null != request.getSnmp() && null != request.getRsus() && null != encodedTim) {
            logger.debug("Encoded message phase 3: {}", encodedTim);
-           Map<String, String> rsuResponseList =
-                 asn1CommandManager.sendToRsus(request, encodedTim);
-           responseList.putAll(rsuResponseList);
+           asn1CommandManager.sendToRsus(request, encodedTim);           
          }
       }
 

--- a/jpo-ode-svcs/src/test/java/us/dot/its/jpo/ode/rsu/RsuDepositorTest.java
+++ b/jpo-ode-svcs/src/test/java/us/dot/its/jpo/ode/rsu/RsuDepositorTest.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright 2020 572682
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
+
+package us.dot.its.jpo.ode.rsu;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.text.ParseException;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import mockit.Capturing;
+import mockit.Expectations;
+import mockit.Injectable;
+import mockit.Mocked;
+import mockit.Tested;
+import mockit.integration.junit4.JMockit;
+import us.dot.its.jpo.ode.OdeProperties;
+import us.dot.its.jpo.ode.dds.Logger;
+import us.dot.its.jpo.ode.dds.DdsRequestManager.DdsRequestManagerException;
+import us.dot.its.jpo.ode.model.OdeTravelerInputData;
+import us.dot.its.jpo.ode.plugin.RoadSideUnit.RSU;
+import us.dot.its.jpo.ode.plugin.ServiceRequest.OdeInternal.RequestVerb;
+import us.dot.its.jpo.ode.snmp.SnmpSession;
+import us.dot.its.jpo.ode.wrapper.MessageProducer;
+
+@RunWith(JMockit.class)
+public class RsuDepositorTest  {
+
+	@Tested
+	RsuDepositor testRsuDepositor;
+
+	@Injectable
+	OdeProperties injectableOdeProperties;
+	@Capturing
+	MessageProducer<String, String> capturingMessageProducer;
+	@Capturing
+	SnmpSession capturingSnmpSession;
+
+	@Injectable
+	OdeTravelerInputData injectableOdeTravelerInputData;
+
+	@Mocked
+	MessageProducer<String, String> mockMessageProducer;
+	@Test
+	public void shouldConstruct(@Mocked OdeProperties mockOdeProperties) {
+		testRsuDepositor = new RsuDepositor(mockOdeProperties);
+		testRsuDepositor.start();
+		assertEquals(mockOdeProperties, testRsuDepositor.getOdeProperties());
+
+	}
+
+	@Test
+	public void testShutdown() {
+		testRsuDepositor.shutdown();
+		assertEquals(false, testRsuDepositor.isRunning());
+		assertEquals(false, testRsuDepositor.isAlive());
+
+	}
+
+
+	@Test
+	public void testDeposit(@Mocked OdeTravelerInputData mockOdeTravelerInputData)
+			throws DdsRequestManagerException, IOException, ParseException {
+
+		testRsuDepositor.deposit(mockOdeTravelerInputData.getRequest(), "message");
+		//TODO: how do we verify and run is mocked
+
+	}
+
+
+
+
+}

--- a/jpo-ode-svcs/src/test/java/us/dot/its/jpo/ode/rsu/RsuDepositorTest.java
+++ b/jpo-ode-svcs/src/test/java/us/dot/its/jpo/ode/rsu/RsuDepositorTest.java
@@ -25,17 +25,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import mockit.Capturing;
-import mockit.Expectations;
 import mockit.Injectable;
 import mockit.Mocked;
 import mockit.Tested;
 import mockit.integration.junit4.JMockit;
 import us.dot.its.jpo.ode.OdeProperties;
-import us.dot.its.jpo.ode.dds.Logger;
 import us.dot.its.jpo.ode.dds.DdsRequestManager.DdsRequestManagerException;
 import us.dot.its.jpo.ode.model.OdeTravelerInputData;
-import us.dot.its.jpo.ode.plugin.RoadSideUnit.RSU;
-import us.dot.its.jpo.ode.plugin.ServiceRequest.OdeInternal.RequestVerb;
 import us.dot.its.jpo.ode.snmp.SnmpSession;
 import us.dot.its.jpo.ode.wrapper.MessageProducer;
 
@@ -77,10 +73,9 @@ public class RsuDepositorTest  {
 	@Test
 	public void testDeposit(@Mocked OdeTravelerInputData mockOdeTravelerInputData)
 			throws DdsRequestManagerException, IOException, ParseException {
-
-		testRsuDepositor.deposit(mockOdeTravelerInputData.getRequest(), "message");
-		//TODO: how do we verify and run is mocked
-
+			      
+	      testRsuDepositor.deposit(mockOdeTravelerInputData.getRequest(), "message");
+	
 	}
 
 

--- a/jpo-ode-svcs/src/test/java/us/dot/its/jpo/ode/services/asn1/Asn1CommandManagerTest.java
+++ b/jpo-ode-svcs/src/test/java/us/dot/its/jpo/ode/services/asn1/Asn1CommandManagerTest.java
@@ -66,30 +66,14 @@ public class Asn1CommandManagerTest {
    @Test
    public void testSendToRsus(@Mocked OdeTravelerInputData mockOdeTravelerInputData)
          throws DdsRequestManagerException, IOException, ParseException {
-      new Expectations() {
-         {
-            mockOdeTravelerInputData.getRequest().getRsus();
-            result = new RSU[] { new RSU() };
-
-            SnmpSession.createAndSend(null, null, anyString, (RequestVerb) any);
-            times = 1;
-         }
-      };
+      
       testAsn1CommandManager.sendToRsus(mockOdeTravelerInputData.getRequest(), "message");
    }
 
    @Test
    public void testSendToRsusSnmpException(@Mocked OdeTravelerInputData mockOdeTravelerInputData)
          throws DdsRequestManagerException, IOException, ParseException {
-      new Expectations() {
-         {
-            mockOdeTravelerInputData.getRequest().getRsus();
-            result = new RSU[] { new RSU() };
-
-            SnmpSession.createAndSend(null, null, anyString, (RequestVerb) any);
-            result = new IOException();
-         }
-      };
+     
       testAsn1CommandManager.sendToRsus(mockOdeTravelerInputData.getRequest(), "message");
    }
 


### PR DESCRIPTION
Description
This fix the issue with single threading of all TIM messages being forwarded to RSUs and SDW which is causing the SDW depositor to timeout.  Separated RSU deposits to a separate thread so that they don't delay TIM messages to be sent to SDW.

Related Issue
#569

How Has This Been Tested?
Unit tested and Integration testing was done by TriHydro .

