### PR TITLE
Resolve variable name change from previous merge conflict change

### DIFF
--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/services/asn1/message/Asn1DecodeMessageJSON.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/services/asn1/message/Asn1DecodeMessageJSON.java
@@ -64,7 +64,7 @@ public class Asn1DecodeMessageJSON extends AbstractSubscriberProcessor<String, S
 				if (key != null && key.toString().equals(BSMContentType)) {
 					/**process consumed data { "BsmMessageContent": [{ "metadata": { "utctimestamp:"2020-11-30T23:45:24.913657Z" }, "payload":"001480CF4B950C400022D2666E923D1EA6D4E28957BD55FFFFF001C758FD7E67D07F7FFF8000000002020218E1C1004A40196FBC042210115C030EF1408801021D4074CE7E1848101C5C0806E8E1A50101A84056EE8A1AB4102B840A9ADA21B9010259C08DEE1C1C560FFDDBFC070C0222210018BFCE309623120FFE9BFBB10C8238A0FFDC3F987114241610009BFB7113024780FFAC3F95F13A26800FED93FDD51202C5E0FE17BF9B31202FBAFFFEC87FC011650090019C70808440C83207873800000000001095084081C903447E31C12FC0"}]}
 					 */
-          OdeBsmMetadata metadata = null;
+					OdeBsmMetadata metadata = null;
           
 					JSONArray rawBSMJsonContentArray = rawJSONObject.getJSONArray(BSMContentType);
 					for (int i = 0; i < rawBSMJsonContentArray.length(); i++) {
@@ -149,7 +149,7 @@ public class Asn1DecodeMessageJSON extends AbstractSubscriberProcessor<String, S
 					/**process consumed data
 					 *  {"TimMessageContent":[{"metadata":{"utctimestamp":"2020-11-30T23:45:24.913657Z", "originRsu":"172.250.250.77"},"payload":"001f5520100000000000564fb69082709b898aac59717eadfffe4fca1bf0a9d828407e137131558b2e2fd581f46ffff00118b2e3b3ee6e2702c18b2e34f4e6e269ec18b2e285426e2580598b2e23b6e6e254c80420005c48"}]}
 					 */
-          OdeLogMetadata metadata = null;
+					OdeLogMetadata metadata = null;
 					
 					JSONArray rawTIMJsonContentArray = rawJSONObject.getJSONArray(TIMContentType);
 					for(int i=0;i<rawTIMJsonContentArray.length();i++)
@@ -173,7 +173,7 @@ public class Asn1DecodeMessageJSON extends AbstractSubscriberProcessor<String, S
 						metadata.addEncoding(unsecuredDataEncoding);
 						
 						//construct odeData
-						odeTimData = new OdeAsn1Data(metadata, payload);
+						odeData = new OdeAsn1Data(metadata, payload);
 						
 						publishEncodedMessageToAsn1Decoder(odeTimData);
 					}


### PR DESCRIPTION
There is a build error caused by a variable name in the 'Asn1DecodeMessageJSON.java' class. It was previously changed to share variables across the class but there was a differently named variable for odeData that was not renamed.

Fix by changing line 176 in 'Asn1DecodeMessageJSON.java' from 'odeTimData' to 'odeData'.

## Related Issue

#416 

## How Has This Been Tested?

This has been tested by building it locally and confirming the build succeeds.

## Types of changes

A variable name change.

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
