### PR TITLE
SRM empty requests list handling fix

### DIFF
--- a/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/builders/SRMBuilder.java
+++ b/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/builders/SRMBuilder.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.codehaus.groovy.runtime.powerassert.SourceText;
 
 import us.dot.its.jpo.ode.plugin.j2735.J2735SRM;
+import us.dot.its.jpo.ode.plugin.j2735.J2735SignalRequestList;
 
 public class SRMBuilder {
 
@@ -39,7 +40,13 @@ public class SRMBuilder {
 		JsonNode requests = SRMMessage.get("requests");
 		if(requests != null)
 		{
-			genericSRM.setRequests(SignalRequestListBuilder.genericSignalRequestList(requests));	
+			J2735SignalRequestList signalRequestList = SignalRequestListBuilder.genericSignalRequestList(requests);
+			if (signalRequestList.getRequests().size() > 0) {
+				genericSRM.setRequests(signalRequestList);	
+			}
+			else {
+				genericSRM.setRequests(null);	
+			}
 		}
 		
         JsonNode requestor = SRMMessage.get("requestor");

--- a/jpo-ode-plugins/src/test/java/us/dot/its/jpo/ode/plugin/j2735/builders/SRMBuilderTest.java
+++ b/jpo-ode-plugins/src/test/java/us/dot/its/jpo/ode/plugin/j2735/builders/SRMBuilderTest.java
@@ -27,4 +27,20 @@ public class SRMBuilderTest {
 		assertEquals(expected, actualSrm.toString()); 
 		
 	}
+
+    @Test
+	public void shouldTranslateSrmEmptyRequestList() {
+
+		JsonNode jsonMap = null;
+		try {
+			jsonMap = XmlUtils.toObjectNode(
+					"<OdeAsn1Data><metadata><payloadType>us.dot.its.jpo.ode.model.OdeAsn1Payload</payloadType><serialId><streamId>18c95c67-a1bd-43e9-b93d-6480b59f8c81</streamId><bundleSize>1</bundleSize><bundleId>0</bundleId><recordId>0</recordId><serialNumber>0</serialNumber></serialId><odeReceivedAt>2021-10-07T06:29:31.198419Z</odeReceivedAt><schemaVersion>6</schemaVersion><maxDurationTime>0</maxDurationTime><odePacketID/><odeTimStartDateTime/><recordGeneratedAt/><recordGeneratedBy/><sanitized>false</sanitized><logFileName/><recordType>srmTx</recordType><securityResultCode/><receivedMessageDetails/><encodings><encodings><elementName>unsecuredData</elementName><elementType>MessageFrame</elementType><encodingRule>UPER</encodingRule></encodings></encodings><originIp>172.250.250.77</originIp><srmSource>RSU</srmSource></metadata><payload><dataType>MessageFrame</dataType><data><MessageFrame><messageId>29</messageId><value><SignalRequestMessage><second>0</second><sequenceNumber>1</sequenceNumber><requests></requests><requestor><id><stationID>2366845094</stationID></id><type><role><publicTransport/></role></type><position><position><lat>395904915</lat><long>-1050913829</long><elevation>16854</elevation></position><heading>14072</heading></position></requestor></SignalRequestMessage></value></MessageFrame></data></payload></OdeAsn1Data>");
+		} catch (XmlUtilsException e) {
+			fail("XML parsing error:" + e);
+		}
+		J2735SRM actualSrm = SRMBuilder.genericSRM(jsonMap.findValue("SignalRequestMessage"));	
+		String expected ="{\"second\":0,\"sequenceNumber\":1,\"requestor\":{\"id\":{\"stationID\":2366845094},\"type\":{\"role\":\"publicTransport\"},\"position\":{\"position\":{\"latitude\":39.5904915,\"longitude\":-105.0913829,\"elevation\":1685.4},\"heading\":175.9000}}}";
+		assertEquals(expected, actualSrm.toString()); 
+		
+	}
 }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
When a SRM has an empty request list in the XML output, it is handled as being null.

`<requests></requests>` now converts to the JSON: `"requests": null` instead of `"requests": {"signalRequestPackage": []}`.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#488 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
CDOT RSUs sometimes receive SRM messages with no requests inside the request list but the object is still included in the ASN1 message so the Asn1_Codec includes it. This is perfectly legal according to J2735 but is handled improperly by the ODE due to how it creates the list POJO.

When decoding SRMs with an empty requests list, the ODE generates a requests object with a list that is empty. This causes schemas to fail. If there is a signalRequestPackage list, it should not be empty according to J2735. This value should instead be null and will be properly accepted by the SRM schema.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A new unit test has been added for this specific corner case.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
