### PR TITLE
Fix deserializing JSON to OdeData objects

### DIFF
--- a/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeBsmData.java
+++ b/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeBsmData.java
@@ -15,6 +15,9 @@
  ******************************************************************************/
 package us.dot.its.jpo.ode.model;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.*;
+
 public class OdeBsmData extends OdeData {
 
    private static final long serialVersionUID = 4944935387116447760L;
@@ -25,6 +28,18 @@ public class OdeBsmData extends OdeData {
 
    public OdeBsmData(OdeMsgMetadata metadata, OdeMsgPayload payload) {
       super(metadata, payload);
+   }
+
+   @Override
+   @JsonTypeInfo(use = Id.CLASS, defaultImpl = OdeBsmMetadata.class)
+   public void setMetadata(OdeMsgMetadata metadata) {
+      super.setMetadata(metadata);
+   }
+
+   @Override
+   @JsonTypeInfo(use = Id.CLASS, defaultImpl = OdeBsmPayload.class)
+   public void setPayload(OdeMsgPayload payload) {
+      super.setPayload(payload);
    }
 
 }

--- a/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeMapData.java
+++ b/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeMapData.java
@@ -1,15 +1,29 @@
 package us.dot.its.jpo.ode.model;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.*;
+
 public class OdeMapData extends OdeData {
 
-	   private static final long serialVersionUID = 4944935387116447760L;
+	private static final long serialVersionUID = 4944935387116447760L;
 
-	   public OdeMapData() {
-	      super();
-	   }
-
-	   public OdeMapData(OdeMsgMetadata metadata, OdeMsgPayload payload) {
-	      super(metadata, payload);
-	   }
-
+	public OdeMapData() {
+		super();
 	}
+
+	public OdeMapData(OdeMsgMetadata metadata, OdeMsgPayload payload) {
+		super(metadata, payload);
+	}
+
+	@Override
+	@JsonTypeInfo(use = Id.CLASS, defaultImpl = OdeMapMetadata.class)
+	public void setMetadata(OdeMsgMetadata metadata) {
+		super.setMetadata(metadata);
+	}
+
+	@Override
+	@JsonTypeInfo(use = Id.CLASS, defaultImpl = OdeMapPayload.class)
+	public void setPayload(OdeMsgPayload payload) {
+		super.setPayload(payload);
+	}
+}

--- a/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeSpatData.java
+++ b/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeSpatData.java
@@ -15,6 +15,9 @@
  ******************************************************************************/
 package us.dot.its.jpo.ode.model;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.*;
+
 public class OdeSpatData extends OdeData {
 
    private static final long serialVersionUID = 4944935387116447760L;
@@ -25,6 +28,18 @@ public class OdeSpatData extends OdeData {
 
    public OdeSpatData(OdeMsgMetadata metadata, OdeMsgPayload payload) {
       super(metadata, payload);
+   }
+
+   @Override
+   @JsonTypeInfo(use = Id.CLASS, defaultImpl = OdeSpatMetadata.class)
+   public void setMetadata(OdeMsgMetadata metadata) {
+      super.setMetadata(metadata);
+   }
+
+   @Override
+   @JsonTypeInfo(use = Id.CLASS, defaultImpl = OdeSpatPayload.class)
+   public void setPayload(OdeMsgPayload payload) {
+      super.setPayload(payload);
    }
 
 }

--- a/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeSrmData.java
+++ b/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeSrmData.java
@@ -1,5 +1,8 @@
 package us.dot.its.jpo.ode.model;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.*;
+
 public class OdeSrmData extends OdeData {
 
     private static final long serialVersionUID = 4944933827116447760L;
@@ -11,4 +14,17 @@ public class OdeSrmData extends OdeData {
     public OdeSrmData(OdeMsgMetadata metadata, OdeMsgPayload payload) {
         super(metadata, payload);
     }
+
+    @Override
+    @JsonTypeInfo(use = Id.CLASS, defaultImpl = OdeSrmMetadata.class)
+    public void setMetadata(OdeMsgMetadata metadata) {
+        super.setMetadata(metadata);
+    }
+
+    @Override
+    @JsonTypeInfo(use = Id.CLASS, defaultImpl = OdeSrmPayload.class)
+    public void setPayload(OdeMsgPayload payload) {
+        super.setPayload(payload);
+    }
+
 }

--- a/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeSsmData.java
+++ b/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeSsmData.java
@@ -1,14 +1,29 @@
 package us.dot.its.jpo.ode.model;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.*;
+
 public class OdeSsmData extends OdeData {
 
     private static final long serialVersionUID = 2057222204896561615L;
 
-   public OdeSsmData() {
-       super();
-   }
+    public OdeSsmData() {
+        super();
+    }
 
-   public OdeSsmData(OdeMsgMetadata metadata, OdeMsgPayload payload) {
-       super(metadata, payload);
-   }
+    public OdeSsmData(OdeMsgMetadata metadata, OdeMsgPayload payload) {
+        super(metadata, payload);
+    }
+
+    @Override
+    @JsonTypeInfo(use = Id.CLASS, defaultImpl = OdeSsmMetadata.class)
+    public void setMetadata(OdeMsgMetadata metadata) {
+        super.setMetadata(metadata);
+    }
+
+    @Override
+    @JsonTypeInfo(use = Id.CLASS, defaultImpl = OdeSsmPayload.class)
+    public void setPayload(OdeMsgPayload payload) {
+        super.setPayload(payload);
+    }
 }

--- a/jpo-ode-core/src/test/java/us/dot/its/jpo/ode/model/OdeBsmDataTest.java
+++ b/jpo-ode-core/src/test/java/us/dot/its/jpo/ode/model/OdeBsmDataTest.java
@@ -1,0 +1,33 @@
+package us.dot.its.jpo.ode.model;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import us.dot.its.jpo.ode.util.JsonUtils;
+
+public class OdeBsmDataTest {
+    
+    @Test
+    public void shouldDeserializeJson_bsmTx() {
+
+        final String bsmJson = "{\"metadata\":{\"bsmSource\":\"RV\",\"logFileName\":\"\",\"recordType\":\"bsmTx\",\"securityResultCode\":\"success\",\"receivedMessageDetails\":{\"locationData\":{\"latitude\":\"\",\"longitude\":\"\",\"elevation\":\"\",\"speed\":\"\",\"heading\":\"\"},\"rxSource\":\"RV\"},\"payloadType\":\"us.dot.its.jpo.ode.model.OdeBsmPayload\",\"serialId\":{\"streamId\":\"504becf3-8e20-49cb-a2d7-25b646c34d0f\",\"bundleSize\":1,\"bundleId\":0,\"recordId\":0,\"serialNumber\":0},\"odeReceivedAt\":\"2022-06-17T19:14:21.223956Z\",\"schemaVersion\":6,\"maxDurationTime\":0,\"recordGeneratedAt\":\"\",\"sanitized\":false,\"odePacketID\":\"\",\"odeTimStartDateTime\":\"\",\"originIp\":\"10.11.81.12\"},\"payload\":{\"data\":{\"coreData\":{\"msgCnt\":46,\"id\":\"E6A99808\",\"secMark\":21061,\"position\":{\"latitude\":39.5881304,\"longitude\":-105.0910403,\"elevation\":1692.0},\"accelSet\":{\"accelLong\":-0.07,\"accelYaw\":-0.09},\"accuracy\":{\"semiMajor\":2.0,\"semiMinor\":2.0,\"orientation\":44.49530799},\"transmission\":\"UNAVAILABLE\",\"speed\":22.62,\"heading\":169.3,\"brakes\":{\"wheelBrakes\":{\"leftFront\":false,\"rightFront\":false,\"unavailable\":true,\"leftRear\":false,\"rightRear\":false},\"traction\":\"unavailable\",\"abs\":\"off\",\"scs\":\"unavailable\",\"brakeBoost\":\"unavailable\",\"auxBrakes\":\"unavailable\"},\"size\":{\"width\":180,\"length\":480}},\"partII\":[{\"id\":\"VehicleSafetyExtensions\",\"value\":{\"pathHistory\":{\"crumbData\":[{\"elevationOffset\":0.8,\"latOffset\":-0.0001802,\"lonOffset\":0.0000434,\"timeOffset\":0.89},{\"elevationOffset\":4.5,\"latOffset\":-0.0011801,\"lonOffset\":0.0002357,\"timeOffset\":5.7},{\"elevationOffset\":9.3,\"latOffset\":-0.0023623,\"lonOffset\":0.0003881,\"timeOffset\":11.1}]},\"pathPrediction\":{\"confidence\":70.0,\"radiusOfCurve\":0.0}}}]},\"dataType\":\"us.dot.its.jpo.ode.plugin.j2735.J2735Bsm\"}}";
+
+        var deserialized = (OdeBsmData)JsonUtils.fromJson(bsmJson, OdeBsmData.class);
+        assertNotNull(deserialized);
+        assertTrue(deserialized.getMetadata() instanceof OdeBsmMetadata);
+        assertTrue(deserialized.getPayload() instanceof OdeBsmPayload);
+        
+    }
+
+    @Test
+    public void shouldDeserializeJson_bsmLogDuringEvent() {
+
+        final String bsmJson = "{\"metadata\":{\"bsmSource\":\"RV\",\"logFileName\":\"bsmLogDuringEvent.gz\",\"recordType\":\"bsmLogDuringEvent\",\"securityResultCode\":\"success\",\"receivedMessageDetails\":{\"locationData\":{\"latitude\":\"40.565771\",\"longitude\":\"-105.0318108\",\"elevation\":\"1487\",\"speed\":\"0.14\",\"heading\":\"205.975\"},\"rxSource\":\"NA\"},\"payloadType\":\"us.dot.its.jpo.ode.model.OdeBsmPayload\",\"serialId\":{\"streamId\":\"801780cb-d91d-444b-8f4d-9c44fe27f5ea\",\"bundleSize\":222,\"bundleId\":71,\"recordId\":221,\"serialNumber\":14725},\"odeReceivedAt\":\"2019-04-09T18:07:12.352Z\",\"schemaVersion\":6,\"recordGeneratedAt\":\"2018-05-01T16:04:23.694Z\",\"recordGeneratedBy\":\"OBU\",\"sanitized\":false},\"payload\":{\"dataType\":\"us.dot.its.jpo.ode.plugin.j2735.J2735Bsm\",\"data\":{\"coreData\":{\"msgCnt\":95,\"id\":\"31325431\",\"secMark\":23794,\"position\":{\"latitude\":40.5657318,\"longitude\":-105.0318485,\"elevation\":1472.8},\"accelSet\":{\"accelLat\":0.00,\"accelLong\":0.52,\"accelVert\":0.00,\"accelYaw\":0.00},\"accuracy\":{\"semiMajor\":12.70,\"semiMinor\":12.40},\"transmission\":\"NEUTRAL\",\"speed\":0.10,\"heading\":250.9125,\"brakes\":{\"wheelBrakes\":{\"leftFront\":false,\"rightFront\":false,\"unavailable\":true,\"leftRear\":false,\"rightRear\":false},\"traction\":\"unavailable\",\"abs\":\"unavailable\",\"scs\":\"unavailable\",\"brakeBoost\":\"unavailable\",\"auxBrakes\":\"unavailable\"},\"size\":{\"width\":190,\"length\":570}},\"partII\":[{\"id\":\"VehicleSafetyExtensions\",\"value\":{\"pathHistory\":{\"crumbData\":[{\"elevationOffset\":0.3,\"latOffset\":-0.0000044,\"lonOffset\":-0.0000106,\"timeOffset\":0.59},{\"elevationOffset\":1.5,\"latOffset\":0.0000141,\"lonOffset\":0.0000047,\"timeOffset\":6.99},{\"elevationOffset\":2.8,\"latOffset\":0.0000385,\"lonOffset\":0.0000206,\"timeOffset\":15.09},{\"elevationOffset\":4.2,\"latOffset\":0.0000394,\"lonOffset\":0.0000051,\"timeOffset\":23.19},{\"elevationOffset\":8.6,\"latOffset\":0.0000586,\"lonOffset\":0.0000595,\"timeOffset\":37.89},{\"elevationOffset\":10.2,\"latOffset\":0.0000866,\"lonOffset\":0.0001174,\"timeOffset\":43.80},{\"elevationOffset\":8.5,\"latOffset\":0.0001026,\"lonOffset\":0.0001127,\"timeOffset\":49.20},{\"elevationOffset\":-0.1,\"latOffset\":0.0001183,\"lonOffset\":0.0000434,\"timeOffset\":55.60},{\"elevationOffset\":-8.1,\"latOffset\":0.0001101,\"lonOffset\":-0.0000274,\"timeOffset\":59.09},{\"elevationOffset\":-14.2,\"latOffset\":0.0001019,\"lonOffset\":-0.0000492,\"timeOffset\":61.19},{\"elevationOffset\":-19.0,\"latOffset\":0.0000944,\"lonOffset\":-0.0000738,\"timeOffset\":63.49},{\"elevationOffset\":-31.4,\"latOffset\":0.0000826,\"lonOffset\":-0.0001389,\"timeOffset\":69.19},{\"elevationOffset\":-39.8,\"latOffset\":0.0000788,\"lonOffset\":-0.0001748,\"timeOffset\":73.09},{\"elevationOffset\":-46.7,\"latOffset\":0.0000753,\"lonOffset\":-0.0002035,\"timeOffset\":78.89},{\"elevationOffset\":-48.9,\"latOffset\":0.0000831,\"lonOffset\":-0.0002563,\"timeOffset\":82.09}]},\"pathPrediction\":{\"confidence\":0.0,\"radiusOfCurve\":0.0}}},{\"id\":\"SupplementalVehicleExtensions\",\"value\":{}}]}}}";
+
+        var deserialized = (OdeBsmData)JsonUtils.fromJson(bsmJson, OdeBsmData.class);
+        assertNotNull(deserialized);
+        assertTrue(deserialized.getMetadata() instanceof OdeBsmMetadata);
+        assertTrue(deserialized.getPayload() instanceof OdeBsmPayload);
+        
+    }
+}

--- a/jpo-ode-core/src/test/java/us/dot/its/jpo/ode/model/OdeBsmDataTest.java
+++ b/jpo-ode-core/src/test/java/us/dot/its/jpo/ode/model/OdeBsmDataTest.java
@@ -3,6 +3,9 @@ package us.dot.its.jpo.ode.model;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
+import us.dot.its.jpo.ode.plugin.j2735.J2735Bsm;
+import us.dot.its.jpo.ode.plugin.j2735.J2735SupplementalVehicleExtensions;
+import us.dot.its.jpo.ode.plugin.j2735.J2735VehicleSafetyExtensions;
 import us.dot.its.jpo.ode.util.JsonUtils;
 
 public class OdeBsmDataTest {
@@ -14,9 +17,14 @@ public class OdeBsmDataTest {
 
         var deserialized = (OdeBsmData)JsonUtils.fromJson(bsmJson, OdeBsmData.class);
         assertNotNull(deserialized);
-        assertTrue(deserialized.getMetadata() instanceof OdeBsmMetadata);
+        assertTrue(deserialized.getMetadata() instanceof OdeBsmMetadata);     
         assertTrue(deserialized.getPayload() instanceof OdeBsmPayload);
-        
+        var payload = (OdeBsmPayload)deserialized.getPayload();
+        assertTrue(payload.getData() instanceof J2735Bsm);
+        var data = (J2735Bsm)payload.getData();
+        assertNotNull(data.getPartII());
+        assertTrue(data.getPartII().size() == 1);
+        assertTrue(data.getPartII().get(0).getValue() instanceof J2735VehicleSafetyExtensions);
     }
 
     @Test
@@ -28,6 +36,12 @@ public class OdeBsmDataTest {
         assertNotNull(deserialized);
         assertTrue(deserialized.getMetadata() instanceof OdeBsmMetadata);
         assertTrue(deserialized.getPayload() instanceof OdeBsmPayload);
-        
+        var payload = (OdeBsmPayload)deserialized.getPayload();
+        assertTrue(payload.getData() instanceof J2735Bsm);
+        var data = (J2735Bsm)payload.getData();
+        assertNotNull(data.getPartII());
+        assertTrue(data.getPartII().size() == 2);
+        assertTrue(data.getPartII().get(0).getValue() instanceof J2735VehicleSafetyExtensions);
+        assertTrue(data.getPartII().get(1).getValue() instanceof J2735SupplementalVehicleExtensions);
     }
 }

--- a/jpo-ode-core/src/test/java/us/dot/its/jpo/ode/model/OdeMapDataTest.java
+++ b/jpo-ode-core/src/test/java/us/dot/its/jpo/ode/model/OdeMapDataTest.java
@@ -1,0 +1,20 @@
+package us.dot.its.jpo.ode.model;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import us.dot.its.jpo.ode.util.JsonUtils;
+
+public class OdeMapDataTest {
+    @Test
+    public void shouldDeserializeJson() {
+
+        final String bsmJson = "{\"metadata\":{\"logFileName\":\"\",\"recordType\":\"mapTx\",\"securityResultCode\":\"success\",\"receivedMessageDetails\":{\"locationData\":null,\"rxSource\":\"NA\"},\"encodings\":null,\"payloadType\":\"us.dot.its.jpo.ode.model.OdeMapPayload\",\"serialId\":{\"streamId\":\"18d7c2e0-9158-4456-916d-5cd4b080d290\",\"bundleSize\":1,\"bundleId\":0,\"recordId\":0,\"serialNumber\":0},\"odeReceivedAt\":\"2022-06-17T19:02:13.083984Z\",\"schemaVersion\":6,\"maxDurationTime\":0,\"recordGeneratedAt\":\"\",\"recordGeneratedBy\":null,\"sanitized\":false,\"odePacketID\":\"\",\"odeTimStartDateTime\":\"\",\"mapSource\":\"RSU\",\"originIp\":\"10.11.81.25\"},\"payload\":{\"data\":{\"timeStamp\":null,\"msgIssueRevision\":2,\"layerType\":\"intersectionData\",\"layerID\":0,\"intersections\":null,\"roadSegments\":null,\"dataParameters\":null,\"restrictionList\":null},\"dataType\":\"us.dot.its.jpo.ode.plugin.j2735.J2735MAP\"}}";
+
+        var deserialized = (OdeMapData)JsonUtils.fromJson(bsmJson, OdeMapData.class);
+        assertNotNull(deserialized);
+        assertTrue(deserialized.getMetadata() instanceof OdeMapMetadata);
+        assertTrue(deserialized.getPayload() instanceof OdeMapPayload);
+        
+    }
+}

--- a/jpo-ode-core/src/test/java/us/dot/its/jpo/ode/model/OdeSpatDataTest.java
+++ b/jpo-ode-core/src/test/java/us/dot/its/jpo/ode/model/OdeSpatDataTest.java
@@ -1,0 +1,20 @@
+package us.dot.its.jpo.ode.model;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import us.dot.its.jpo.ode.util.JsonUtils;
+
+public class OdeSpatDataTest {
+    @Test
+    public void shouldDeserializeJson() {
+
+        final String bsmJson = "{\"metadata\":{\"logFileName\":\"\",\"recordType\":\"spatTx\",\"securityResultCode\":\"success\",\"receivedMessageDetails\":{\"locationData\":null,\"rxSource\":\"NA\"},\"encodings\":null,\"payloadType\":\"us.dot.its.jpo.ode.model.OdeSpatPayload\",\"serialId\":{\"streamId\":\"24d9dfcb-1ca0-41b8-8576-f4a00a51218e\",\"bundleSize\":1,\"bundleId\":0,\"recordId\":0,\"serialNumber\":0},\"odeReceivedAt\":\"2022-06-17T19:02:05.366148Z\",\"schemaVersion\":6,\"maxDurationTime\":0,\"recordGeneratedAt\":\"\",\"recordGeneratedBy\":null,\"sanitized\":false,\"odePacketID\":\"\",\"odeTimStartDateTime\":\"\",\"spatSource\":\"V2X\",\"originIp\":\"10.11.81.12\",\"isCertPresent\":false},\"payload\":{\"data\":{\"timeStamp\":null,\"name\":null,\"intersectionStateList\":null},\"dataType\":\"us.dot.its.jpo.ode.plugin.j2735.J2735SPAT\"}}";
+
+        var deserialized = (OdeSpatData)JsonUtils.fromJson(bsmJson, OdeSpatData.class);
+        assertNotNull(deserialized);
+        assertTrue(deserialized.getMetadata() instanceof OdeSpatMetadata);
+        assertTrue(deserialized.getPayload() instanceof OdeSpatPayload);
+        
+    }
+}

--- a/jpo-ode-core/src/test/java/us/dot/its/jpo/ode/model/OdeSrmDataTest.java
+++ b/jpo-ode-core/src/test/java/us/dot/its/jpo/ode/model/OdeSrmDataTest.java
@@ -1,0 +1,20 @@
+package us.dot.its.jpo.ode.model;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import us.dot.its.jpo.ode.util.JsonUtils;
+
+public class OdeSrmDataTest {
+    @Test
+    public void shouldDeserializeJson() {
+
+        final String bsmJson = "{\"metadata\":{\"logFileName\":\"\",\"recordType\":\"srmTx\",\"securityResultCode\":null,\"receivedMessageDetails\":{\"locationData\":null,\"rxSource\":\"NA\"},\"encodings\":null,\"payloadType\":\"us.dot.its.jpo.ode.model.OdeSrmPayload\",\"serialId\":{\"streamId\":\"c3ff825f-ed1f-4411-a12e-1ba889f56483\",\"bundleSize\":1,\"bundleId\":0,\"recordId\":0,\"serialNumber\":0},\"odeReceivedAt\":\"2022-12-13T18:58:53.541816Z\",\"schemaVersion\":6,\"maxDurationTime\":0,\"recordGeneratedAt\":\"\",\"recordGeneratedBy\":null,\"sanitized\":false,\"odePacketID\":\"\",\"odeTimStartDateTime\":\"\",\"originIp\":\"172.21.0.1\",\"srmSource\":\"RSU\"},\"payload\":{\"data\":{\"timeStamp\":null,\"second\":0,\"sequenceNumber\":1,\"requests\":{\"signalRequestPackage\":[{\"request\":{\"id\":{\"region\":null,\"id\":12109},\"requestID\":4,\"requestType\":\"priorityRequest\",\"inBoundLane\":{\"lane\":13,\"approach\":null,\"connection\":null},\"outBoundLane\":{\"lane\":4,\"approach\":null,\"connection\":null}},\"minute\":null,\"second\":null,\"duration\":10979}]},\"requestor\":{\"id\":{\"entityID\":null,\"stationID\":2366845094},\"type\":{\"role\":\"publicTransport\",\"subrole\":null,\"request\":null,\"iso3883\":null,\"hpmsType\":null},\"position\":{\"position\":{\"latitude\":39.5904915,\"longitude\":-105.0913829,\"elevation\":1685.4},\"heading\":175.9000,\"speed\":null},\"name\":null,\"routeName\":null,\"transitStatus\":null,\"transitOccupancy\":null,\"transitSchedule\":null}},\"dataType\":\"us.dot.its.jpo.ode.plugin.j2735.J2735SRM\"}}";
+
+        var deserialized = (OdeSrmData)JsonUtils.fromJson(bsmJson, OdeSrmData.class);
+        assertNotNull(deserialized);
+        assertTrue(deserialized.getMetadata() instanceof OdeSrmMetadata);
+        assertTrue(deserialized.getPayload() instanceof OdeSrmPayload);
+        
+    }
+}

--- a/jpo-ode-core/src/test/java/us/dot/its/jpo/ode/model/OdeSsmDataTest.java
+++ b/jpo-ode-core/src/test/java/us/dot/its/jpo/ode/model/OdeSsmDataTest.java
@@ -1,0 +1,20 @@
+package us.dot.its.jpo.ode.model;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import us.dot.its.jpo.ode.util.JsonUtils;
+
+public class OdeSsmDataTest {
+    @Test
+    public void shouldDeserializeJson() {
+
+        final String bsmJson = "{\"metadata\":{\"logFileName\":\"\",\"recordType\":\"ssmTx\",\"securityResultCode\":null,\"receivedMessageDetails\":{\"locationData\":null,\"rxSource\":\"NA\"},\"encodings\":null,\"payloadType\":\"us.dot.its.jpo.ode.model.OdeSsmPayload\",\"serialId\":{\"streamId\":\"b9801eb3-66fb-4d36-ae08-3e8f2bcb2026\",\"bundleSize\":1,\"bundleId\":0,\"recordId\":0,\"serialNumber\":0},\"odeReceivedAt\":\"2022-12-13T19:00:42.326229Z\",\"schemaVersion\":6,\"maxDurationTime\":0,\"recordGeneratedAt\":\"\",\"recordGeneratedBy\":null,\"sanitized\":false,\"odePacketID\":\"\",\"odeTimStartDateTime\":\"\",\"originIp\":\"172.21.0.1\",\"ssmSource\":\"RSU\"},\"payload\":{\"data\":{\"timeStamp\":null,\"second\":0,\"sequenceNumber\":null,\"status\":{\"signalStatus\":[{\"sequenceNumber\":0,\"id\":{\"region\":null,\"id\":12110},\"sigStatus\":{\"signalStatusPackage\":[{\"requester\":{\"id\":{\"entityID\":null,\"stationID\":2366845094},\"request\":3,\"sequenceNumber\":0,\"role\":null,\"typeData\":{\"role\":\"publicTransport\",\"subrole\":null,\"request\":null,\"iso3883\":null,\"hpmsType\":null}},\"inboundOn\":{\"lane\":23,\"approach\":null,\"connection\":null},\"outboundOn\":null,\"minute\":null,\"second\":null,\"duration\":null,\"status\":\"granted\"}]}}]}},\"dataType\":\"us.dot.its.jpo.ode.plugin.j2735.J2735SSM\"}}";
+
+        var deserialized = (OdeSsmData)JsonUtils.fromJson(bsmJson, OdeSsmData.class);
+        assertNotNull(deserialized);
+        assertTrue(deserialized.getMetadata() instanceof OdeSsmMetadata);
+        assertTrue(deserialized.getPayload() instanceof OdeSsmPayload);
+        
+    }
+}

--- a/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/J2735BsmPart2Content.java
+++ b/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/J2735BsmPart2Content.java
@@ -15,6 +15,13 @@
  ******************************************************************************/
 package us.dot.its.jpo.ode.plugin.j2735;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.*;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+
 import us.dot.its.jpo.ode.plugin.asn1.Asn1Object;
 
 public class J2735BsmPart2Content extends Asn1Object {
@@ -47,6 +54,15 @@ public class J2735BsmPart2Content extends Asn1Object {
 		return value;
 	}
 
+    @JsonTypeInfo(
+        use = Id.NAME, 
+        include = As.EXTERNAL_PROPERTY, 
+        property = "id")
+    @JsonSubTypes({
+        @Type(value = J2735VehicleSafetyExtensions.class, name = "VehicleSafetyExtensions"),
+        @Type(value = J2735SupplementalVehicleExtensions.class, name = "SupplementalVehicleExtensions"),
+        @Type(value = J2735SpecialVehicleExtensions.class, name = "SpecialVehicleExtensions")
+    })
 	public void setValue(J2735BsmPart2ExtensionBase value) {
 		this.value = value;
 	}

--- a/jpo-ode-plugins/src/test/java/us/dot/its/jpo/ode/plugin/j2735/J2735BsmPart2ContentTest.java
+++ b/jpo-ode-plugins/src/test/java/us/dot/its/jpo/ode/plugin/j2735/J2735BsmPart2ContentTest.java
@@ -1,0 +1,52 @@
+package us.dot.its.jpo.ode.plugin.j2735;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+import static us.dot.its.jpo.ode.plugin.j2735.J2735BsmPart2Content.J2735BsmPart2Id.*;
+
+import us.dot.its.jpo.ode.util.JsonUtils;
+
+public class J2735BsmPart2ContentTest {
+
+
+    
+    @Test
+    public void shouldDeserializeBsmPart2Content_VehicleSafetyExtensions() {
+
+        final String bsmJson = "{\"id\":\"VehicleSafetyExtensions\",\"value\":{\"pathHistory\":{\"crumbData\":[{\"elevationOffset\":0.0,\"latOffset\":-0.0000491,\"lonOffset\":-0.0000043,\"timeOffset\":0.39},{\"elevationOffset\":-1.1,\"latOffset\":-0.0007303,\"lonOffset\":-0.0001015,\"timeOffset\":6.79},{\"elevationOffset\":-1.1,\"latOffset\":-0.0012664,\"lonOffset\":-0.0002581,\"timeOffset\":10.9},{\"elevationOffset\":-0.7,\"latOffset\":-0.0018413,\"lonOffset\":-0.0005267,\"timeOffset\":14.39}]},\"pathPrediction\":{\"confidence\":70.0,\"radiusOfCurve\":-3139.0}}}";
+
+        var deserialized = (J2735BsmPart2Content)JsonUtils.fromJson(bsmJson, J2735BsmPart2Content.class);
+
+        assertNotNull(deserialized);
+        assertEquals(deserialized.getId(), VehicleSafetyExtensions);
+        assertTrue(deserialized.getValue() instanceof J2735VehicleSafetyExtensions);
+        var extensions = (J2735VehicleSafetyExtensions)deserialized.getValue();
+        assertNotNull(extensions.getPathHistory());
+        assertNotNull(extensions.getPathPrediction());
+    }
+
+    @Test
+    public void shouldDeserializeBsmPart2Content_SupplementalVehicleExtensions() {
+        final String bsmJson = "{\"id\":\"SupplementalVehicleExtensions\",\"value\":{\"classification\":null,\"classDetails\":null,\"vehicleData\":null,\"weatherReport\":null,\"weatherProbe\":null,\"obstacle\":null,\"status\":null,\"speedProfile\":null,\"theRTCM\":null}}";
+
+        var deserialized = (J2735BsmPart2Content)JsonUtils.fromJson(bsmJson, J2735BsmPart2Content.class);
+
+        assertNotNull(deserialized);
+        assertEquals(deserialized.getId(), SupplementalVehicleExtensions);
+        assertTrue(deserialized.getValue() instanceof J2735SupplementalVehicleExtensions);
+    }
+
+    @Test
+    public void shouldDeserializeBsmPart2Content_SpecialVehicleExtensions() {
+        final String bsmJson = "{\"id\":\"SpecialVehicleExtensions\",\"value\":{\"vehicleAlerts\":null,\"description\":null,\"trailers\":null}}";
+
+        var deserialized = (J2735BsmPart2Content)JsonUtils.fromJson(bsmJson, J2735BsmPart2Content.class);
+
+        assertNotNull(deserialized);
+        assertEquals(deserialized.getId(), SpecialVehicleExtensions);
+        assertTrue(deserialized.getValue() instanceof J2735SpecialVehicleExtensions);
+    }
+}

--- a/scripts/tests/udpsender_bsm.py
+++ b/scripts/tests/udpsender_bsm.py
@@ -1,0 +1,19 @@
+import socket
+import time
+import os
+
+# Currently set to oim-dev environment's ODE
+UDP_IP = os.getenv('DOCKER_HOST_IP')
+UDP_PORT = 46800
+MESSAGE = "0022e12d18466c65c1493800000e00e4616183e85a8f0100c000038081bc001480b8494c4c950cd8cde6e9651116579f22a424dd78fffff00761e4fd7eb7d07f7fff80005f11d1020214c1c0ffc7c016aff4017a0ff65403b0fd204c20ffccc04f8fe40c420ffe6404cefe60e9a10133408fcfde1438103ab4138f00e1eec1048ec160103e237410445c171104e26bc103dc4154305c2c84103b1c1c8f0a82f42103f34262d1123198103dac25fb12034ce10381c259f12038ca103574251b10e3b2210324c23ad0f23d8efffe0000209340d10000004264bf00"
+
+print("UDP target IP:", UDP_IP)
+print("UDP target port:", UDP_PORT)
+#print("message:", MESSAGE)
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM) # UDP
+
+while True:
+  time.sleep(5)
+  print("sending BSM every 5 second")
+  sock.sendto(bytes.fromhex(MESSAGE), (UDP_IP, UDP_PORT))


### PR DESCRIPTION
# PR Details
## Description

<!--- Describe your changes in detail -->
Adds the ability to deserialize JSON data for OdeData objects related to connected intersections: (MAP, SPAT, BSM, SRM, and SSM) in the conventional way using Jackson, without having to create custom deserializer classes.

## Implementation

Adds overridden setters with Jackson annotations to the following classes to enable Jackson to deserialize JSON into them.
* OdeBsmData
* OdeMapData
* OdeSpatData
* OdeSrmData
* OdeSsmData

The annotations remove the ambiguity for the deserializer about which implementation class to create for the base classes
`OdeMsgMetadata` and `OdeMsgPayload`.

Adds Jackson annotations to the `J2735BsmPart2Content` value setter to disambiguate which implementation of the BSM Part II extension base class to use. 


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
See [Issue #486 Deserializing JSON to OdeData Objects](https://github.com/usdot-jpo-ode/jpo-ode/issues/486)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The motivation is explained in the above issue.

## Scope of this PR
This PR does not fix the JSON deserialization issue for other OdeData objects that are not directly related to connected intersections such as TIM messages.

## How Has This Been Tested?

### Unit Tests ###
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The following classes in `jpo-ode-core` were created to test deserializing JSON:
* OdeBsmDataTest
* OdeMapDataTest
* OdeSpatDataTest
* OdeSrmDataTest
* OdeSsmDataTest

The following class in `jpo-ode-plugins` adds tests for BSM Part II deserialization:
* J2735BsmPart2ContentTest


### Integration Tests ###

In addition to unit tests, we also ran the integration test scripts in the `scripts/tests` directory with the ODE running in Docker while monitoring the OdeX__Json topics, to verify that these changes did not break the ODE's UPER -> XML -> JSON decoding functionality.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

