### PR TITLE
TIM Metadata Class For Asn1DecodeMessageJSON

### DIFF
--- a/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeLogMetadata.java
+++ b/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeLogMetadata.java
@@ -23,7 +23,7 @@ public class OdeLogMetadata extends OdeMsgMetadata {
    private static final long serialVersionUID = -8601265839394150140L;
 
    public enum RecordType {
-      bsmLogDuringEvent, rxMsg, dnMsg, bsmTx, driverAlert, spatTx, unsupported
+      bsmLogDuringEvent, rxMsg, dnMsg, bsmTx, driverAlert, spatTx, timMsg, unsupported
    }
 
    public enum SecurityResultCode {

--- a/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeTimMetadata.java
+++ b/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeTimMetadata.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright 2018 572682
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
+package us.dot.its.jpo.ode.model;
+
+public class OdeTimMetadata extends OdeLogMetadata {
+
+    private static final long serialVersionUID = 2057040404896561615L;
+
+    private String originIp;
+    
+    public OdeTimMetadata() {
+        super();
+    }
+
+    public OdeTimMetadata(OdeMsgPayload payload) {
+        super(payload);
+    }
+
+    public String getOriginIp() {
+        return originIp;
+     }
+ 
+     public void setOriginIp(String originIp) {
+        this.originIp = originIp;
+     }
+}

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/services/asn1/message/Asn1DecodeMessageJSON.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/services/asn1/message/Asn1DecodeMessageJSON.java
@@ -175,7 +175,7 @@ public class Asn1DecodeMessageJSON extends AbstractSubscriberProcessor<String, S
 						//construct odeData
 						odeData = new OdeAsn1Data(metadata, payload);
 						
-						publishEncodedMessageToAsn1Decoder(odeTimData);
+						publishEncodedMessageToAsn1Decoder(odeData);
 					}
 				} 
 				else {

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/services/asn1/message/Asn1DecodeMessageJSON.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/services/asn1/message/Asn1DecodeMessageJSON.java
@@ -22,7 +22,10 @@ import us.dot.its.jpo.ode.model.OdeLogMetadata.RecordType;
 import us.dot.its.jpo.ode.model.OdeLogMetadata.SecurityResultCode;
 import us.dot.its.jpo.ode.model.OdeLogMsgMetadataLocation;
 import us.dot.its.jpo.ode.model.OdeMsgPayload;
+import us.dot.its.jpo.ode.model.OdeMsgMetadata;
+import us.dot.its.jpo.ode.model.OdeMsgMetadata.GeneratedBy;
 import us.dot.its.jpo.ode.model.OdeLogMetadata;
+import us.dot.its.jpo.ode.model.OdeTimMetadata;
 import us.dot.its.jpo.ode.model.OdeSpatMetadata;
 import us.dot.its.jpo.ode.model.OdeSpatMetadata.SpatSource;
 import us.dot.its.jpo.ode.model.ReceivedMessageDetails;
@@ -149,7 +152,7 @@ public class Asn1DecodeMessageJSON extends AbstractSubscriberProcessor<String, S
 					/**process consumed data
 					 *  {"TimMessageContent":[{"metadata":{"utctimestamp":"2020-11-30T23:45:24.913657Z", "originRsu":"172.250.250.77"},"payload":"001f5520100000000000564fb69082709b898aac59717eadfffe4fca1bf0a9d828407e137131558b2e2fd581f46ffff00118b2e3b3ee6e2702c18b2e34f4e6e269ec18b2e285426e2580598b2e23b6e6e254c80420005c48"}]}
 					 */
-					OdeLogMetadata metadata = null;
+					OdeTimMetadata metadata = null;
 					
 					JSONArray rawTIMJsonContentArray = rawJSONObject.getJSONArray(TIMContentType);
 					for(int i=0;i<rawTIMJsonContentArray.length();i++)
@@ -164,10 +167,11 @@ public class Asn1DecodeMessageJSON extends AbstractSubscriberProcessor<String, S
 						payload = new OdeAsn1Payload(new OdeHexByteArray(encodedPayload));
 
 						//construct metadata
-						metadata = new OdeBsmMetadata(payload);
+						metadata = new OdeTimMetadata(payload);
 						metadata.setOdeReceivedAt(rawmetadata.getString("utctimestamp"));
-						metadata.setRecordGeneratedAt(rawmetadata.getString("originRsu"));
-						metadata.setRecordType(RecordType.unsupported);
+						metadata.setOriginIp(rawmetadata.getString("originRsu"));
+						metadata.setRecordType(RecordType.timMsg);
+						metadata.setRecordGeneratedBy(GeneratedBy.RSU);
 						
 						Asn1Encoding unsecuredDataEncoding = new Asn1Encoding("unsecuredData", "MessageFrame",EncodingRule.UPER);
 						metadata.addEncoding(unsecuredDataEncoding);


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This request adds a TIM metadata class for the decoding of TIM messages through the Asn1DecodeMessageJSON class. Previously, there was not a a TIM metadata class so BSM metadata was put on the TIM. This way the TIM messages will only have data pertaining to them.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#424 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
#424 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested with building it on a local dev machine. A machine was configured to send TIM messages to the local ODE to receive over UDP and decoded through the Asn1DecodeMessageJSON class. The Kafka topic topic.OdeTimJson was then listened to to verify the proper TIM output contained only the relevant TIM fields.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
