### PR TITLE
Dev Container C++ Debugging Support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -67,3 +67,11 @@ RUN chmod 775 /etc/init.d/kafka && update-rc.d kafka defaults
 COPY ./docker-entrypoint.sh ./docker-entrypoint.sh
 RUN chmod +x ./docker-entrypoint.sh
 ENTRYPOINT ["./docker-entrypoint.sh"]
+
+# C++
+RUN apt-get update
+RUN apt-get install -y g++ cmake libsasl2-dev libsasl2-modules libssl-dev librdkafka-dev
+RUN apt install -y autoconf libtool
+
+ENV REDACTION_PROPERTIES_PATH /workspaces/jpo-ode/jpo-cvdp/config/fieldsToRedact.txt
+ENV RPM_DEBUG true

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.154.0/containers/java-8
 {
-	"name": "Java 11",
+	"name": "Java 11 and C++",
 	"dockerFile": "Dockerfile",
 	"overrideCommand": false,
 	"shutdownAction": "stopContainer",
@@ -21,7 +21,9 @@
 		"mhutchie.git-graph",
 		"tabnine.tabnine-vscode",
 		"redhat.java",
-		"redhat.vscode-commons"
+		"redhat.vscode-commons",
+		"ms-vscode.cpptools",
+		"ms-vscode.cmake-tools"
 	],
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [8080, 9090, 46753, 46800, 5555, 6666, 8090, 2181, 9092],

--- a/README.md
+++ b/README.md
@@ -393,6 +393,9 @@ Install the IDE of your choice:
 
 * TravisCI: <https://travis-ci.org/usdot-jpo-ode/jpo-ode>
 
+### Dev Container Environment
+The project can be reopened inside of a dev container in VSCode. This environment should have all of the necessary dependencies to debug the ODE and its submodules. When attempting to run scripts in this environment, it may be necessary to make them executable with "chmod +x" first.
+
 [Back to top](#toc)
 
 <!--


### PR DESCRIPTION
# PR Details
## Description
These changes allow developers to debug the C++ submodules from inside the dev container for the ODE.

## Related Issue
A relevant issue doesn't exist for these changes.

## Motivation and Context
The dev container is intended to give the developer an environment that is capable of running the project. The dev container does not at this time support debugging C++, which the PPM and ACM are programmed in.

## How Has This Been Tested?
The unit tests for the PPM have been run while inside the dev container for the ODE.

## Types of changes
- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)
- [x] Dev container modification (change to devcontainer.json or the dockerfile for the dev container)

## Checklist:
- [ ] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
