### PR TITLE
Fix Docker for Mac link in docker.md

### DIFF
--- a/docker.md
+++ b/docker.md
@@ -6,10 +6,7 @@ The following sections summarize installation and setup of Docker on your machin
 - Install [Docker for Windows](https://store.docker.com/editions/community/docker-ce-desktop-windows)
 ## Mac OSX
 - Enable virtualization in your BIOS
-- Install [Docker for Mac](## Windows
-- Enable visualization in your BIOS
-- Install [Docker for Windows](https://store.docker.com/editions/community/docker-ce-desktop-windows)
-)
+- Install [Docker for Mac](https://hub.docker.com/editions/community/docker-ce-desktop-mac/)
 ## Linux
 - Install [Docker Engine](https://store.docker.com/search?type=edition&offering=community&operating_system=linux) on Docker host machine
 - Install [docker-compose](https://docs.docker.com/compose/install/) on docker host and/or local machine


### PR DESCRIPTION
# PR Details

## Description

This is a simple change. I noticed that the Markdown was a little goofed up in the docker.md file and decided to fix it. Basically the link to the Windows Docker download was included twice and in a way that broke the markdown a bit.

## Related Issue

https://github.com/usdot-jpo-ode/jpo-ode/issues/405

## Motivation and Context

It resolves some potential confusion in a readme.

## How Has This Been Tested?

The link works.

## Types of changes

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) - __This link seems to be non-existent now__
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
