### PR TITLE
Spat JSON fixes

### DIFF
--- a/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/J2735IntersectionState.java
+++ b/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/J2735IntersectionState.java
@@ -11,7 +11,7 @@ public class J2735IntersectionState extends Asn1Object {
 	private String name;
 	private J2735IntersectionReferenceID id;
 	private Integer revision;
-	private J2735IntersectionStatusObject status;
+	private J2735BitString status;
 	private Integer moy;
 	private Integer timeStamp;
 	private J2735EnableLaneList enabledLanes;
@@ -42,11 +42,11 @@ public class J2735IntersectionState extends Asn1Object {
 		this.revision = revision;
 	}
 
-	public J2735IntersectionStatusObject getStatus() {
+	public J2735BitString getStatus() {
 		return status;
 	}
 
-	public void setStatus(J2735IntersectionStatusObject status) {
+	public void setStatus(J2735BitString status) {
 		this.status = status;
 	}
 

--- a/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/J2735IntersectionStatusObject.java
+++ b/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/J2735IntersectionStatusObject.java
@@ -2,18 +2,18 @@ package us.dot.its.jpo.ode.plugin.j2735;
 
 
 public enum J2735IntersectionStatusObject {
-	MANUALCONTROLISENABLED,
-	STOPTIMEISACTIVATED,
-	FAILUREFLASH,
-	PREEMPTISACTIVE,
-	SIGNALPRIORITYISACTIVE,
-	FIXEDTIMEOPERATION,
-	TRAFFICDEPENDENTOPERATION,
-	STANDBYOPERATION,
-	FAILUREMODE,
-	OFF,
-	RECENTMAPMESSAGEUPDATE,
-	RECENTCHANGEINMAPASSIGNEDLANESIDSUSED,
-	NOVALIDMAPISAVAILABLEATTHISTIME,
-	NOVALIDSPATISAVAILABLEATTHISTIME
+	manualControlIsEnabled,
+	stopTimeIsActivated,
+	failureFlash,
+	preemptIsActive,
+	signalPriorityIsActive,
+	fixedTimeOperation,
+	trafficDependentOperation,
+	standbyOperation,
+	failureMode,
+	off,
+	recentMAPmessageUpdate,
+	recentChangeInMAPassignedLanesIDsUsed,
+	noValidMAPisAvailableAtThisTime,
+	noValidSPATisAvailableAtThisTime
 }

--- a/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/builders/IntersectionStateBuilder.java
+++ b/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/builders/IntersectionStateBuilder.java
@@ -4,6 +4,8 @@ import java.util.Iterator;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import us.dot.its.jpo.ode.plugin.j2735.J2735BitString;
+import us.dot.its.jpo.ode.plugin.j2735.J2735EnableLaneList;
 import us.dot.its.jpo.ode.plugin.j2735.J2735IntersectionReferenceID;
 import us.dot.its.jpo.ode.plugin.j2735.J2735IntersectionState;
 import us.dot.its.jpo.ode.plugin.j2735.J2735IntersectionStatusObject;
@@ -34,14 +36,12 @@ public class IntersectionStateBuilder {
 
 		if(intersectionState.get("IntersectionState").get("status") != null)
 		{
-
-			Integer status = intersectionState.get("IntersectionState").get("status").asInt();
-			for (J2735IntersectionStatusObject statusobj : J2735IntersectionStatusObject.values()) {
-				if (statusobj.ordinal() == status) {
-					genericIntersectionState.setStatus(J2735IntersectionStatusObject.values()[status]);
-					break;
-				}
+			JsonNode status = intersectionState.get("IntersectionState").get("status");
+			if (status != null) {
+				J2735BitString statusObj = BitStringBuilder.genericBitString(status, J2735IntersectionStatusObject.values());
+				genericIntersectionState.setStatus(statusObj);
 			}
+			
 		}
 
 		if (intersectionState.get("IntersectionState").get("moy") != null)
@@ -52,11 +52,12 @@ public class IntersectionStateBuilder {
 
 		if (intersectionState.get("IntersectionState").get("enabledLanes") != null
 				&& intersectionState.get("IntersectionState").get("enabledLanes").get("LaneID") != null) {
+			genericIntersectionState.setEnabledLanes(new J2735EnableLaneList());
 			if (intersectionState.get("IntersectionState").get("enabledLanes").get("LaneID").isArray()) {
 				Iterator<JsonNode> elements = intersectionState.get("IntersectionState").get("enabledLanes").get("LaneID").elements();
 				while (elements.hasNext()) {
 					genericIntersectionState.getEnabledLanes().getEnabledLaneList()
-							.add(elements.next().get("LaneID").asInt());
+							.add(elements.next().asInt());
 				}
 			} else {
 				genericIntersectionState.getEnabledLanes().getEnabledLaneList()
@@ -83,14 +84,14 @@ public class IntersectionStateBuilder {
 				&& intersectionState.get("IntersectionState").get("maneuverAssistList").get("ConnectionManeuverAssist") != null) { // maneuverAssistList
 			J2735ManeuverAssistList maneuverAssistList = new J2735ManeuverAssistList();
 			if (intersectionState.get("IntersectionState").get("maneuverAssistList").get("ConnectionManeuverAssist").isArray()) {
-				Iterator<JsonNode> elements = intersectionState.get("maneuverAssistList").get("ConnectionManeuverAssist").elements();
+				Iterator<JsonNode> elements = intersectionState.get("IntersectionState").get("maneuverAssistList").get("ConnectionManeuverAssist").elements();
 				while (elements.hasNext()) {
 					maneuverAssistList.getManeuverAssistList()
 							.add(ManeuverAssistBuilder.genericManeuverAssist(elements.next()));
 				}
 			} else {
 				maneuverAssistList.getManeuverAssistList().add(ManeuverAssistBuilder.genericManeuverAssist(
-						intersectionState.get("IntersectionState").get("maneuverAssistList").get("ConnectionManueverAssist")));
+						intersectionState.get("IntersectionState").get("maneuverAssistList").get("ConnectionManeuverAssist")));
 			}
 			genericIntersectionState.setManeuverAssistList(maneuverAssistList);
 		}

--- a/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/builders/ManeuverAssistBuilder.java
+++ b/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/builders/ManeuverAssistBuilder.java
@@ -17,14 +17,20 @@ public class ManeuverAssistBuilder {
 		if (maneuverAssistJson.get("queueLength") != null)
 			maneuverAssist.setQueueLength(maneuverAssistJson.get("queueLength").asInt());
 
-		if (maneuverAssistJson.get("waitOnStop") != null)
-			maneuverAssist.setWaitOnStop(maneuverAssistJson.get("waitOnStop").asBoolean());
+		JsonNode waitOnStop = maneuverAssistJson.get("waitOnStop");
+		if (waitOnStop != null) {
+			boolean isTrue = (waitOnStop.get("true") != null);
+			maneuverAssist.setWaitOnStop(isTrue);
+		}
 
 		if (maneuverAssistJson.get("availableStorageLength") != null)
 			maneuverAssist.setAvailableStorageLength(maneuverAssistJson.get("availableStorageLength").asInt());
 
-		if (maneuverAssistJson.get("pedBicycleDetect") != null)
-			maneuverAssist.setPedBicycleDetect(maneuverAssistJson.get("pedBicycleDetect").asBoolean());
+		JsonNode pedBicycleDetect = maneuverAssistJson.get("pedBicycleDetect");
+		if (pedBicycleDetect != null) {
+			boolean isTrue = (pedBicycleDetect.get("true") != null);
+			maneuverAssist.setPedBicycleDetect(isTrue);
+		}
 
 		return maneuverAssist;
 	}

--- a/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/builders/MovementStateBuilder.java
+++ b/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/builders/MovementStateBuilder.java
@@ -38,18 +38,18 @@ public class MovementStateBuilder {
 		}
 		
 		if(movementStatesJson.get("maneuverAssistList") != null
-				&& movementStatesJson.get("maneuverAssistList").get("ConnectionManueverAssist") != null)
+				&& movementStatesJson.get("maneuverAssistList").get("ConnectionManeuverAssist") != null)
 		{
 			J2735ManeuverAssistList maneuverAssistList = new J2735ManeuverAssistList();
-			if (movementStatesJson.get("maneuverAssistList").get("ConnectionManueverAssist").isArray()) {
-				Iterator<JsonNode> elements = movementStatesJson.get("maneuverAssistList").get("ConnectionManueverAssist").elements();
+			if (movementStatesJson.get("maneuverAssistList").get("ConnectionManeuverAssist").isArray()) {
+				Iterator<JsonNode> elements = movementStatesJson.get("maneuverAssistList").get("ConnectionManeuverAssist").elements();
 				while (elements.hasNext()) {
 					maneuverAssistList.getManeuverAssistList()
 							.add(ManeuverAssistBuilder.genericManeuverAssist(elements.next()));
 				}
 			} else {
 				maneuverAssistList.getManeuverAssistList().add(ManeuverAssistBuilder.genericManeuverAssist(
-						movementStatesJson.get("maneuverAssistList").get("ConnectionManueverAssist")));
+						movementStatesJson.get("maneuverAssistList").get("ConnectionManeuverAssist")));
 			}
 			state.setManeuverAssistList(maneuverAssistList);
 		}

--- a/jpo-ode-plugins/src/test/java/us/dot/its/jpo/ode/plugin/j2735/builders/IntersectionStateBuilderTest.java
+++ b/jpo-ode-plugins/src/test/java/us/dot/its/jpo/ode/plugin/j2735/builders/IntersectionStateBuilderTest.java
@@ -1,0 +1,108 @@
+package us.dot.its.jpo.ode.plugin.j2735.builders;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import us.dot.its.jpo.ode.plugin.j2735.J2735IntersectionState;
+import us.dot.its.jpo.ode.util.XmlUtils;
+import us.dot.its.jpo.ode.util.XmlUtils.XmlUtilsException;
+
+public class IntersectionStateBuilderTest {
+
+    // Common code for the tests
+    private void shouldTranslateIntersectionState(final String xml, final String expectedJson) {
+        JsonNode node = null;
+        try {
+            node = XmlUtils.toObjectNode(xml);
+        } catch (XmlUtilsException e) {
+            fail("XML parsing error:" + e.getMessage());
+        }
+
+        J2735IntersectionState actualIntersectionState = IntersectionStateBuilder.genericIntersectionState(node);
+        
+        assertEquals(expectedJson, actualIntersectionState.toJson(false));
+    }
+
+    
+     
+    @Test
+    public void shouldTranslateIntersectionState_J2735MandatoryElements() {
+        final String xml = "<IntersectionState><id><id>12111</id></id><revision>0</revision><status>0000000000000000</status><states><MovementState><signalGroup>2</signalGroup><state-time-speed><MovementEvent><eventState><protected-Movement-Allowed/></eventState><timing><minEndTime>22120</minEndTime></timing></MovementEvent></state-time-speed></MovementState><MovementState><signalGroup>4</signalGroup><state-time-speed><MovementEvent><eventState><stop-And-Remain/></eventState><timing><minEndTime>22120</minEndTime></timing></MovementEvent></state-time-speed></MovementState></states></IntersectionState>";
+        
+        final String expectedJson = "{\"id\":{\"id\":12111},\"revision\":0,\"status\":{\"manualControlIsEnabled\":false,\"stopTimeIsActivated\":false,\"failureFlash\":false,\"preemptIsActive\":false,\"signalPriorityIsActive\":false,\"fixedTimeOperation\":false,\"trafficDependentOperation\":false,\"standbyOperation\":false,\"failureMode\":false,\"off\":false,\"recentMAPmessageUpdate\":false,\"recentChangeInMAPassignedLanesIDsUsed\":false,\"noValidMAPisAvailableAtThisTime\":false,\"noValidSPATisAvailableAtThisTime\":false},\"states\":{\"movementList\":[{\"signalGroup\":2,\"state_time_speed\":{\"movementEventList\":[{\"eventState\":\"PROTECTED_MOVEMENT_ALLOWED\",\"timing\":{\"minEndTime\":22120}}]}},{\"signalGroup\":4,\"state_time_speed\":{\"movementEventList\":[{\"eventState\":\"STOP_AND_REMAIN\",\"timing\":{\"minEndTime\":22120}}]}}]}}";
+        
+        shouldTranslateIntersectionState(xml, expectedJson);
+    }
+
+
+
+    @Test
+    public void shouldTranslateIntersectionState_WithoutStatus() {
+        final String xml = "<IntersectionState><id><id>12111</id></id><revision>0</revision><states><MovementState><signalGroup>2</signalGroup><state-time-speed><MovementEvent><eventState><protected-Movement-Allowed/></eventState><timing><minEndTime>22120</minEndTime></timing></MovementEvent></state-time-speed></MovementState></states></IntersectionState>";
+        
+        final String expectedJson = "{\"id\":{\"id\":12111},\"revision\":0,\"states\":{\"movementList\":[{\"signalGroup\":2,\"state_time_speed\":{\"movementEventList\":[{\"eventState\":\"PROTECTED_MOVEMENT_ALLOWED\",\"timing\":{\"minEndTime\":22120}}]}}]}}";
+
+        shouldTranslateIntersectionState(xml, expectedJson);
+
+       
+    }
+
+    @Test
+    public void shouldTranslateIntersectionState_WithEnabledLanes() {
+        final String xml = "<IntersectionState><id><id>12111</id></id><revision>0</revision><enabledLanes><LaneID>1</LaneID></enabledLanes><states><MovementState><signalGroup>2</signalGroup><state-time-speed><MovementEvent><eventState><protected-Movement-Allowed/></eventState><timing><minEndTime>22120</minEndTime></timing></MovementEvent></state-time-speed></MovementState></states></IntersectionState>";
+        
+        final String expectedJson = "{\"id\":{\"id\":12111},\"revision\":0,\"enabledLanes\":{\"enabledLaneList\":[1]},\"states\":{\"movementList\":[{\"signalGroup\":2,\"state_time_speed\":{\"movementEventList\":[{\"eventState\":\"PROTECTED_MOVEMENT_ALLOWED\",\"timing\":{\"minEndTime\":22120}}]}}]}}";
+
+        shouldTranslateIntersectionState(xml, expectedJson);
+
+        
+    }
+
+    @Test
+    public void shouldTranslateIntersectionState_WithEnabledLanesArray() {
+        final String xml = "<IntersectionState><id><id>12111</id></id><revision>0</revision><enabledLanes><LaneID>1</LaneID><LaneID>2</LaneID></enabledLanes><states><MovementState><signalGroup>2</signalGroup><state-time-speed><MovementEvent><eventState><protected-Movement-Allowed/></eventState><timing><minEndTime>22120</minEndTime></timing></MovementEvent></state-time-speed></MovementState></states></IntersectionState>";
+        
+        final String expectedJson = "{\"id\":{\"id\":12111},\"revision\":0,\"enabledLanes\":{\"enabledLaneList\":[1,2]},\"states\":{\"movementList\":[{\"signalGroup\":2,\"state_time_speed\":{\"movementEventList\":[{\"eventState\":\"PROTECTED_MOVEMENT_ALLOWED\",\"timing\":{\"minEndTime\":22120}}]}}]}}";
+        
+        shouldTranslateIntersectionState(xml, expectedJson);
+
+        
+    }
+
+    @Test
+    public void shouldTranslateIntersectionState_WithManeuverAssist() {
+        final String xml = "<IntersectionState><id><id>12111</id></id><revision>0</revision><states><MovementState><signalGroup>2</signalGroup><state-time-speed><MovementEvent><eventState><protected-Movement-Allowed/></eventState><timing><minEndTime>22120</minEndTime></timing></MovementEvent></state-time-speed></MovementState></states><maneuverAssistList><ConnectionManeuverAssist><connectionID>1</connectionID><queueLength>0</queueLength><availableStorageLength>0</availableStorageLength><waitOnStop><true/></waitOnStop><pedBicycleDetect><true/></pedBicycleDetect></ConnectionManeuverAssist></maneuverAssistList></IntersectionState>";
+        final String expectedJson = "{\"id\":{\"id\":12111},\"revision\":0,\"states\":{\"movementList\":[{\"signalGroup\":2,\"state_time_speed\":{\"movementEventList\":[{\"eventState\":\"PROTECTED_MOVEMENT_ALLOWED\",\"timing\":{\"minEndTime\":22120}}]}}]},\"maneuverAssistList\":{\"maneuverAssistList\":[{\"connectionID\":1,\"queueLength\":0,\"availableStorageLength\":0,\"waitOnStop\":true,\"pedBicycleDetect\":true}]}}";
+        
+        shouldTranslateIntersectionState(xml, expectedJson);
+
+       
+    }
+
+    @Test
+    public void shouldTranslateIntersectionState_WithManeuverAssistArray() {
+        final String xml = "<IntersectionState><id><id>12111</id></id><revision>0</revision><states><MovementState><signalGroup>2</signalGroup><state-time-speed><MovementEvent><eventState><protected-Movement-Allowed/></eventState><timing><minEndTime>22120</minEndTime></timing></MovementEvent></state-time-speed></MovementState></states><maneuverAssistList><ConnectionManeuverAssist><connectionID>1</connectionID><queueLength>0</queueLength><availableStorageLength>0</availableStorageLength><waitOnStop><true/></waitOnStop><pedBicycleDetect><true/></pedBicycleDetect></ConnectionManeuverAssist><ConnectionManeuverAssist><connectionID>2</connectionID><queueLength>0</queueLength><availableStorageLength>0</availableStorageLength><waitOnStop><false/></waitOnStop><pedBicycleDetect><false/></pedBicycleDetect></ConnectionManeuverAssist></maneuverAssistList></IntersectionState>";
+        
+        final String expectedJson = "{\"id\":{\"id\":12111},\"revision\":0,\"states\":{\"movementList\":[{\"signalGroup\":2,\"state_time_speed\":{\"movementEventList\":[{\"eventState\":\"PROTECTED_MOVEMENT_ALLOWED\",\"timing\":{\"minEndTime\":22120}}]}}]},\"maneuverAssistList\":{\"maneuverAssistList\":[{\"connectionID\":1,\"queueLength\":0,\"availableStorageLength\":0,\"waitOnStop\":true,\"pedBicycleDetect\":true},{\"connectionID\":2,\"queueLength\":0,\"availableStorageLength\":0,\"waitOnStop\":false,\"pedBicycleDetect\":false}]}}";
+        
+        shouldTranslateIntersectionState(xml, expectedJson);
+
+       
+    }
+
+    @Test
+    public void shouldTranslateIntersectionState_WithOtherOptionalElements() {
+        final String xml = "<IntersectionState><name>Intersection Name</name><id><region>0</region><id>12111</id></id><revision>0</revision><status>0000000000000000</status><moy>400000</moy><timeStamp>35176</timeStamp><states><MovementState><signalGroup>2</signalGroup><state-time-speed><MovementEvent><eventState><protected-Movement-Allowed/></eventState><timing><startTime>22120</startTime><minEndTime>22120</minEndTime><maxEndTime>22121</maxEndTime><likelyTime>22120</likelyTime><confidence>15</confidence><nextTime>22220</nextTime></timing></MovementEvent></state-time-speed></MovementState></states></IntersectionState>";
+        
+        final String expectedJson = "{\"name\":\"Intersection Name\",\"id\":{\"region\":0,\"id\":12111},\"revision\":0,\"status\":{\"manualControlIsEnabled\":false,\"stopTimeIsActivated\":false,\"failureFlash\":false,\"preemptIsActive\":false,\"signalPriorityIsActive\":false,\"fixedTimeOperation\":false,\"trafficDependentOperation\":false,\"standbyOperation\":false,\"failureMode\":false,\"off\":false,\"recentMAPmessageUpdate\":false,\"recentChangeInMAPassignedLanesIDsUsed\":false,\"noValidMAPisAvailableAtThisTime\":false,\"noValidSPATisAvailableAtThisTime\":false},\"moy\":400000,\"timeStamp\":35176,\"states\":{\"movementList\":[{\"signalGroup\":2,\"state_time_speed\":{\"movementEventList\":[{\"eventState\":\"PROTECTED_MOVEMENT_ALLOWED\",\"timing\":{\"startTime\":22120,\"minEndTime\":22120,\"maxEndTime\":22121,\"likelyTime\":22120,\"confidence\":15,\"nextTime\":22220}}]}}]}}";
+        
+        shouldTranslateIntersectionState(xml, expectedJson);
+
+       
+    }
+    
+}

--- a/jpo-ode-plugins/src/test/java/us/dot/its/jpo/ode/plugin/j2735/builders/IntersectionStateBuilderTest.java
+++ b/jpo-ode-plugins/src/test/java/us/dot/its/jpo/ode/plugin/j2735/builders/IntersectionStateBuilderTest.java
@@ -8,7 +8,9 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import us.dot.its.jpo.ode.plugin.j2735.J2735IntersectionState;
+import us.dot.its.jpo.ode.util.JsonUtils;
 import us.dot.its.jpo.ode.util.XmlUtils;
+import us.dot.its.jpo.ode.util.JsonUtils.JsonUtilsException;
 import us.dot.its.jpo.ode.util.XmlUtils.XmlUtilsException;
 
 public class IntersectionStateBuilderTest {
@@ -23,8 +25,23 @@ public class IntersectionStateBuilderTest {
         }
 
         J2735IntersectionState actualIntersectionState = IntersectionStateBuilder.genericIntersectionState(node);
+
+        // Convert expected and actual JSON to JsonNode structures to compare them
+        // because we want to ignore null values and the order of keys in JSON objects
+        // in the comparison, so the expected JSON string doesn't need to depend on the order of 
+        // items in the Intersection Status and Maneuver Assist Bitstrings which is not
+        // preserved in the JSON representation and not known before running the tests.
+        JsonNode expectedJsonNode = null;
+        JsonNode actualJsonNode = null;
+        try {
+            expectedJsonNode = JsonUtils.toObjectNode(expectedJson);
+            actualJsonNode = JsonUtils.toObjectNode(JsonUtils.toJson(actualIntersectionState, false));
+        } catch (JsonUtilsException e) {
+            fail("Error parsing expected JSON: " + e.getMessage());
+        }
         
-        assertEquals(expectedJson, actualIntersectionState.toJson(false));
+        
+        assertEquals(expectedJsonNode, actualJsonNode);
     }
 
     

--- a/jpo-ode-plugins/src/test/java/us/dot/its/jpo/ode/plugin/j2735/builders/ManeuverAssistBuilderTest.java
+++ b/jpo-ode-plugins/src/test/java/us/dot/its/jpo/ode/plugin/j2735/builders/ManeuverAssistBuilderTest.java
@@ -1,0 +1,47 @@
+package us.dot.its.jpo.ode.plugin.j2735.builders;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import us.dot.its.jpo.ode.plugin.j2735.J2735ConnectionManueverAssist;
+import us.dot.its.jpo.ode.util.XmlUtils;
+import us.dot.its.jpo.ode.util.XmlUtils.XmlUtilsException;
+
+public class ManeuverAssistBuilderTest {
+
+    // Common code for the tests
+    private void shouldTranslateManeuverAssist(final String xml, final String expectedJson) {
+        JsonNode node = null;
+        try {
+            node = XmlUtils.toObjectNode(xml).get("ConnectionManeuverAssist");
+        } catch (XmlUtilsException e) {
+            fail("XML parsing error:" + e.getMessage());
+        }
+
+        final J2735ConnectionManueverAssist actualManeuverAssist = ManeuverAssistBuilder.genericManeuverAssist(node);
+        
+        assertEquals(expectedJson, actualManeuverAssist.toJson(false));
+    }
+
+    @Test
+    public void shouldTranslateManeuverAssist_WithTrueBooleans() {
+        String xml = "<ConnectionManeuverAssist><connectionID>1</connectionID><queueLength>20</queueLength><availableStorageLength>10</availableStorageLength><waitOnStop><true/></waitOnStop><pedBicycleDetect><true/></pedBicycleDetect></ConnectionManeuverAssist>";
+
+        String expectedJson = "{\"connectionID\":1,\"queueLength\":20,\"availableStorageLength\":10,\"waitOnStop\":true,\"pedBicycleDetect\":true}";
+
+        shouldTranslateManeuverAssist(xml, expectedJson);
+    }
+
+    @Test
+    public void shouldTranslateManeuverAssist_WithFalseBooleans() {
+        String xml = "<ConnectionManeuverAssist><connectionID>1</connectionID><queueLength>20</queueLength><availableStorageLength>10</availableStorageLength><waitOnStop><false/></waitOnStop><pedBicycleDetect><false/></pedBicycleDetect></ConnectionManeuverAssist>";
+
+        String expectedJson = "{\"connectionID\":1,\"queueLength\":20,\"availableStorageLength\":10,\"waitOnStop\":false,\"pedBicycleDetect\":false}";
+
+        shouldTranslateManeuverAssist(xml, expectedJson);
+    }
+}

--- a/jpo-ode-plugins/src/test/java/us/dot/its/jpo/ode/plugin/j2735/builders/MovementEventBuilderTest.java
+++ b/jpo-ode-plugins/src/test/java/us/dot/its/jpo/ode/plugin/j2735/builders/MovementEventBuilderTest.java
@@ -1,0 +1,57 @@
+package us.dot.its.jpo.ode.plugin.j2735.builders;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import us.dot.its.jpo.ode.plugin.j2735.J2735MovementEvent;
+import us.dot.its.jpo.ode.util.XmlUtils;
+import us.dot.its.jpo.ode.util.XmlUtils.XmlUtilsException;
+
+public class MovementEventBuilderTest {
+
+// Common code for the tests
+    private void shouldTranslateMovementEvent(final String xml, final String expectedJson) {
+        JsonNode node = null;
+        try {
+            node = XmlUtils.toObjectNode(xml).get("MovementEvent");
+        } catch (XmlUtilsException e) {
+            fail("XML parsing error: " + e.getMessage());
+        }
+
+        final J2735MovementEvent actualMovementEvent = MovementEventBuilder.genericMovementState(node);
+        
+        assertEquals(expectedJson, actualMovementEvent.toJson(false));
+    }
+
+    @Test
+    public void shouldTranslateMovementEvent() {
+        final String xml = "<MovementEvent><eventState><protected-Movement-Allowed/></eventState><timing><startTime>22120</startTime><minEndTime>22120</minEndTime><maxEndTime>22121</maxEndTime><likelyTime>22120</likelyTime><confidence>15</confidence><nextTime>22220</nextTime></timing></MovementEvent>";
+
+        final String expectedJson = "{\"eventState\":\"PROTECTED_MOVEMENT_ALLOWED\",\"timing\":{\"startTime\":22120,\"minEndTime\":22120,\"maxEndTime\":22121,\"likelyTime\":22120,\"confidence\":15,\"nextTime\":22220}}";
+
+        shouldTranslateMovementEvent(xml, expectedJson);
+    }
+    
+    @Test
+    public void shouldTranslateMovementEvent_WithAdvisorySpeed() {
+        final String xml = "<MovementEvent><eventState><protected-Movement-Allowed/></eventState><timing><startTime>22120</startTime><minEndTime>22120</minEndTime><maxEndTime>22121</maxEndTime><likelyTime>22120</likelyTime><confidence>15</confidence><nextTime>22220</nextTime></timing><speeds><AdvisorySpeed><type><transit/></type><speed>250</speed><confidence><prec1ms/></confidence><distance>100</distance><class>1</class></AdvisorySpeed></speeds></MovementEvent>";
+
+        final String expectedJson = "{\"eventState\":\"PROTECTED_MOVEMENT_ALLOWED\",\"timing\":{\"startTime\":22120,\"minEndTime\":22120,\"maxEndTime\":22121,\"likelyTime\":22120,\"confidence\":15,\"nextTime\":22220},\"speeds\":{\"advisorySpeedList\":[{\"type\":\"TRANSIT\",\"speed\":250,\"confidence\":\"PREC1MS\",\"distance\":100,\"classId\":1}]}}";
+
+        shouldTranslateMovementEvent(xml, expectedJson);
+    }
+
+    @Test
+    public void shouldTranslateMovementEvent_WithAdvisorySpeedArray() {
+        final String xml = "<MovementEvent><eventState><protected-Movement-Allowed/></eventState><timing><startTime>22120</startTime><minEndTime>22120</minEndTime><maxEndTime>22121</maxEndTime><likelyTime>22120</likelyTime><confidence>15</confidence><nextTime>22220</nextTime></timing><speeds><AdvisorySpeed><type><transit/></type><speed>250</speed><confidence><prec1ms/></confidence><distance>100</distance><class>1</class></AdvisorySpeed><AdvisorySpeed><type><greenwave/></type><speed>250</speed><confidence><prec100ms/></confidence><distance>50</distance><class>1</class></AdvisorySpeed></speeds></MovementEvent>";
+
+        final String expectedJson = "{\"eventState\":\"PROTECTED_MOVEMENT_ALLOWED\",\"timing\":{\"startTime\":22120,\"minEndTime\":22120,\"maxEndTime\":22121,\"likelyTime\":22120,\"confidence\":15,\"nextTime\":22220},\"speeds\":{\"advisorySpeedList\":[{\"type\":\"TRANSIT\",\"speed\":250,\"confidence\":\"PREC1MS\",\"distance\":100,\"classId\":1},{\"type\":\"GREENWAVE\",\"speed\":250,\"confidence\":\"PREC100MS\",\"distance\":50,\"classId\":1}]}}";
+
+        shouldTranslateMovementEvent(xml, expectedJson);
+    }
+
+}

--- a/jpo-ode-plugins/src/test/java/us/dot/its/jpo/ode/plugin/j2735/builders/MovementStateBuilderTest.java
+++ b/jpo-ode-plugins/src/test/java/us/dot/its/jpo/ode/plugin/j2735/builders/MovementStateBuilderTest.java
@@ -1,0 +1,61 @@
+package us.dot.its.jpo.ode.plugin.j2735.builders;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import us.dot.its.jpo.ode.plugin.j2735.J2735MovementState;
+import us.dot.its.jpo.ode.util.XmlUtils;
+import us.dot.its.jpo.ode.util.XmlUtils.XmlUtilsException;
+
+public class MovementStateBuilderTest {
+    
+
+    // Common code for the tests
+    private void shouldTranslateMovementState(final String xml, final String expectedJson) {
+        JsonNode node = null;
+        try {
+            node = XmlUtils.toObjectNode(xml).get("MovementState");
+        } catch (XmlUtilsException e) {
+            fail("XML parsing error: " + e.getMessage());
+        }
+
+        final J2735MovementState actualMovementState = MovementStateBuilder.genericMovementState(node);
+        
+        assertEquals(expectedJson, actualMovementState.toJson(false));
+    }
+
+    @Test
+    public void shouldTranslateMovementState_J2735MandatoryElements() {
+        final String xml = "<MovementState><signalGroup>2</signalGroup><state-time-speed><MovementEvent><eventState><protected-Movement-Allowed/></eventState><timing><minEndTime>22120</minEndTime></timing></MovementEvent></state-time-speed></MovementState>";
+
+        final String expectedJson = "{\"signalGroup\":2,\"state_time_speed\":{\"movementEventList\":[{\"eventState\":\"PROTECTED_MOVEMENT_ALLOWED\",\"timing\":{\"minEndTime\":22120}}]}}";
+
+        shouldTranslateMovementState(xml, expectedJson);
+    }
+
+    
+
+    @Test
+    public void shouldTranslateMovementState_WithManeuverAssist() {
+        final String xml = "<MovementState><signalGroup>2</signalGroup><state-time-speed><MovementEvent><eventState><protected-Movement-Allowed/></eventState><timing><minEndTime>22120</minEndTime></timing></MovementEvent></state-time-speed><maneuverAssistList><ConnectionManeuverAssist><connectionID>1</connectionID><queueLength>20</queueLength><availableStorageLength>10</availableStorageLength><waitOnStop><false/></waitOnStop><pedBicycleDetect><false/></pedBicycleDetect></ConnectionManeuverAssist></maneuverAssistList></MovementState>";
+
+        final String expectedJson = "{\"signalGroup\":2,\"state_time_speed\":{\"movementEventList\":[{\"eventState\":\"PROTECTED_MOVEMENT_ALLOWED\",\"timing\":{\"minEndTime\":22120}}]},\"maneuverAssistList\":{\"maneuverAssistList\":[{\"connectionID\":1,\"queueLength\":20,\"availableStorageLength\":10,\"waitOnStop\":false,\"pedBicycleDetect\":false}]}}";
+
+        shouldTranslateMovementState(xml, expectedJson);
+    }
+
+    @Test 
+    public void shouldTranslateMovementState_WithManeuverAssistArray() {
+        final String xml = "<MovementState><signalGroup>2</signalGroup><state-time-speed><MovementEvent><eventState><protected-Movement-Allowed/></eventState><timing><minEndTime>22120</minEndTime></timing></MovementEvent></state-time-speed><maneuverAssistList><ConnectionManeuverAssist><connectionID>1</connectionID><queueLength>20</queueLength><availableStorageLength>10</availableStorageLength><waitOnStop><true/></waitOnStop><pedBicycleDetect><true/></pedBicycleDetect></ConnectionManeuverAssist><ConnectionManeuverAssist><connectionID>2</connectionID><queueLength>20</queueLength><availableStorageLength>10</availableStorageLength><waitOnStop><true/></waitOnStop><pedBicycleDetect><true/></pedBicycleDetect></ConnectionManeuverAssist></maneuverAssistList></MovementState>";
+
+        final String expectedJson = "{\"signalGroup\":2,\"state_time_speed\":{\"movementEventList\":[{\"eventState\":\"PROTECTED_MOVEMENT_ALLOWED\",\"timing\":{\"minEndTime\":22120}}]},\"maneuverAssistList\":{\"maneuverAssistList\":[{\"connectionID\":1,\"queueLength\":20,\"availableStorageLength\":10,\"waitOnStop\":true,\"pedBicycleDetect\":true},{\"connectionID\":2,\"queueLength\":20,\"availableStorageLength\":10,\"waitOnStop\":true,\"pedBicycleDetect\":true}]}}";
+
+        shouldTranslateMovementState(xml, expectedJson);
+    }
+
+    
+}


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[SPAT JSON Builder bugs #484](https://github.com/usdot-jpo-ode/jpo-ode/issues/484)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This change is required to enable the ODE to produce valid JSON from any valid SPAT message that it recieves.  It fixes some bugs producing SPAT JSON when certain elements are present in the input message.  See the above issue for details.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The following unit test classes are added which test that the JSON builders can convert XER encoded SPAT messages to JSON:
* IntersectionStateBuilderTest
* ManeuverAssistBuilderTest
* MovementEventBuilderTest
* MovementStateBuilderTest

The validity of the XML test messages was verified by round tripping them through the Asn.1 encoder/decoder.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that cause existing functionality to change)'

The following classes have fixes which mainly amount to fixing typos to prevent the code from throwing null pointer exceptions:
* IntersectionStateBuilder
* ManeuverAssistBuilder
* MovementStateBuilder

The following classes contain fixes that might be considered breaking changes:
* J2735IntersectionState
    * Change the type of the status property to J2735BitString to conform with the specification as a BIT STRING in J2735_201603, sec. 7.57, DE_IntersectionStatusObject.
* J2735IntersectionStatusObject
    * Change the enumerated values to camel case to match the above specification, and to be consistent with how other bit strings are represented in the JSON format.


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
