### PR TITLE
Spat header document update

### DIFF
--- a/data/wydotLogRecords.h
+++ b/data/wydotLogRecords.h
@@ -90,7 +90,6 @@ typedef struct _receivedMsgRecord {
     uint32_t  utcTimeInSec;
     uint16_t  msec;
     int8_t    verificationStatus;
-    int8_t    is_cert_present; /*ieee 1609 (acceptable values 0 = no,1 =yes)*/
     uint16_t  length;
     /* payload of length size*/
 } __attribute__((__packed__)) receivedMsgRecord;
@@ -110,6 +109,7 @@ typedef struct _SPaTMsgRecord {
     uint32_t  utcTimeInSec;
     uint16_t  msec;
     int8_t    verificationStatus;
+    int8_t    is_cert_present; /*ieee 1609 (acceptable values 0 = no,1 =yes)*/
     uint16_t  length;
     /* payload of length size*/
 } __attribute__((__packed__)) SPaTMsgRecord;


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
We have used the int8_t    is_cert_present; /*ieee 1609 (acceptable values 0 = no,1 =yes)*/ to indicate whether the spat binary file should include the IEEE1609 encoding.
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-jpo-ode/jpo-ode/issues/415
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
N/A
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
N/A
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
