### PR TITLE
Update all message type JSON schemas to current ODE output

### DIFF
--- a/docs/schemas/README.md
+++ b/docs/schemas/README.md
@@ -1,0 +1,26 @@
+# jpo-ode JSON Output Schemas
+
+The jpo-ode supports receiving and decoding ASN1 messages from RSUs. The supported message types are currently BSM, MAP, SPaT, SRM and SSM. These are decoded into XML, deserialized into POJOs and finally serialized into JSON. This JSON output can be access from any of the corresponding message's JSON output Kafka topics:
+
+- [topic.OdeBsmJson](schema-bsm.json)
+- [topic.OdeMapJson](schema-map.json)
+- [topic.OdeSpatJson](schema-spat.json)
+- [topic.OdeSrmJson](schema-srm.json)
+- [topic.OdeSsmJson](schema-ssm.json)
+
+The output JSON of the ODE is complex but it is similar to the official standard of J2735 with some minor differences due to the form of their deserialized POJOs. To help implement proper data validation for the JSON output of the ODE into any data pipeline infrastruture, you may use the provided validation schemas within this directory.
+
+## Testing the schemas
+These schemas can be used for manual validation in the following steps:
+1. To perform a simple schema validation check against output JSON data from the jpo-ode, you may use a schema validation site such as https://www.jsonschemavalidator.net. 
+2. Retrieve a jpo-ode output message from the specific message type you would like to validate.
+   - Example for retreiving output BSM with kafkacat: `kafkacat -b kafka-broker-ip:9092 -G my_consumer_group topic.OdeBsmJson -f '\nTopic: %t, Key: %k, Offset: %o, Timestamp: %T\nValue: %s\n'`
+3. Copy and paste the provided schema into the left panel for the message type you plan to validate. 
+4. Copy and paste the output JSON data from the jpo-ode to the right panel.
+5. The site will describe any fields that may be incorrect or provide a green checkmark for a proper validation of the data.
+
+## Next steps
+These schemas can be used for automatic validation if used as a step in a data pipeline. 
+- Many of the cloud services have message pipelines and provide different options to validate incoming data, including schema validation. 
+- Confluent provides a service known as schema registry which is easy to configure as a part of a Kafka deployment to automatically validate messages as they are produced.
+- Configuring KafkaStreams to validate jpo-ode output before processing the data further in a custom solution.

--- a/docs/schemas/README.md
+++ b/docs/schemas/README.md
@@ -8,13 +8,13 @@ The jpo-ode supports receiving and decoding ASN1 messages from RSUs. The support
 - [topic.OdeSrmJson](schema-srm.json)
 - [topic.OdeSsmJson](schema-ssm.json)
 
-The output JSON of the ODE is complex but it is similar to the official standard of J2735 with some minor differences due to the form of their deserialized POJOs. To help implement proper data validation for the JSON output of the ODE into any data pipeline infrastruture, you may use the provided validation schemas within this directory.
+The output JSON of the ODE is complex but it is similar to the official standard of J2735 with some minor differences due to the form of their deserialized POJOs. To help implement proper data validation for the JSON output of the ODE into any data pipeline infrastructure, you may use the provided validation schemas within this directory.
 
 ## Testing the schemas
 These schemas can be used for manual validation in the following steps:
 1. To perform a simple schema validation check against output JSON data from the jpo-ode, you may use a schema validation site such as https://www.jsonschemavalidator.net. 
 2. Retrieve a jpo-ode output message from the specific message type you would like to validate.
-   - Example for retreiving output BSM with kafkacat: `kafkacat -b kafka-broker-ip:9092 -G my_consumer_group topic.OdeBsmJson -f '\nTopic: %t, Key: %k, Offset: %o, Timestamp: %T\nValue: %s\n'`
+   - Example for retrieving output BSM with kafkacat: `kafkacat -b kafka-broker-ip:9092 -G my_consumer_group topic.OdeBsmJson -f '\nTopic: %t, Key: %k, Offset: %o, Timestamp: %T\nValue: %s\n'`
 3. Copy and paste the provided schema into the left panel for the message type you plan to validate. 
 4. Copy and paste the output JSON data from the jpo-ode to the right panel.
 5. The site will describe any fields that may be incorrect or provide a green checkmark for a proper validation of the data.

--- a/docs/schemas/schema-bsm.json
+++ b/docs/schemas/schema-bsm.json
@@ -1,2272 +1,2207 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "additionalProperties": false,
   "properties": {
-    "metadata": {
-      "additionalProperties": false,
-      "properties": {
-        "bsmSource": {
-          "enum": [
-            "EV",
-            "RV",
-            "unknown"
-          ],
-          "type": "string"
-        },
-        "encodings": {
-          "items": {
-            "additionalProperties": false,
-            "properties": {
-              "elementName": {
-                "type": "string"
-              },
-              "elementType": {
-                "type": "string"
-              },
-              "encodingRule": {
-                "enum": [
-                  "UPER",
-                  "COER"
-                ],
-                "type": "string"
-              }
-            },
-            "required": [
-              "elementName",
-              "elementType",
-              "encodingRule"
-            ],
-            "type": "object"
-          },
-          "type": [
-            "array",
-            "null"
-          ]
-        },
-        "logFileName": {
-          "type": "string"
-        },
-        "maxDurationTime": {
-          "type": [
-            "integer",
-            "null"
-          ]
-        },
-        "odePacketID": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "odeReceivedAt": {
-          "type": "string"
-        },
-        "odeTimStartDateTime": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "originIp": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "payloadType": {
-          "type": "string"
-        },
-        "receivedMessageDetails": {
-          "additionalProperties": false,
+      "metadata": {
           "properties": {
-            "locationData": {
-              "additionalProperties": false,
-              "properties": {
-                "elevation": {
+              "@class": {
                   "type": "string"
-                },
-                "heading": {
-                  "type": "string"
-                },
-                "latitude": {
-                  "type": "string"
-                },
-                "longitude": {
-                  "type": "string"
-                },
-                "speed": {
-                  "type": "string"
-                }
               },
-              "required": [
-                "latitude",
-                "longitude",
-                "elevation",
-                "speed",
-                "heading"
-              ],
-              "type": "object"
-            },
-            "rxSource": {
-              "enum": [
-                "RSU",
-                "SAT",
-                "RV",
-                "SNMP",
-                "NA",
-                "UNKNOWN"
-              ],
-              "type": "string"
-            }
-          },
-          "required": [
-            "locationData",
-            "rxSource"
-          ],
-          "type": "object"
-        },
-        "recordGeneratedAt": {
-          "type": "string"
-        },
-        "recordGeneratedBy": {
-          "enum": [
-            "TMC",
-            "OBU",
-            "RSU",
-            "TMC_VIA_SAT",
-            "TMC_VIA_SNMP",
-            "UNKNOWN",
-            null
-          ],
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "recordType": {
-          "enum": [
-            "bsmLogDuringEvent",
-            "rxMsg",
-            "dnMsg",
-            "bsmTx",
-            "driverAlert",
-            "spatTx",
-            "timMsg",
-            "unsupported"
-          ],
-          "type": "string"
-        },
-        "sanitized": {
-          "type": "boolean"
-        },
-        "schemaVersion": {
-          "const": 6,
-          "type": "integer"
-        },
-        "securityResultCode": {
-          "enum": [
-            "success",
-            "unknown",
-            "inconsistentInputParameters",
-            "spduParsingInvalidInput",
-            "spduParsingUnsupportedCriticalInformationField",
-            "spduParsingCertificateNotFound",
-            "spduParsingGenerationTimeNotAvailable",
-            "spduParsingGenerationLocationNotAvailable",
-            "spduCertificateChainNotEnoughInformationToConstructChain",
-            "spduCertificateChainChainEndedAtUntrustedRoot",
-            "spduCertificateChainChainWasTooLongForImplementation",
-            "spduCertificateChainCertificateRevoked",
-            "spduCertificateChainOverdueCRL",
-            "spduCertificateChainInconsistentExpiryTimes",
-            "spduCertificateChainInconsistentStartTimes",
-            "spduCertificateChainInconsistentChainPermissions",
-            "spduCryptoVerificationFailure",
-            "spduConsistencyFutureCertificateAtGenerationTime",
-            "spduConsistencyExpiredCertificateAtGenerationTime",
-            "spduConsistencyExpiryDateTooEarly",
-            "spduConsistencyExpiryDateTooLate",
-            "spduConsistencyGenerationLocationOutsideValidityRegion",
-            "spduConsistencyNoGenerationLocation",
-            "spduConsistencyUnauthorizedPSID",
-            "spduInternalConsistencyExpiryTimeBeforeGenerationTime",
-            "spduInternalConsistencyextDataHashDoesntMatch",
-            "spduInternalConsistencynoExtDataHashProvided",
-            "spduInternalConsistencynoExtDataHashPresent",
-            "spduLocalConsistencyPSIDsDontMatch",
-            "spduLocalConsistencyChainWasTooLongForSDEE",
-            "spduRelevanceGenerationTimeTooFarInPast",
-            "spduRelevanceGenerationTimeTooFarInFuture",
-            "spduRelevanceExpiryTimeInPast",
-            "spduRelevanceGenerationLocationTooDistant",
-            "spduRelevanceReplayedSpdu",
-            "spduCertificateExpired"
-          ],
-          "type": "string"
-        },
-        "serialId": {
-          "additionalProperties": false,
-          "properties": {
-            "bundleId": {
-              "type": "integer"
-            },
-            "bundleSize": {
-              "type": "integer"
-            },
-            "recordId": {
-              "type": "integer"
-            },
-            "serialNumber": {
-              "type": "integer"
-            },
-            "streamId": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "streamId",
-            "bundleSize",
-            "bundleId",
-            "recordId",
-            "serialNumber"
-          ],
-          "type": "object"
-        }
-      },
-      "required": [
-        "bsmSource",
-        "logFileName",
-        "recordType",
-        "securityResultCode",
-        "receivedMessageDetails",
-        "payloadType",
-        "serialId",
-        "odeReceivedAt",
-        "schemaVersion",
-        "recordGeneratedAt",
-        "sanitized"
-      ],
-      "type": "object"
-    },
-    "payload": {
-      "additionalProperties": false,
-      "properties": {
-        "data": {
-          "additionalProperties": false,
-          "properties": {
-            "coreData": {
-              "additionalProperties": false,
-              "properties": {
-                "accelSet": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "accelLat": {
-                      "type": [
-                        "number",
-                        "null"
-                      ]
-                    },
-                    "accelLong": {
-                      "type": "number"
-                    },
-                    "accelVert": {
-                      "type": [
-                        "number",
-                        "null"
-                      ]
-                    },
-                    "accelYaw": {
-                      "type": "number"
-                    }
-                  },
-                  "required": [
-                    "accelLong",
-                    "accelYaw"
+              "bsmSource": {
+                  "enum": [
+                      "EV",
+                      "RV",
+                      "unknown"
                   ],
-                  "type": "object"
-                },
-                "accuracy": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "orientation": {
-                      "type": [
-                        "number",
-                        "null"
-                      ]
-                    },
-                    "semiMajor": {
-                      "type": [
-                        "number",
-                        "null"
-                      ]
-                    },
-                    "semiMinor": {
-                      "type": [
-                        "number",
-                        "null"
-                      ]
-                    }
-                  },
-                  "required": [],
-                  "type": "object"
-                },
-                "angle": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                },
-                "brakes": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "abs": {
-                      "type": "string"
-                    },
-                    "auxBrakes": {
-                      "type": "string"
-                    },
-                    "brakeBoost": {
-                      "type": "string"
-                    },
-                    "scs": {
-                      "type": "string"
-                    },
-                    "traction": {
-                      "type": "string"
-                    },
-                    "wheelBrakes": {
-                      "additionalProperties": false,
+                  "type": "string"
+              },
+              "encodings": {
+                  "items": {
                       "properties": {
-                        "leftFront": {
-                          "type": "boolean"
-                        },
-                        "leftRear": {
-                          "type": "boolean"
-                        },
-                        "rightFront": {
-                          "type": "boolean"
-                        },
-                        "rightRear": {
-                          "type": "boolean"
-                        },
-                        "unavailable": {
-                          "type": "boolean"
-                        }
+                          "elementName": {
+                              "type": "string"
+                          },
+                          "elementType": {
+                              "type": "string"
+                          },
+                          "encodingRule": {
+                              "enum": [
+                                  "UPER",
+                                  "COER"
+                              ],
+                              "type": "string"
+                          }
                       },
                       "required": [
-                        "unavailable",
-                        "leftFront",
-                        "leftRear",
-                        "rightFront",
-                        "rightRear"
+                          "elementName",
+                          "elementType",
+                          "encodingRule"
                       ],
                       "type": "object"
-                    }
                   },
-                  "required": [
-                    "wheelBrakes",
-                    "traction",
-                    "abs",
-                    "scs",
-                    "brakeBoost",
-                    "auxBrakes"
-                  ],
-                  "type": "object"
-                },
-                "heading": {
-                  "type": "number"
-                },
-                "id": {
-                  "type": "string"
-                },
-                "msgCnt": {
-                  "type": "integer"
-                },
-                "position": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "elevation": {
-                      "type": [
-                        "number",
-                        "null"
-                      ]
-                    },
-                    "latitude": {
-                      "type": "number"
-                    },
-                    "longitude": {
-                      "type": "number"
-                    }
-                  },
-                  "required": [
-                    "latitude",
-                    "longitude"
-                  ],
-                  "type": "object"
-                },
-                "secMark": {
-                  "type": "integer"
-                },
-                "size": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "length": {
-                      "type": [
-                        "integer",
-                        "null"
-                      ]
-                    },
-                    "width": {
-                      "type": [
-                        "integer",
-                        "null"
-                      ]
-                    }
-                  },
-                  "required": [],
-                  "type": "object"
-                },
-                "speed": {
-                  "type": "number"
-                },
-                "transmission": {
-                  "enum": [
-                    "NEUTRAL",
-                    "PARK",
-                    "FORWARDGEARS",
-                    "REVERSEGEARS",
-                    "RESERVED1",
-                    "RESERVED2",
-                    "RESERVED3",
-                    "UNAVAILABLE"
-                  ],
-                  "type": "string"
-                }
+                  "type": [
+                      "array",
+                      "null"
+                  ]
               },
-              "required": [
-                "msgCnt",
-                "id",
-                "secMark",
-                "position",
-                "accelSet",
-                "accuracy",
-                "transmission",
-                "speed",
-                "heading",
-                "brakes",
-                "size"
-              ],
-              "type": "object"
-            },
-            "partII": {
-              "items": {
-                "oneOf": [
-                  {
-                    "additionalProperties": false,
-                    "properties": {
-                      "id": {
-                        "const": "VehicleSafetyExtensions",
-                        "type": "string"
-                      },
-                      "value": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "events": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "eventABSactivated": {
-                                "type": "boolean"
-                              },
-                              "eventAirBagDeployment": {
-                                "type": "boolean"
-                              },
-                              "eventDisabledVehicle": {
-                                "type": "boolean"
-                              },
-                              "eventFlatTire": {
-                                "type": "boolean"
-                              },
-                              "eventHardBraking": {
-                                "type": "boolean"
-                              },
-                              "eventHazardLights": {
-                                "type": "boolean"
-                              },
-                              "eventHazardousMaterials": {
-                                "type": "boolean"
-                              },
-                              "eventLightsChanged": {
-                                "type": "boolean"
-                              },
-                              "eventReserved1": {
-                                "type": "boolean"
-                              },
-                              "eventStabilityControlactivated": {
-                                "type": "boolean"
-                              },
-                              "eventStopLineViolation": {
-                                "type": "boolean"
-                              },
-                              "eventTractionControlLoss": {
-                                "type": "boolean"
-                              },
-                              "eventWipersChanged": {
-                                "type": "boolean"
-                              }
-                            },
-                            "required": [
-                              "eventHazardLights",
-                              "eventStopLineViolation",
-                              "eventABSactivated",
-                              "eventTractionControlLoss",
-                              "eventStabilityControlactivated",
-                              "eventHazardousMaterials",
-                              "eventReserved1",
-                              "eventHardBraking",
-                              "eventLightsChanged",
-                              "eventWipersChanged",
-                              "eventFlatTire",
-                              "eventDisabledVehicle",
-                              "eventAirBagDeployment"
-                            ],
-                            "type": [
-                              "object",
-                              "null"
-                            ]
-                          },
-                          "lights": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "automaticLightControlOn": {
-                                "type": "boolean"
-                              },
-                              "daytimeRunningLightsOn": {
-                                "type": "boolean"
-                              },
-                              "fogLightOn": {
-                                "type": "boolean"
-                              },
-                              "hazardSignalOn": {
-                                "type": "boolean"
-                              },
-                              "highBeamHeadlightsOn": {
-                                "type": "boolean"
-                              },
-                              "leftTurnSignalOn": {
-                                "type": "boolean"
-                              },
-                              "lowBeamHeadlightsOn": {
-                                "type": "boolean"
-                              },
-                              "parkingLightsOn": {
-                                "type": "boolean"
-                              },
-                              "rightTurnSignalOn": {
-                                "type": "boolean"
-                              }
-                            },
-                            "required": [
-                              "lowBeamHeadlightsOn",
-                              "highBeamHeadlightsOn",
-                              "leftTurnSignalOn",
-                              "rightTurnSignalOn",
-                              "hazardSignalOn",
-                              "automaticLightControlOn",
-                              "daytimeRunningLightsOn",
-                              "fogLightOn",
-                              "parkingLightsOn"
-                            ],
-                            "type": [
-                              "object",
-                              "null"
-                            ]
-                          },
-                          "pathHistory": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "crumbData": {
-                                "items": {
-                                  "additionalProperties": false,
-                                  "properties": {
-                                    "elevationOffset": {
-                                      "type": "number"
-                                    },
-                                    "heading": {
-                                      "type": [
-                                        "number",
-                                        "null"
-                                      ]
-                                    },
-                                    "latOffset": {
-                                      "type": "number"
-                                    },
-                                    "lonOffset": {
-                                      "type": "number"
-                                    },
-                                    "posAccuracy": {
-                                      "additionalProperties": false,
-                                      "properties": {
-                                        "orientation": {
-                                          "type": "number"
-                                        },
-                                        "semiMajor": {
-                                          "type": "number"
-                                        },
-                                        "semiMinor": {
-                                          "type": "number"
-                                        }
-                                      },
-                                      "required": [
-                                        "semiMajor",
-                                        "semiMinor",
-                                        "orientation"
-                                      ],
-                                      "type": [
-                                        "object",
-                                        "null"
-                                      ]
-                                    },
-                                    "speed": {
-                                      "type": [
-                                        "number",
-                                        "null"
-                                      ]
-                                    },
-                                    "timeOffset": {
-                                      "type": "number"
-                                    }
-                                  },
-                                  "required": [
-                                    "elevationOffset",
-                                    "latOffset",
-                                    "lonOffset",
-                                    "timeOffset"
-                                  ],
-                                  "type": "object"
-                                },
-                                "maxItems": 23,
-                                "minItems": 1,
-                                "type": "array"
-                              },
-                              "currGNSSstatus": {
-                                "additionalProperties": false,
-                                "properties": {
-                                  "aPDOPofUnder5": {
-                                    "type": "boolean"
-                                  },
-                                  "baseStationType": {
-                                    "type": "boolean"
-                                  },
-                                  "inViewOfUnder5": {
-                                    "type": "boolean"
-                                  },
-                                  "isHealthy": {
-                                    "type": "boolean"
-                                  },
-                                  "isMonitored": {
-                                    "type": "boolean"
-                                  },
-                                  "localCorrectionsPresent": {
-                                    "type": "boolean"
-                                  },
-                                  "networkCorrectionsPresent": {
-                                    "type": "boolean"
-                                  },
-                                  "unavailable": {
-                                    "type": "boolean"
-                                  }
-                                },
-                                "required": [
-                                  "unavailable",
-                                  "isHealthy",
-                                  "isMonitored",
-                                  "baseStationType",
-                                  "aPDOPofUnder5",
-                                  "inViewOfUnder5",
-                                  "localCorrectionsPresent",
-                                  "networkCorrectionsPresent"
-                                ],
-                                "type": [
-                                  "object",
-                                  "null"
-                                ]
-                              },
-                              "initialPosition": {
-                                "additionalProperties": false,
-                                "properties": {
-                                  "heading": {
-                                    "type": [
-                                      "number",
-                                      "null"
-                                    ]
-                                  },
-                                  "posAccuracy": {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "orientation": {
-                                        "type": [
-                                          "number",
-                                          "null"
-                                        ]
-                                      },
-                                      "semiMajor": {
-                                        "type": [
-                                          "number",
-                                          "null"
-                                        ]
-                                      },
-                                      "semiMinor": {
-                                        "type": [
-                                          "number",
-                                          "null"
-                                        ]
-                                      }
-                                    },
-                                    "required": [],
-                                    "type": "object"
-                                  },
-                                  "posConfidence": {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "elevation": {
-                                        "enum": [
-                                          "UNAVAILABLE",
-                                          "ELEV_500_00",
-                                          "ELEV_200_00",
-                                          "ELEV_100_00",
-                                          "ELEV_050_00",
-                                          "ELEV_020_00",
-                                          "ELEV_010_00",
-                                          "ELEV_005_00",
-                                          "ELEV_002_00",
-                                          "ELEV_001_00",
-                                          "ELEV_000_50",
-                                          "ELEV_000_20",
-                                          "ELEV_000_10",
-                                          "ELEV_000_05",
-                                          "ELEV_000_02",
-                                          "ELEV_000_01"
-                                        ],
-                                        "type": "string"
-                                      },
-                                      "pos": {
-                                        "enum": [
-                                          "UNAVAILABLE",
-                                          "A500M",
-                                          "A200M",
-                                          "A100M",
-                                          "A50M",
-                                          "A20M",
-                                          "A10M",
-                                          "A5M",
-                                          "A2M",
-                                          "A1M",
-                                          "A50CM",
-                                          "A20CM",
-                                          "A10CM",
-                                          "A5CM",
-                                          "A2CM",
-                                          "A1CM"
-                                        ],
-                                        "type": "string"
-                                      }
-                                    },
-                                    "required": [
-                                      "pos",
-                                      "elevation"
-                                    ],
-                                    "type": [
-                                      "object",
-                                      "null"
-                                    ]
-                                  },
-                                  "position": {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "elevation": {
-                                        "type": [
-                                          "number",
-                                          "null"
-                                        ]
-                                      },
-                                      "latitude": {
-                                        "type": "number"
-                                      },
-                                      "longitude": {
-                                        "type": "number"
-                                      }
-                                    },
-                                    "required": [
-                                      "latitude",
-                                      "longitude"
-                                    ],
-                                    "type": "object"
-                                  },
-                                  "speed": {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "speed": {
-                                        "type": "number"
-                                      },
-                                      "transmission": {
-                                        "enum": [
-                                          "NEUTRAL",
-                                          "PARK",
-                                          "FORWARDGEARS",
-                                          "REVERSEGEARS",
-                                          "RESERVED1",
-                                          "RESERVED2",
-                                          "RESERVED3",
-                                          "UNAVAILABLE"
-                                        ],
-                                        "type": "string"
-                                      }
-                                    },
-                                    "required": [
-                                      "speed",
-                                      "transmission"
-                                    ],
-                                    "type": [
-                                      "object",
-                                      "null"
-                                    ]
-                                  },
-                                  "speedConfidence": {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "heading": {
-                                        "enum": [
-                                          "UNAVAILABLE",
-                                          "PREC10DEG",
-                                          "PREC05DEG",
-                                          "PREC01DEG",
-                                          "PREC0_1DEG",
-                                          "PREC0_05DEG",
-                                          "PREC0_01DEG",
-                                          "PREC0_0125DEG"
-                                        ],
-                                        "type": "string"
-                                      },
-                                      "speed": {
-                                        "enum": [
-                                          "UNAVAILABLE",
-                                          "PREC100MS",
-                                          "PREC10MS",
-                                          "PREC5MS",
-                                          "PREC1MS",
-                                          "PREC0_1MS",
-                                          "PREC0_05MS",
-                                          "PREC0_01MS"
-                                        ],
-                                        "type": "string"
-                                      },
-                                      "throttle": {
-                                        "enum": [
-                                          "UNAVAILABLE",
-                                          "PREC10PERCENT",
-                                          "PREC1PERCENT",
-                                          "PREC0_5PERCENT"
-                                        ],
-                                        "type": "string"
-                                      }
-                                    },
-                                    "required": [
-                                      "heading",
-                                      "speed",
-                                      "throttle"
-                                    ],
-                                    "type": [
-                                      "object",
-                                      "null"
-                                    ]
-                                  },
-                                  "timeConfidence": {
-                                    "enum": [
-                                      "UNAVAILABLE",
-                                      "TIME_100_000",
-                                      "TIME_050_000",
-                                      "TIME_020_000",
-                                      "TIME_010_000",
-                                      "TIME_002_000",
-                                      "TIME_001_000",
-                                      "TIME_000_500",
-                                      "TIME_000_200",
-                                      "TIME_000_100",
-                                      "TIME_000_050",
-                                      "TIME_000_020",
-                                      "TIME_000_010",
-                                      "TIME_000_005",
-                                      "TIME_000_002",
-                                      "TIME_000_001",
-                                      "TIME_000_000_5",
-                                      "TIME_000_000_2",
-                                      "TIME_000_000_1",
-                                      "TIME_000_000_05",
-                                      "TIME_000_000_02",
-                                      "TIME_000_000_01",
-                                      "TIME_000_000_005",
-                                      "TIME_000_000_002",
-                                      "TIME_000_000_001",
-                                      "TIME_000_000_000_5",
-                                      "TIME_000_000_000_2",
-                                      "TIME_000_000_000_1",
-                                      "TIME_000_000_000_05",
-                                      "TIME_000_000_000_02",
-                                      "TIME_000_000_000_01",
-                                      "TIME_000_000_000_005",
-                                      "TIME_000_000_000_002",
-                                      "TIME_000_000_000_001",
-                                      "TIME_000_000_000_000_5",
-                                      "TIME_000_000_000_000_2",
-                                      "TIME_000_000_000_000_1",
-                                      "TIME_000_000_000_000_05",
-                                      "TIME_000_000_000_000_02",
-                                      "TIME_000_000_000_000_01",
-                                      null
-                                    ],
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ]
-                                  },
-                                  "utcTime": {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "day": {
-                                        "type": [
-                                          "integer",
-                                          "null"
-                                        ]
-                                      },
-                                      "hour": {
-                                        "type": [
-                                          "integer",
-                                          "null"
-                                        ]
-                                      },
-                                      "minute": {
-                                        "type": [
-                                          "integer",
-                                          "null"
-                                        ]
-                                      },
-                                      "month": {
-                                        "type": [
-                                          "integer",
-                                          "null"
-                                        ]
-                                      },
-                                      "offset": {
-                                        "type": [
-                                          "integer",
-                                          "null"
-                                        ]
-                                      },
-                                      "second": {
-                                        "type": [
-                                          "integer",
-                                          "null"
-                                        ]
-                                      },
-                                      "year": {
-                                        "type": [
-                                          "integer",
-                                          "null"
-                                        ]
-                                      }
-                                    },
-                                    "required": [],
-                                    "type": [
-                                      "object",
-                                      "null"
-                                    ]
-                                  }
-                                },
-                                "required": [
-                                  "position"
-                                ],
-                                "type": [
-                                  "object",
-                                  "null"
-                                ]
-                              }
-                            },
-                            "required": [
-                              "crumbData"
-                            ],
-                            "type": [
-                              "object",
-                              "null"
-                            ]
-                          },
-                          "pathPrediction": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "confidence": {
-                                "type": "number"
-                              },
-                              "radiusOfCurve": {
-                                "type": "number"
-                              }
-                            },
-                            "required": [
-                              "confidence",
-                              "radiusOfCurve"
-                            ],
-                            "type": [
-                              "object",
-                              "null"
-                            ]
-                          }
-                        },
-                        "required": [],
-                        "type": "object"
-                      }
-                    },
-                    "required": [
-                      "id",
-                      "value"
-                    ],
-                    "type": "object"
-                  },
-                  {
-                    "additionalProperties": false,
-                    "properties": {
-                      "id": {
-                        "const": "SpecialVehicleExtensions",
-                        "type": "string"
-                      },
-                      "value": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "description": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "description": {
-                                "items": {
-                                  "type": "integer"
-                                },
-                                "maxItems": 8,
-                                "minItems": 1,
-                                "type": [
-                                  "array",
-                                  "null"
-                                ]
-                              },
-                              "extent": {
-                                "enum": [
-                                  "USEINSTANTLYONLY",
-                                  "USEFOR3METERS",
-                                  "USEFOR10METERS",
-                                  "USEFOR50METERS",
-                                  "USEFOR100METERS",
-                                  "USEFOR500METERS",
-                                  "USEFOR1000METERS",
-                                  "USEFOR5000METERS",
-                                  "USEFOR10000METERS",
-                                  "USEFOR50000METERS",
-                                  "USEFOR100000METERS",
-                                  "USEFOR500000METERS",
-                                  "USEFOR1000000METERS",
-                                  "USEFOR5000000METERS",
-                                  "USEFOR10000000METERS",
-                                  "FOREVER",
-                                  null
-                                ],
-                                "type": [
-                                  "string",
-                                  "null"
-                                ]
+              "logFileName": {
+                  "type": "string"
+              },
+              "maxDurationTime": {
+                  "type": [
+                      "integer",
+                      "null"
+                  ]
+              },
+              "odePacketID": {
+                  "type": [
+                      "string",
+                      "null"
+                  ]
+              },
+              "odeReceivedAt": {
+                  "type": "string"
+              },
+              "odeTimStartDateTime": {
+                  "type": [
+                      "string",
+                      "null"
+                  ]
+              },
+              "originIp": {
+                  "type": [
+                      "string",
+                      "null"
+                  ]
+              },
+              "payloadType": {
+                  "type": "string"
+              },
+              "receivedMessageDetails": {
+                  "properties": {
+                      "locationData": {
+                          "properties": {
+                              "elevation": {
+                                  "type": "string"
                               },
                               "heading": {
-                                "additionalProperties": false,
-                                "properties": {
-                                  "FROM000_0TO022_5DEGREES": {
-                                    "type": "boolean"
-                                  },
-                                  "FROM022_5TO045_0DEGREES": {
-                                    "type": "boolean"
-                                  },
-                                  "FROM045_0TO067_5DEGREES": {
-                                    "type": "boolean"
-                                  },
-                                  "FROM067_5TO090_0DEGREES": {
-                                    "type": "boolean"
-                                  },
-                                  "FROM090_0TO112_5DEGREES": {
-                                    "type": "boolean"
-                                  },
-                                  "FROM112_5TO135_0DEGREES": {
-                                    "type": "boolean"
-                                  },
-                                  "FROM135_0TO157_5DEGREES": {
-                                    "type": "boolean"
-                                  },
-                                  "FROM157_5TO180_0DEGREES": {
-                                    "type": "boolean"
-                                  },
-                                  "FROM180_0TO202_5DEGREES": {
-                                    "type": "boolean"
-                                  },
-                                  "FROM202_5TO225_0DEGREES": {
-                                    "type": "boolean"
-                                  },
-                                  "FROM225_0TO247_5DEGREES": {
-                                    "type": "boolean"
-                                  },
-                                  "FROM247_5TO270_0DEGREES": {
-                                    "type": "boolean"
-                                  },
-                                  "FROM270_0TO292_5DEGREES": {
-                                    "type": "boolean"
-                                  },
-                                  "FROM292_5TO315_0DEGREES": {
-                                    "type": "boolean"
-                                  },
-                                  "FROM315_0TO337_5DEGREES": {
-                                    "type": "boolean"
-                                  },
-                                  "FROM337_5TO360_0DEGREES": {
-                                    "type": "boolean"
-                                  }
-                                },
-                                "required": [
-                                  "FROM000_0TO022_5DEGREES",
-                                  "FROM022_5TO045_0DEGREES",
-                                  "FROM045_0TO067_5DEGREES",
-                                  "FROM067_5TO090_0DEGREES",
-                                  "FROM090_0TO112_5DEGREES",
-                                  "FROM112_5TO135_0DEGREES",
-                                  "FROM135_0TO157_5DEGREES",
-                                  "FROM157_5TO180_0DEGREES",
-                                  "FROM180_0TO202_5DEGREES",
-                                  "FROM202_5TO225_0DEGREES",
-                                  "FROM225_0TO247_5DEGREES",
-                                  "FROM247_5TO270_0DEGREES",
-                                  "FROM270_0TO292_5DEGREES",
-                                  "FROM292_5TO315_0DEGREES",
-                                  "FROM315_0TO337_5DEGREES",
-                                  "FROM337_5TO360_0DEGREES"
-                                ],
-                                "type": [
-                                  "object",
-                                  "null"
-                                ]
+                                  "type": "string"
                               },
-                              "priority": {
-                                "type": [
-                                  "string",
-                                  "null"
-                                ]
+                              "latitude": {
+                                  "type": "string"
                               },
-                              "regional": {
-                                "items": {
-                                  "additionalProperties": false,
-                                  "properties": {
-                                    "id": {
-                                      "type": "integer"
-                                    },
-                                    "value": {
-                                      "contentEncoding": "base64",
-                                      "type": "string"
-                                    }
-                                  },
-                                  "required": [
-                                    "id",
-                                    "value"
-                                  ],
-                                  "type": "object"
-                                },
-                                "maxItems": 4,
-                                "minItems": 1,
-                                "type": [
-                                  "array",
-                                  "null"
-                                ]
+                              "longitude": {
+                                  "type": "string"
                               },
-                              "typeEvent": {
-                                "type": "integer"
+                              "speed": {
+                                  "type": "string"
                               }
-                            },
-                            "required": [],
-                            "type": [
-                              "object",
-                              "null"
-                            ]
                           },
-                          "trailers": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "connection": {
-                                "additionalProperties": false,
-                                "properties": {
-                                  "pivotAngle": {
-                                    "type": "number"
-                                  },
-                                  "pivotOffset": {
-                                    "type": "number"
-                                  },
-                                  "pivots": {
-                                    "type": "boolean"
-                                  }
-                                },
-                                "required": [
-                                  "pivotOffset",
-                                  "pivotAngle",
-                                  "pivots"
-                                ],
-                                "type": "object"
-                              },
-                              "sspRights": {
-                                "type": "integer"
-                              },
-                              "units": {
-                                "items": {
-                                  "additionalProperties": false,
-                                  "properties": {
-                                    "bumperHeights": {
-                                      "additionalProperties": false,
-                                      "properties": {
-                                        "front": {
-                                          "type": "number"
-                                        },
-                                        "rear": {
-                                          "type": "number"
-                                        }
-                                      },
-                                      "required": [
-                                        "front",
-                                        "rear"
-                                      ],
-                                      "type": [
-                                        "object",
-                                        "null"
-                                      ]
-                                    },
-                                    "centerOfGravity": {
-                                      "type": [
-                                        "number",
-                                        "null"
-                                      ]
-                                    },
-                                    "crumbData": {
-                                      "items": {
-                                        "additionalProperties": false,
-                                        "properties": {
-                                          "elevationOffset": {
-                                            "type": "number"
-                                          },
-                                          "heading": {
-                                            "type": [
-                                              "number",
-                                              "null"
-                                            ]
-                                          },
-                                          "latOffset": {
-                                            "type": "number"
-                                          },
-                                          "lonOffset": {
-                                            "type": "number"
-                                          },
-                                          "posAccuracy": {
-                                            "additionalProperties": false,
-                                            "properties": {
-                                              "orientation": {
-                                                "type": "number"
-                                              },
-                                              "semiMajor": {
-                                                "type": "number"
-                                              },
-                                              "semiMinor": {
-                                                "type": "number"
-                                              }
-                                            },
-                                            "required": [
-                                              "semiMajor",
-                                              "semiMinor",
-                                              "orientation"
-                                            ],
-                                            "type": [
-                                              "object",
-                                              "null"
-                                            ]
-                                          },
-                                          "speed": {
-                                            "type": [
-                                              "number",
-                                              "null"
-                                            ]
-                                          },
-                                          "timeOffset": {
-                                            "type": "number"
-                                          }
-                                        },
-                                        "required": [
-                                          "elevationOffset",
-                                          "latOffset",
-                                          "lonOffset",
-                                          "timeOffset"
-                                        ],
-                                        "type": "object"
-                                      },
-                                      "maxItems": 23,
-                                      "minItems": 1,
-                                      "type": [
-                                        "array",
-                                        "null"
-                                      ]
-                                    },
-                                    "elevationOffset": {
-                                      "type": [
-                                        "number",
-                                        "null"
-                                      ]
-                                    },
-                                    "frontPivot": {
-                                      "additionalProperties": false,
-                                      "properties": {
-                                        "pivotAngle": {
-                                          "type": "number"
-                                        },
-                                        "pivotOffset": {
-                                          "type": "number"
-                                        },
-                                        "pivots": {
-                                          "type": "boolean"
-                                        }
-                                      },
-                                      "required": [
-                                        "pivotOffset",
-                                        "pivotAngle",
-                                        "pivots"
-                                      ],
-                                      "type": "object"
-                                    },
-                                    "height": {
-                                      "type": [
-                                        "number",
-                                        "null"
-                                      ]
-                                    },
-                                    "isDolly": {
-                                      "type": "boolean"
-                                    },
-                                    "length": {
-                                      "type": [
-                                        "integer",
-                                        "null"
-                                      ]
-                                    },
-                                    "mass": {
-                                      "type": [
-                                        "integer",
-                                        "null"
-                                      ]
-                                    },
-                                    "positionOffset": {
-                                      "additionalProperties": false,
-                                      "properties": {
-                                        "x": {
-                                          "type": "number"
-                                        },
-                                        "y": {
-                                          "type": "number"
-                                        }
-                                      },
-                                      "required": [
-                                        "x",
-                                        "y"
-                                      ],
-                                      "type": "object"
-                                    },
-                                    "rearPivot": {
-                                      "additionalProperties": false,
-                                      "properties": {
-                                        "pivotAngle": {
-                                          "type": "number"
-                                        },
-                                        "pivotOffset": {
-                                          "type": "number"
-                                        },
-                                        "pivots": {
-                                          "type": "boolean"
-                                        }
-                                      },
-                                      "required": [
-                                        "pivotOffset",
-                                        "pivotAngle",
-                                        "pivots"
-                                      ],
-                                      "type": [
-                                        "object",
-                                        "null"
-                                      ]
-                                    },
-                                    "rearWheelOffset": {
-                                      "type": [
-                                        "number",
-                                        "null"
-                                      ]
-                                    },
-                                    "width": {
-                                      "type": [
-                                        "integer",
-                                        "null"
-                                      ]
-                                    }
-                                  },
-                                  "required": [
-                                    "isDolly",
-                                    "frontPivot",
-                                    "positionOffset"
-                                  ],
-                                  "type": "object"
-                                },
-                                "maxItems": 8,
-                                "minItems": 1,
-                                "type": "array"
-                              }
-                            },
-                            "required": [
-                              "connection",
-                              "sspRights",
-                              "units"
-                            ],
-                            "type": [
-                              "object",
-                              "null"
-                            ]
-                          },
-                          "vehicleAlerts": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "events": {
-                                "additionalProperties": false,
-                                "properties": {
-                                  "event": {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "peEmergencyLightsActive": {
-                                        "type": "boolean"
-                                      },
-                                      "peEmergencyResponse": {
-                                        "type": "boolean"
-                                      },
-                                      "peEmergencySoundActive": {
-                                        "type": "boolean"
-                                      },
-                                      "peNonEmergencyLightsActive": {
-                                        "type": "boolean"
-                                      },
-                                      "peNonEmergencySoundActive": {
-                                        "type": "boolean"
-                                      },
-                                      "peUnavailable": {
-                                        "type": "boolean"
-                                      }
-                                    },
-                                    "required": [
-                                      "peUnavailable",
-                                      "peEmergencyResponse",
-                                      "peEmergencyLightsActive",
-                                      "peEmergencySoundActive",
-                                      "peNonEmergencyLightsActive",
-                                      "peNonEmergencySoundActive"
-                                    ],
-                                    "type": "object"
-                                  },
-                                  "sspRights": {
-                                    "type": "integer"
-                                  }
-                                },
-                                "required": [
-                                  "event",
-                                  "sspRights"
-                                ],
-                                "type": [
-                                  "object",
-                                  "null"
-                                ]
-                              },
-                              "lightsUse": {
-                                "enum": [
-                                  "UNAVAILABLE",
-                                  "NOTINUSE",
-                                  "INUSE",
-                                  "YELLOWCAUTIONLIGHTS",
-                                  "SCHOOLBUSLIGHTS",
-                                  "ARROWSIGNSACTIVE",
-                                  "SLOWMOVINGVEHICLE",
-                                  "FREQSTOPS"
-                                ],
-                                "type": "string"
-                              },
-                              "multi": {
-                                "enum": [
-                                  "UNAVAILABLE",
-                                  "SINGLEVEHICLE",
-                                  "MULTIVEHICLE",
-                                  "RESERVED"
-                                ],
-                                "type": "string"
-                              },
-                              "responseType": {
-                                "enum": [
-                                  "NOTINUSEORNOTEQUIPPED",
-                                  "EMERGENCY",
-                                  "NONEMERGENCY",
-                                  "PURSUIT",
-                                  "STATIONARY",
-                                  "SLOWMOVING",
-                                  "STOPANDGOMOVEMENT",
-                                  null
-                                ],
-                                "type": [
-                                  "string",
-                                  "null"
-                                ]
-                              },
-                              "sirenUse": {
-                                "enum": [
-                                  "UNAVAILABLE",
-                                  "NOTINUSE",
-                                  "INUSE",
-                                  "RESERVED"
-                                ],
-                                "type": "string"
-                              },
-                              "sspRights": {
-                                "type": "number"
-                              }
-                            },
-                            "required": [
-                              "sspRights",
-                              "lightsUse",
-                              "multi",
-                              "sirenUse"
-                            ],
-                            "type": [
-                              "object",
-                              "null"
-                            ]
-                          }
-                        },
-                        "required": [],
-                        "type": "object"
-                      }
-                    },
-                    "required": [
-                      "id",
-                      "value"
-                    ],
-                    "type": "object"
-                  },
-                  {
-                    "additionalProperties": false,
-                    "properties": {
-                      "id": {
-                        "const": "SupplementalVehicleExtensions",
-                        "type": "string"
+                          "required": [
+                              "latitude",
+                              "longitude",
+                              "elevation",
+                              "speed",
+                              "heading"
+                          ],
+                          "type": "object"
                       },
-                      "value": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "classDetails": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "fuelType": {
-                                "enum": [
-                                  "unknownFuel",
-                                  "gasoline",
-                                  "ethanol",
-                                  "diesel",
-                                  "electric",
-                                  "hybrid",
-                                  "hydrogen",
-                                  "natGasLiquid",
-                                  "natGasComp",
-                                  "propane",
-                                  null
-                                ],
-                                "type": [
-                                  "string",
-                                  "null"
-                                ]
-                              },
-                              "hpmsType": {
-                                "enum": [
-                                  "none",
-                                  "unknown",
-                                  "special",
-                                  "moto",
-                                  "car",
-                                  "carOther",
-                                  "bus",
-                                  "axleCnt2",
-                                  "axleCnt3",
-                                  "axleCnt4",
-                                  "axleCnt4Trailer",
-                                  "axleCnt5Trailer",
-                                  "axleCnt6Trailer",
-                                  "axleCnt5MultiTrailer",
-                                  "axleCnt6MultiTrailer",
-                                  "axleCnt7MultiTrailer",
-                                  null
-                                ],
-                                "type": [
-                                  "string",
-                                  "null"
-                                ]
-                              },
-                              "iso3883": {
-                                "type": [
-                                  "integer",
-                                  "null"
-                                ]
-                              },
-                              "keyType": {
-                                "type": [
-                                  "integer",
-                                  "null"
-                                ]
-                              },
-                              "regional": {
-                                "items": {
-                                  "contentEncoding": "base64",
-                                  "type": "string"
-                                },
-                                "maxItems": 4,
-                                "minItems": 1,
-                                "type": [
-                                  "array",
-                                  "null"
-                                ]
-                              },
-                              "responderType": {
-                                "enum": [
-                                  "emergency_vehicle_units",
-                                  "federal_law_enforcement_units",
-                                  "state_police_units",
-                                  "county_police_units",
-                                  "local_police_units",
-                                  "ambulance_units",
-                                  "rescue_units",
-                                  "fire_units",
-                                  "hAZMAT_units",
-                                  "light_tow_unit",
-                                  "heavy_tow_unit",
-                                  "freeway_service_patrols",
-                                  "transportation_response_units",
-                                  "private_contractor_response_units",
-                                  null
-                                ],
-                                "type": [
-                                  "string",
-                                  "null"
-                                ]
-                              },
-                              "responseEquip": {
-                                "additionalProperties": false,
-                                "properties": {
-                                  "name": {
-                                    "type": "string"
-                                  },
-                                  "value": {
-                                    "type": [
-                                      "integer",
-                                      "null"
-                                    ]
-                                  }
-                                },
-                                "required": [
-                                  "name"
-                                ],
-                                "type": [
-                                  "object",
-                                  "null"
-                                ]
-                              },
-                              "role": {
-                                "enum": [
-                                  "basicVehicle",
-                                  "publicTransport",
-                                  "specialTransport",
-                                  "dangerousGoods",
-                                  "roadWork",
-                                  "roadRescue",
-                                  "emergency",
-                                  "safetyCar",
-                                  "none_unknown",
-                                  "truck",
-                                  "motorcycle",
-                                  "roadSideSource",
-                                  "police",
-                                  "fire",
-                                  "ambulance",
-                                  "dot",
-                                  "transit",
-                                  "slowMoving",
-                                  "stopNgo",
-                                  "cyclist",
-                                  "pedestrian",
-                                  "nonMotorized",
-                                  "military",
-                                  null
-                                ],
-                                "type": [
-                                  "string",
-                                  "null"
-                                ]
-                              },
-                              "vehicleType": {
-                                "additionalProperties": false,
-                                "properties": {
-                                  "name": {
-                                    "type": "string"
-                                  },
-                                  "value": {
-                                    "type": [
-                                      "integer",
-                                      "null"
-                                    ]
-                                  }
-                                },
-                                "required": [
-                                  "name"
-                                ],
-                                "type": [
-                                  "object",
-                                  "null"
-                                ]
-                              }
-                            },
-                            "required": [],
-                            "type": [
-                              "object",
-                              "null"
-                            ]
-                          },
-                          "classification": {
-                            "type": [
-                              "integer",
-                              "null"
-                            ]
-                          },
-                          "obstacle": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "dateTime": {
-                                "additionalProperties": false,
-                                "properties": {
-                                  "day": {
-                                    "type": [
-                                      "integer",
-                                      "null"
-                                    ]
-                                  },
-                                  "hour": {
-                                    "type": [
-                                      "integer",
-                                      "null"
-                                    ]
-                                  },
-                                  "minute": {
-                                    "type": [
-                                      "integer",
-                                      "null"
-                                    ]
-                                  },
-                                  "month": {
-                                    "type": [
-                                      "integer",
-                                      "null"
-                                    ]
-                                  },
-                                  "offset": {
-                                    "type": [
-                                      "integer",
-                                      "null"
-                                    ]
-                                  },
-                                  "second": {
-                                    "type": [
-                                      "integer",
-                                      "null"
-                                    ]
-                                  },
-                                  "year": {
-                                    "type": [
-                                      "integer",
-                                      "null"
-                                    ]
-                                  }
-                                },
-                                "required": [],
-                                "type": [
-                                  "object",
-                                  "null"
-                                ]
-                              },
-                              "description": {
-                                "type": [
-                                  "integer",
-                                  "null"
-                                ]
-                              },
-                              "locationDetails": {
-                                "additionalProperties": false,
-                                "properties": {
-                                  "name": {
-                                    "type": "string"
-                                  },
-                                  "value": {
-                                    "type": [
-                                      "integer",
-                                      "null"
-                                    ]
-                                  }
-                                },
-                                "required": [
-                                  "name"
-                                ],
-                                "type": [
-                                  "object",
-                                  "null"
-                                ]
-                              },
-                              "obDirect": {
-                                "type": "number"
-                              },
-                              "obDist": {
-                                "type": "integer"
-                              },
-                              "vertEvent": {
-                                "additionalProperties": false,
-                                "properties": {
-                                  "leftFront": {
-                                    "type": "boolean"
-                                  },
-                                  "leftRear": {
-                                    "type": "boolean"
-                                  },
-                                  "notEquipped": {
-                                    "type": "boolean"
-                                  },
-                                  "rightFront": {
-                                    "type": "boolean"
-                                  },
-                                  "rightRear": {
-                                    "type": "boolean"
-                                  }
-                                },
-                                "required": [
-                                  "rightRear",
-                                  "rightFront",
-                                  "leftRear",
-                                  "leftFront",
-                                  "notEquipped"
-                                ],
-                                "type": [
-                                  "object",
-                                  "null"
-                                ]
-                              }
-                            },
-                            "required": [
-                              "obDirect",
-                              "obDist"
-                            ],
-                            "type": [
-                              "object",
-                              "null"
-                            ]
-                          },
-                          "regional": {
-                            "items": {
-                              "contentEncoding": "base64",
-                              "type": "string"
-                            },
-                            "maxItems": 4,
-                            "minItems": 1,
-                            "type": [
-                              "array",
-                              "null"
-                            ]
-                          },
-                          "speedProfile": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "speedReports": {
-                                "items": {
-                                  "type": "integer"
-                                },
-                                "maxItems": 20,
-                                "minItems": 1,
-                                "type": "array"
-                              }
-                            },
-                            "required": [],
-                            "type": [
-                              "object",
-                              "null"
-                            ]
-                          },
-                          "status": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "locationDetails": {
-                                "additionalProperties": false,
-                                "properties": {
-                                  "name": {
-                                    "type": "string"
-                                  },
-                                  "value": {
-                                    "type": [
-                                      "integer",
-                                      "null"
-                                    ]
-                                  }
-                                },
-                                "required": [
-                                  "name"
-                                ],
-                                "type": [
-                                  "object",
-                                  "null"
-                                ]
-                              },
-                              "statusDetails": {
-                                "type": "integer"
-                              }
-                            },
-                            "required": [
-                              "statusDetails"
-                            ],
-                            "type": [
-                              "object",
-                              "null"
-                            ]
-                          },
-                          "theRTCM": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "msgs": {
-                                "items": {
-                                  "type": "string"
-                                },
-                                "maxItems": 5,
-                                "minItems": 1,
-                                "type": "array"
-                              },
-                              "rtcmHeader": {
-                                "additionalProperties": false,
-                                "properties": {
-                                  "offsetSet": {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "antOffsetX": {
-                                        "type": "number"
-                                      },
-                                      "antOffsetY": {
-                                        "type": "number"
-                                      },
-                                      "antOffsetZ": {
-                                        "type": "number"
-                                      }
-                                    },
-                                    "required": [
-                                      "antOffsetX",
-                                      "antOffsetY",
-                                      "antOffsetZ"
-                                    ],
-                                    "type": "object"
-                                  },
-                                  "status": {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "aPDOPofUnder5": {
-                                        "type": "boolean"
-                                      },
-                                      "baseStationType": {
-                                        "type": "boolean"
-                                      },
-                                      "inViewOfUnder5": {
-                                        "type": "boolean"
-                                      },
-                                      "isHealthy": {
-                                        "type": "boolean"
-                                      },
-                                      "isMonitored": {
-                                        "type": "boolean"
-                                      },
-                                      "localCorrectionsPresent": {
-                                        "type": "boolean"
-                                      },
-                                      "networkCorrectionsPresent": {
-                                        "type": "boolean"
-                                      },
-                                      "unavailable": {
-                                        "type": "boolean"
-                                      }
-                                    },
-                                    "required": [
-                                      "unavailable",
-                                      "isHealthy",
-                                      "isMonitored",
-                                      "baseStationType",
-                                      "aPDOPofUnder5",
-                                      "inViewOfUnder5",
-                                      "localCorrectionsPresent",
-                                      "networkCorrectionsPresent"
-                                    ],
-                                    "type": "object"
-                                  }
-                                },
-                                "required": [
-                                  "status",
-                                  "offsetSet"
-                                ],
-                                "type": [
-                                  "object",
-                                  "null"
-                                ]
-                              }
-                            },
-                            "required": [
-                              "msgs"
-                            ],
-                            "type": "object"
-                          },
-                          "vehicleData": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "bumpers": {
-                                "additionalProperties": false,
-                                "properties": {
-                                  "front": {
-                                    "type": "number"
-                                  },
-                                  "rear": {
-                                    "type": "number"
-                                  }
-                                },
-                                "required": [
-                                  "front",
-                                  "rear"
-                                ],
-                                "type": [
-                                  "object",
-                                  "null"
-                                ]
-                              },
-                              "height": {
-                                "type": [
-                                  "number",
-                                  "null"
-                                ]
-                              },
-                              "mass": {
-                                "type": [
-                                  "integer",
-                                  "null"
-                                ]
-                              },
-                              "trailerWeight": {
-                                "type": [
-                                  "integer",
-                                  "null"
-                                ]
-                              }
-                            },
-                            "required": [],
-                            "type": [
-                              "object",
-                              "null"
-                            ]
-                          },
-                          "weatherProbe": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "airPressure": {
-                                "type": [
-                                  "integer",
-                                  "null"
-                                ]
-                              },
-                              "airTemp": {
-                                "type": [
-                                  "integer",
-                                  "null"
-                                ]
-                              },
-                              "rainRates": {
-                                "additionalProperties": false,
-                                "properties": {
-                                  "rateFront": {
-                                    "type": "integer"
-                                  },
-                                  "rateRear": {
-                                    "type": [
-                                      "integer",
-                                      "null"
-                                    ]
-                                  },
-                                  "statusFront": {
-                                    "enum": [
-                                      "UNAVAILABLE",
-                                      "OFF",
-                                      "INTERMITTENT",
-                                      "LOW",
-                                      "HIGH",
-                                      "WASHERINUSE",
-                                      "AUTOMATICPRESENT"
-                                    ],
-                                    "type": "string"
-                                  },
-                                  "statusRear": {
-                                    "enum": [
-                                      "UNAVAILABLE",
-                                      "OFF",
-                                      "INTERMITTENT",
-                                      "LOW",
-                                      "HIGH",
-                                      "WASHERINUSE",
-                                      "AUTOMATICPRESENT",
-                                      null
-                                    ],
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ]
-                                  }
-                                },
-                                "required": [
-                                  "rateFront",
-                                  "statusFront"
-                                ],
-                                "type": [
-                                  "object",
-                                  "null"
-                                ]
-                              }
-                            },
-                            "required": [],
-                            "type": [
-                              "object",
-                              "null"
-                            ]
-                          },
-                          "weatherReport": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "friction": {
-                                "type": [
-                                  "integer",
-                                  "null"
-                                ]
-                              },
-                              "isRaining": {
-                                "enum": [
-                                  "NA",
-                                  "PRECIP",
-                                  "NOPRECIP",
-                                  "ERROR"
-                                ],
-                                "type": "string"
-                              },
-                              "precipSituation": {
-                                "enum": [
-                                  "NA",
-                                  "OTHER",
-                                  "UNKNOWN",
-                                  "NOPRECIPITATION",
-                                  "UNIDENTIFIEDSLIGHT",
-                                  "UNIDENTIFIEDMODERATE",
-                                  "UNIDENTIFIEDHEAVY",
-                                  "SNOWSLIGHT",
-                                  "SNOWMODERATE",
-                                  "SNOWHEAVY",
-                                  "RAINSLIGHT",
-                                  "RAINMODERATE",
-                                  "RAINHEAVY",
-                                  "FROZENPRECIPITATIONSLIGHT",
-                                  "FROZENPRECIPITATIONMODERATE",
-                                  "FROZENPRECIPITATIONHEAVY",
-                                  null
-                                ],
-                                "type": [
-                                  "string",
-                                  "null"
-                                ]
-                              },
-                              "rainRate": {
-                                "type": [
-                                  "number",
-                                  "null"
-                                ]
-                              },
-                              "roadFriction": {
-                                "type": [
-                                  "number",
-                                  "null"
-                                ]
-                              },
-                              "solarRadiation": {
-                                "type": [
-                                  "integer",
-                                  "null"
-                                ]
-                              }
-                            },
-                            "required": [
-                              "isRaining"
-                            ],
-                            "type": [
-                              "object",
-                              "null"
-                            ]
-                          }
-                        },
-                        "required": [],
-                        "type": "object"
+                      "rxSource": {
+                          "enum": [
+                              "RSU",
+                              "SAT",
+                              "RV",
+                              "SNMP",
+                              "NA",
+                              "UNKNOWN"
+                          ],
+                          "type": "string"
                       }
-                    },
-                    "required": [
-                      "id",
-                      "value"
-                    ],
-                    "type": "object"
-                  }
-                ]
+                  },
+                  "required": [
+                      "locationData",
+                      "rxSource"
+                  ],
+                  "type": "object"
               },
-              "maxItems": 8,
-              "minItems": 1,
-              "type": [
-                "array",
-                "null"
-              ]
-            }
+              "recordGeneratedAt": {
+                  "type": "string"
+              },
+              "recordGeneratedBy": {
+                  "enum": [
+                      "TMC",
+                      "OBU",
+                      "RSU",
+                      "TMC_VIA_SAT",
+                      "TMC_VIA_SNMP",
+                      "UNKNOWN",
+                      null
+                  ],
+                  "type": [
+                      "string",
+                      "null"
+                  ]
+              },
+              "recordType": {
+                  "enum": [
+                      "bsmLogDuringEvent",
+                      "rxMsg",
+                      "dnMsg",
+                      "bsmTx",
+                      "driverAlert",
+                      "spatTx",
+                      "timMsg",
+                      "unsupported"
+                  ],
+                  "type": "string"
+              },
+              "sanitized": {
+                  "type": "boolean"
+              },
+              "schemaVersion": {
+                  "const": 6,
+                  "type": "integer"
+              },
+              "securityResultCode": {
+                  "enum": [
+                      "success",
+                      "unknown",
+                      "inconsistentInputParameters",
+                      "spduParsingInvalidInput",
+                      "spduParsingUnsupportedCriticalInformationField",
+                      "spduParsingCertificateNotFound",
+                      "spduParsingGenerationTimeNotAvailable",
+                      "spduParsingGenerationLocationNotAvailable",
+                      "spduCertificateChainNotEnoughInformationToConstructChain",
+                      "spduCertificateChainChainEndedAtUntrustedRoot",
+                      "spduCertificateChainChainWasTooLongForImplementation",
+                      "spduCertificateChainCertificateRevoked",
+                      "spduCertificateChainOverdueCRL",
+                      "spduCertificateChainInconsistentExpiryTimes",
+                      "spduCertificateChainInconsistentStartTimes",
+                      "spduCertificateChainInconsistentChainPermissions",
+                      "spduCryptoVerificationFailure",
+                      "spduConsistencyFutureCertificateAtGenerationTime",
+                      "spduConsistencyExpiredCertificateAtGenerationTime",
+                      "spduConsistencyExpiryDateTooEarly",
+                      "spduConsistencyExpiryDateTooLate",
+                      "spduConsistencyGenerationLocationOutsideValidityRegion",
+                      "spduConsistencyNoGenerationLocation",
+                      "spduConsistencyUnauthorizedPSID",
+                      "spduInternalConsistencyExpiryTimeBeforeGenerationTime",
+                      "spduInternalConsistencyextDataHashDoesntMatch",
+                      "spduInternalConsistencynoExtDataHashProvided",
+                      "spduInternalConsistencynoExtDataHashPresent",
+                      "spduLocalConsistencyPSIDsDontMatch",
+                      "spduLocalConsistencyChainWasTooLongForSDEE",
+                      "spduRelevanceGenerationTimeTooFarInPast",
+                      "spduRelevanceGenerationTimeTooFarInFuture",
+                      "spduRelevanceExpiryTimeInPast",
+                      "spduRelevanceGenerationLocationTooDistant",
+                      "spduRelevanceReplayedSpdu",
+                      "spduCertificateExpired"
+                  ],
+                  "type": "string"
+              },
+              "serialId": {
+                  "properties": {
+                      "bundleId": {
+                          "type": "integer"
+                      },
+                      "bundleSize": {
+                          "type": "integer"
+                      },
+                      "recordId": {
+                          "type": "integer"
+                      },
+                      "serialNumber": {
+                          "type": "integer"
+                      },
+                      "streamId": {
+                          "type": "string"
+                      }
+                  },
+                  "required": [
+                      "streamId",
+                      "bundleSize",
+                      "bundleId",
+                      "recordId",
+                      "serialNumber"
+                  ],
+                  "type": "object"
+              }
           },
           "required": [
-            "coreData",
-            "partII"
+              "@class",
+              "bsmSource",
+              "logFileName",
+              "recordType",
+              "securityResultCode",
+              "receivedMessageDetails",
+              "payloadType",
+              "serialId",
+              "odeReceivedAt",
+              "schemaVersion",
+              "recordGeneratedAt",
+              "sanitized"
           ],
           "type": "object"
-        },
-        "dataType": {
-          "type": "string"
-        }
       },
-      "required": [
-        "dataType",
-        "data"
-      ],
-      "type": "object"
-    }
+      "payload": {
+          "properties": {
+              "data": {
+                  "properties": {
+                      "coreData": {
+                          "properties": {
+                              "accelSet": {
+                                  "properties": {
+                                      "accelLat": {
+                                          "type": [
+                                              "number",
+                                              "null"
+                                          ]
+                                      },
+                                      "accelLong": {
+                                          "type": "number"
+                                      },
+                                      "accelVert": {
+                                          "type": [
+                                              "number",
+                                              "null"
+                                          ]
+                                      },
+                                      "accelYaw": {
+                                          "type": "number"
+                                      }
+                                  },
+                                  "required": [
+                                      "accelLong",
+                                      "accelYaw"
+                                  ],
+                                  "type": "object"
+                              },
+                              "accuracy": {
+                                  "properties": {
+                                      "orientation": {
+                                          "type": [
+                                              "number",
+                                              "null"
+                                          ]
+                                      },
+                                      "semiMajor": {
+                                          "type": [
+                                              "number",
+                                              "null"
+                                          ]
+                                      },
+                                      "semiMinor": {
+                                          "type": [
+                                              "number",
+                                              "null"
+                                          ]
+                                      }
+                                  },
+                                  "required": [],
+                                  "type": "object"
+                              },
+                              "angle": {
+                                  "type": [
+                                      "number",
+                                      "null"
+                                  ]
+                              },
+                              "brakes": {
+                                  "properties": {
+                                      "abs": {
+                                          "type": "string"
+                                      },
+                                      "auxBrakes": {
+                                          "type": "string"
+                                      },
+                                      "brakeBoost": {
+                                          "type": "string"
+                                      },
+                                      "scs": {
+                                          "type": "string"
+                                      },
+                                      "traction": {
+                                          "type": "string"
+                                      },
+                                      "wheelBrakes": {
+                                          "properties": {
+                                              "leftFront": {
+                                                  "type": "boolean"
+                                              },
+                                              "leftRear": {
+                                                  "type": "boolean"
+                                              },
+                                              "rightFront": {
+                                                  "type": "boolean"
+                                              },
+                                              "rightRear": {
+                                                  "type": "boolean"
+                                              },
+                                              "unavailable": {
+                                                  "type": "boolean"
+                                              }
+                                          },
+                                          "required": [
+                                              "unavailable",
+                                              "leftFront",
+                                              "leftRear",
+                                              "rightFront",
+                                              "rightRear"
+                                          ],
+                                          "type": "object"
+                                      }
+                                  },
+                                  "required": [
+                                      "wheelBrakes",
+                                      "traction",
+                                      "abs",
+                                      "scs",
+                                      "brakeBoost",
+                                      "auxBrakes"
+                                  ],
+                                  "type": "object"
+                              },
+                              "heading": {
+                                  "type": "number"
+                              },
+                              "id": {
+                                  "type": "string"
+                              },
+                              "msgCnt": {
+                                  "type": "integer"
+                              },
+                              "position": {
+                                  "properties": {
+                                      "elevation": {
+                                          "type": [
+                                              "number",
+                                              "null"
+                                          ]
+                                      },
+                                      "latitude": {
+                                          "type": "number"
+                                      },
+                                      "longitude": {
+                                          "type": "number"
+                                      }
+                                  },
+                                  "required": [
+                                      "latitude",
+                                      "longitude"
+                                  ],
+                                  "type": "object"
+                              },
+                              "secMark": {
+                                  "type": "integer"
+                              },
+                              "size": {
+                                  "properties": {
+                                      "length": {
+                                          "type": [
+                                              "integer",
+                                              "null"
+                                          ]
+                                      },
+                                      "width": {
+                                          "type": [
+                                              "integer",
+                                              "null"
+                                          ]
+                                      }
+                                  },
+                                  "required": [],
+                                  "type": "object"
+                              },
+                              "speed": {
+                                  "type": "number"
+                              },
+                              "transmission": {
+                                  "enum": [
+                                      "NEUTRAL",
+                                      "PARK",
+                                      "FORWARDGEARS",
+                                      "REVERSEGEARS",
+                                      "RESERVED1",
+                                      "RESERVED2",
+                                      "RESERVED3",
+                                      "UNAVAILABLE"
+                                  ],
+                                  "type": "string"
+                              }
+                          },
+                          "required": [
+                              "msgCnt",
+                              "id",
+                              "secMark",
+                              "position",
+                              "accelSet",
+                              "accuracy",
+                              "transmission",
+                              "speed",
+                              "heading",
+                              "brakes",
+                              "size"
+                          ],
+                          "type": "object"
+                      },
+                      "partII": {
+                          "items": {
+                              "oneOf": [
+                                  {
+                                      "properties": {
+                                          "id": {
+                                              "const": "VehicleSafetyExtensions",
+                                              "type": "string"
+                                          },
+                                          "value": {
+                                              "properties": {
+                                                  "events": {
+                                                      "properties": {
+                                                          "eventABSactivated": {
+                                                              "type": "boolean"
+                                                          },
+                                                          "eventAirBagDeployment": {
+                                                              "type": "boolean"
+                                                          },
+                                                          "eventDisabledVehicle": {
+                                                              "type": "boolean"
+                                                          },
+                                                          "eventFlatTire": {
+                                                              "type": "boolean"
+                                                          },
+                                                          "eventHardBraking": {
+                                                              "type": "boolean"
+                                                          },
+                                                          "eventHazardLights": {
+                                                              "type": "boolean"
+                                                          },
+                                                          "eventHazardousMaterials": {
+                                                              "type": "boolean"
+                                                          },
+                                                          "eventLightsChanged": {
+                                                              "type": "boolean"
+                                                          },
+                                                          "eventReserved1": {
+                                                              "type": "boolean"
+                                                          },
+                                                          "eventStabilityControlactivated": {
+                                                              "type": "boolean"
+                                                          },
+                                                          "eventStopLineViolation": {
+                                                              "type": "boolean"
+                                                          },
+                                                          "eventTractionControlLoss": {
+                                                              "type": "boolean"
+                                                          },
+                                                          "eventWipersChanged": {
+                                                              "type": "boolean"
+                                                          }
+                                                      },
+                                                      "required": [
+                                                          "eventHazardLights",
+                                                          "eventStopLineViolation",
+                                                          "eventABSactivated",
+                                                          "eventTractionControlLoss",
+                                                          "eventStabilityControlactivated",
+                                                          "eventHazardousMaterials",
+                                                          "eventReserved1",
+                                                          "eventHardBraking",
+                                                          "eventLightsChanged",
+                                                          "eventWipersChanged",
+                                                          "eventFlatTire",
+                                                          "eventDisabledVehicle",
+                                                          "eventAirBagDeployment"
+                                                      ],
+                                                      "type": [
+                                                          "object",
+                                                          "null"
+                                                      ]
+                                                  },
+                                                  "lights": {
+                                                      "properties": {
+                                                          "automaticLightControlOn": {
+                                                              "type": "boolean"
+                                                          },
+                                                          "daytimeRunningLightsOn": {
+                                                              "type": "boolean"
+                                                          },
+                                                          "fogLightOn": {
+                                                              "type": "boolean"
+                                                          },
+                                                          "hazardSignalOn": {
+                                                              "type": "boolean"
+                                                          },
+                                                          "highBeamHeadlightsOn": {
+                                                              "type": "boolean"
+                                                          },
+                                                          "leftTurnSignalOn": {
+                                                              "type": "boolean"
+                                                          },
+                                                          "lowBeamHeadlightsOn": {
+                                                              "type": "boolean"
+                                                          },
+                                                          "parkingLightsOn": {
+                                                              "type": "boolean"
+                                                          },
+                                                          "rightTurnSignalOn": {
+                                                              "type": "boolean"
+                                                          }
+                                                      },
+                                                      "required": [
+                                                          "lowBeamHeadlightsOn",
+                                                          "highBeamHeadlightsOn",
+                                                          "leftTurnSignalOn",
+                                                          "rightTurnSignalOn",
+                                                          "hazardSignalOn",
+                                                          "automaticLightControlOn",
+                                                          "daytimeRunningLightsOn",
+                                                          "fogLightOn",
+                                                          "parkingLightsOn"
+                                                      ],
+                                                      "type": [
+                                                          "object",
+                                                          "null"
+                                                      ]
+                                                  },
+                                                  "pathHistory": {
+                                                      "properties": {
+                                                          "crumbData": {
+                                                              "items": {
+                                                                  "properties": {
+                                                                      "elevationOffset": {
+                                                                          "type": "number"
+                                                                      },
+                                                                      "heading": {
+                                                                          "type": [
+                                                                              "number",
+                                                                              "null"
+                                                                          ]
+                                                                      },
+                                                                      "latOffset": {
+                                                                          "type": "number"
+                                                                      },
+                                                                      "lonOffset": {
+                                                                          "type": "number"
+                                                                      },
+                                                                      "posAccuracy": {
+                                                                          "properties": {
+                                                                              "orientation": {
+                                                                                  "type": "number"
+                                                                              },
+                                                                              "semiMajor": {
+                                                                                  "type": "number"
+                                                                              },
+                                                                              "semiMinor": {
+                                                                                  "type": "number"
+                                                                              }
+                                                                          },
+                                                                          "required": [
+                                                                              "semiMajor",
+                                                                              "semiMinor",
+                                                                              "orientation"
+                                                                          ],
+                                                                          "type": [
+                                                                              "object",
+                                                                              "null"
+                                                                          ]
+                                                                      },
+                                                                      "speed": {
+                                                                          "type": [
+                                                                              "number",
+                                                                              "null"
+                                                                          ]
+                                                                      },
+                                                                      "timeOffset": {
+                                                                          "type": "number"
+                                                                      }
+                                                                  },
+                                                                  "required": [
+                                                                      "elevationOffset",
+                                                                      "latOffset",
+                                                                      "lonOffset",
+                                                                      "timeOffset"
+                                                                  ],
+                                                                  "type": "object"
+                                                              },
+                                                              "maxItems": 23,
+                                                              "minItems": 1,
+                                                              "type": "array"
+                                                          },
+                                                          "currGNSSstatus": {
+                                                              "properties": {
+                                                                  "aPDOPofUnder5": {
+                                                                      "type": "boolean"
+                                                                  },
+                                                                  "baseStationType": {
+                                                                      "type": "boolean"
+                                                                  },
+                                                                  "inViewOfUnder5": {
+                                                                      "type": "boolean"
+                                                                  },
+                                                                  "isHealthy": {
+                                                                      "type": "boolean"
+                                                                  },
+                                                                  "isMonitored": {
+                                                                      "type": "boolean"
+                                                                  },
+                                                                  "localCorrectionsPresent": {
+                                                                      "type": "boolean"
+                                                                  },
+                                                                  "networkCorrectionsPresent": {
+                                                                      "type": "boolean"
+                                                                  },
+                                                                  "unavailable": {
+                                                                      "type": "boolean"
+                                                                  }
+                                                              },
+                                                              "required": [
+                                                                  "unavailable",
+                                                                  "isHealthy",
+                                                                  "isMonitored",
+                                                                  "baseStationType",
+                                                                  "aPDOPofUnder5",
+                                                                  "inViewOfUnder5",
+                                                                  "localCorrectionsPresent",
+                                                                  "networkCorrectionsPresent"
+                                                              ],
+                                                              "type": [
+                                                                  "object",
+                                                                  "null"
+                                                              ]
+                                                          },
+                                                          "initialPosition": {
+                                                              "properties": {
+                                                                  "heading": {
+                                                                      "type": [
+                                                                          "number",
+                                                                          "null"
+                                                                      ]
+                                                                  },
+                                                                  "posAccuracy": {
+                                                                      "properties": {
+                                                                          "orientation": {
+                                                                              "type": [
+                                                                                  "number",
+                                                                                  "null"
+                                                                              ]
+                                                                          },
+                                                                          "semiMajor": {
+                                                                              "type": [
+                                                                                  "number",
+                                                                                  "null"
+                                                                              ]
+                                                                          },
+                                                                          "semiMinor": {
+                                                                              "type": [
+                                                                                  "number",
+                                                                                  "null"
+                                                                              ]
+                                                                          }
+                                                                      },
+                                                                      "required": [],
+                                                                      "type": "object"
+                                                                  },
+                                                                  "posConfidence": {
+                                                                      "properties": {
+                                                                          "elevation": {
+                                                                              "enum": [
+                                                                                  "UNAVAILABLE",
+                                                                                  "ELEV_500_00",
+                                                                                  "ELEV_200_00",
+                                                                                  "ELEV_100_00",
+                                                                                  "ELEV_050_00",
+                                                                                  "ELEV_020_00",
+                                                                                  "ELEV_010_00",
+                                                                                  "ELEV_005_00",
+                                                                                  "ELEV_002_00",
+                                                                                  "ELEV_001_00",
+                                                                                  "ELEV_000_50",
+                                                                                  "ELEV_000_20",
+                                                                                  "ELEV_000_10",
+                                                                                  "ELEV_000_05",
+                                                                                  "ELEV_000_02",
+                                                                                  "ELEV_000_01"
+                                                                              ],
+                                                                              "type": "string"
+                                                                          },
+                                                                          "pos": {
+                                                                              "enum": [
+                                                                                  "UNAVAILABLE",
+                                                                                  "A500M",
+                                                                                  "A200M",
+                                                                                  "A100M",
+                                                                                  "A50M",
+                                                                                  "A20M",
+                                                                                  "A10M",
+                                                                                  "A5M",
+                                                                                  "A2M",
+                                                                                  "A1M",
+                                                                                  "A50CM",
+                                                                                  "A20CM",
+                                                                                  "A10CM",
+                                                                                  "A5CM",
+                                                                                  "A2CM",
+                                                                                  "A1CM"
+                                                                              ],
+                                                                              "type": "string"
+                                                                          }
+                                                                      },
+                                                                      "required": [
+                                                                          "pos",
+                                                                          "elevation"
+                                                                      ],
+                                                                      "type": [
+                                                                          "object",
+                                                                          "null"
+                                                                      ]
+                                                                  },
+                                                                  "position": {
+                                                                      "properties": {
+                                                                          "elevation": {
+                                                                              "type": [
+                                                                                  "number",
+                                                                                  "null"
+                                                                              ]
+                                                                          },
+                                                                          "latitude": {
+                                                                              "type": "number"
+                                                                          },
+                                                                          "longitude": {
+                                                                              "type": "number"
+                                                                          }
+                                                                      },
+                                                                      "required": [
+                                                                          "latitude",
+                                                                          "longitude"
+                                                                      ],
+                                                                      "type": "object"
+                                                                  },
+                                                                  "speed": {
+                                                                      "properties": {
+                                                                          "speed": {
+                                                                              "type": "number"
+                                                                          },
+                                                                          "transmission": {
+                                                                              "enum": [
+                                                                                  "NEUTRAL",
+                                                                                  "PARK",
+                                                                                  "FORWARDGEARS",
+                                                                                  "REVERSEGEARS",
+                                                                                  "RESERVED1",
+                                                                                  "RESERVED2",
+                                                                                  "RESERVED3",
+                                                                                  "UNAVAILABLE"
+                                                                              ],
+                                                                              "type": "string"
+                                                                          }
+                                                                      },
+                                                                      "required": [
+                                                                          "speed",
+                                                                          "transmission"
+                                                                      ],
+                                                                      "type": [
+                                                                          "object",
+                                                                          "null"
+                                                                      ]
+                                                                  },
+                                                                  "speedConfidence": {
+                                                                      "properties": {
+                                                                          "heading": {
+                                                                              "enum": [
+                                                                                  "UNAVAILABLE",
+                                                                                  "PREC10DEG",
+                                                                                  "PREC05DEG",
+                                                                                  "PREC01DEG",
+                                                                                  "PREC0_1DEG",
+                                                                                  "PREC0_05DEG",
+                                                                                  "PREC0_01DEG",
+                                                                                  "PREC0_0125DEG"
+                                                                              ],
+                                                                              "type": "string"
+                                                                          },
+                                                                          "speed": {
+                                                                              "enum": [
+                                                                                  "UNAVAILABLE",
+                                                                                  "PREC100MS",
+                                                                                  "PREC10MS",
+                                                                                  "PREC5MS",
+                                                                                  "PREC1MS",
+                                                                                  "PREC0_1MS",
+                                                                                  "PREC0_05MS",
+                                                                                  "PREC0_01MS"
+                                                                              ],
+                                                                              "type": "string"
+                                                                          },
+                                                                          "throttle": {
+                                                                              "enum": [
+                                                                                  "UNAVAILABLE",
+                                                                                  "PREC10PERCENT",
+                                                                                  "PREC1PERCENT",
+                                                                                  "PREC0_5PERCENT"
+                                                                              ],
+                                                                              "type": "string"
+                                                                          }
+                                                                      },
+                                                                      "required": [
+                                                                          "heading",
+                                                                          "speed",
+                                                                          "throttle"
+                                                                      ],
+                                                                      "type": [
+                                                                          "object",
+                                                                          "null"
+                                                                      ]
+                                                                  },
+                                                                  "timeConfidence": {
+                                                                      "enum": [
+                                                                          "UNAVAILABLE",
+                                                                          "TIME_100_000",
+                                                                          "TIME_050_000",
+                                                                          "TIME_020_000",
+                                                                          "TIME_010_000",
+                                                                          "TIME_002_000",
+                                                                          "TIME_001_000",
+                                                                          "TIME_000_500",
+                                                                          "TIME_000_200",
+                                                                          "TIME_000_100",
+                                                                          "TIME_000_050",
+                                                                          "TIME_000_020",
+                                                                          "TIME_000_010",
+                                                                          "TIME_000_005",
+                                                                          "TIME_000_002",
+                                                                          "TIME_000_001",
+                                                                          "TIME_000_000_5",
+                                                                          "TIME_000_000_2",
+                                                                          "TIME_000_000_1",
+                                                                          "TIME_000_000_05",
+                                                                          "TIME_000_000_02",
+                                                                          "TIME_000_000_01",
+                                                                          "TIME_000_000_005",
+                                                                          "TIME_000_000_002",
+                                                                          "TIME_000_000_001",
+                                                                          "TIME_000_000_000_5",
+                                                                          "TIME_000_000_000_2",
+                                                                          "TIME_000_000_000_1",
+                                                                          "TIME_000_000_000_05",
+                                                                          "TIME_000_000_000_02",
+                                                                          "TIME_000_000_000_01",
+                                                                          "TIME_000_000_000_005",
+                                                                          "TIME_000_000_000_002",
+                                                                          "TIME_000_000_000_001",
+                                                                          "TIME_000_000_000_000_5",
+                                                                          "TIME_000_000_000_000_2",
+                                                                          "TIME_000_000_000_000_1",
+                                                                          "TIME_000_000_000_000_05",
+                                                                          "TIME_000_000_000_000_02",
+                                                                          "TIME_000_000_000_000_01",
+                                                                          null
+                                                                      ],
+                                                                      "type": [
+                                                                          "string",
+                                                                          "null"
+                                                                      ]
+                                                                  },
+                                                                  "utcTime": {
+                                                                      "properties": {
+                                                                          "day": {
+                                                                              "type": [
+                                                                                  "integer",
+                                                                                  "null"
+                                                                              ]
+                                                                          },
+                                                                          "hour": {
+                                                                              "type": [
+                                                                                  "integer",
+                                                                                  "null"
+                                                                              ]
+                                                                          },
+                                                                          "minute": {
+                                                                              "type": [
+                                                                                  "integer",
+                                                                                  "null"
+                                                                              ]
+                                                                          },
+                                                                          "month": {
+                                                                              "type": [
+                                                                                  "integer",
+                                                                                  "null"
+                                                                              ]
+                                                                          },
+                                                                          "offset": {
+                                                                              "type": [
+                                                                                  "integer",
+                                                                                  "null"
+                                                                              ]
+                                                                          },
+                                                                          "second": {
+                                                                              "type": [
+                                                                                  "integer",
+                                                                                  "null"
+                                                                              ]
+                                                                          },
+                                                                          "year": {
+                                                                              "type": [
+                                                                                  "integer",
+                                                                                  "null"
+                                                                              ]
+                                                                          }
+                                                                      },
+                                                                      "required": [],
+                                                                      "type": [
+                                                                          "object",
+                                                                          "null"
+                                                                      ]
+                                                                  }
+                                                              },
+                                                              "required": [
+                                                                  "position"
+                                                              ],
+                                                              "type": [
+                                                                  "object",
+                                                                  "null"
+                                                              ]
+                                                          }
+                                                      },
+                                                      "required": [
+                                                          "crumbData"
+                                                      ],
+                                                      "type": [
+                                                          "object",
+                                                          "null"
+                                                      ]
+                                                  },
+                                                  "pathPrediction": {
+                                                      "properties": {
+                                                          "confidence": {
+                                                              "type": "number"
+                                                          },
+                                                          "radiusOfCurve": {
+                                                              "type": "number"
+                                                          }
+                                                      },
+                                                      "required": [
+                                                          "confidence",
+                                                          "radiusOfCurve"
+                                                      ],
+                                                      "type": [
+                                                          "object",
+                                                          "null"
+                                                      ]
+                                                  }
+                                              },
+                                              "required": [],
+                                              "type": "object"
+                                          }
+                                      },
+                                      "required": [
+                                          "id",
+                                          "value"
+                                      ],
+                                      "type": "object"
+                                  },
+                                  {
+                                      "properties": {
+                                          "id": {
+                                              "const": "SpecialVehicleExtensions",
+                                              "type": "string"
+                                          },
+                                          "value": {
+                                              "properties": {
+                                                  "description": {
+                                                      "properties": {
+                                                          "description": {
+                                                              "items": {
+                                                                  "type": "integer"
+                                                              },
+                                                              "maxItems": 8,
+                                                              "minItems": 1,
+                                                              "type": [
+                                                                  "array",
+                                                                  "null"
+                                                              ]
+                                                          },
+                                                          "extent": {
+                                                              "enum": [
+                                                                  "USEINSTANTLYONLY",
+                                                                  "USEFOR3METERS",
+                                                                  "USEFOR10METERS",
+                                                                  "USEFOR50METERS",
+                                                                  "USEFOR100METERS",
+                                                                  "USEFOR500METERS",
+                                                                  "USEFOR1000METERS",
+                                                                  "USEFOR5000METERS",
+                                                                  "USEFOR10000METERS",
+                                                                  "USEFOR50000METERS",
+                                                                  "USEFOR100000METERS",
+                                                                  "USEFOR500000METERS",
+                                                                  "USEFOR1000000METERS",
+                                                                  "USEFOR5000000METERS",
+                                                                  "USEFOR10000000METERS",
+                                                                  "FOREVER",
+                                                                  null
+                                                              ],
+                                                              "type": [
+                                                                  "string",
+                                                                  "null"
+                                                              ]
+                                                          },
+                                                          "heading": {
+                                                              "properties": {
+                                                                  "FROM000_0TO022_5DEGREES": {
+                                                                      "type": "boolean"
+                                                                  },
+                                                                  "FROM022_5TO045_0DEGREES": {
+                                                                      "type": "boolean"
+                                                                  },
+                                                                  "FROM045_0TO067_5DEGREES": {
+                                                                      "type": "boolean"
+                                                                  },
+                                                                  "FROM067_5TO090_0DEGREES": {
+                                                                      "type": "boolean"
+                                                                  },
+                                                                  "FROM090_0TO112_5DEGREES": {
+                                                                      "type": "boolean"
+                                                                  },
+                                                                  "FROM112_5TO135_0DEGREES": {
+                                                                      "type": "boolean"
+                                                                  },
+                                                                  "FROM135_0TO157_5DEGREES": {
+                                                                      "type": "boolean"
+                                                                  },
+                                                                  "FROM157_5TO180_0DEGREES": {
+                                                                      "type": "boolean"
+                                                                  },
+                                                                  "FROM180_0TO202_5DEGREES": {
+                                                                      "type": "boolean"
+                                                                  },
+                                                                  "FROM202_5TO225_0DEGREES": {
+                                                                      "type": "boolean"
+                                                                  },
+                                                                  "FROM225_0TO247_5DEGREES": {
+                                                                      "type": "boolean"
+                                                                  },
+                                                                  "FROM247_5TO270_0DEGREES": {
+                                                                      "type": "boolean"
+                                                                  },
+                                                                  "FROM270_0TO292_5DEGREES": {
+                                                                      "type": "boolean"
+                                                                  },
+                                                                  "FROM292_5TO315_0DEGREES": {
+                                                                      "type": "boolean"
+                                                                  },
+                                                                  "FROM315_0TO337_5DEGREES": {
+                                                                      "type": "boolean"
+                                                                  },
+                                                                  "FROM337_5TO360_0DEGREES": {
+                                                                      "type": "boolean"
+                                                                  }
+                                                              },
+                                                              "required": [
+                                                                  "FROM000_0TO022_5DEGREES",
+                                                                  "FROM022_5TO045_0DEGREES",
+                                                                  "FROM045_0TO067_5DEGREES",
+                                                                  "FROM067_5TO090_0DEGREES",
+                                                                  "FROM090_0TO112_5DEGREES",
+                                                                  "FROM112_5TO135_0DEGREES",
+                                                                  "FROM135_0TO157_5DEGREES",
+                                                                  "FROM157_5TO180_0DEGREES",
+                                                                  "FROM180_0TO202_5DEGREES",
+                                                                  "FROM202_5TO225_0DEGREES",
+                                                                  "FROM225_0TO247_5DEGREES",
+                                                                  "FROM247_5TO270_0DEGREES",
+                                                                  "FROM270_0TO292_5DEGREES",
+                                                                  "FROM292_5TO315_0DEGREES",
+                                                                  "FROM315_0TO337_5DEGREES",
+                                                                  "FROM337_5TO360_0DEGREES"
+                                                              ],
+                                                              "type": [
+                                                                  "object",
+                                                                  "null"
+                                                              ]
+                                                          },
+                                                          "priority": {
+                                                              "type": [
+                                                                  "string",
+                                                                  "null"
+                                                              ]
+                                                          },
+                                                          "regional": {
+                                                              "items": {
+                                                                  "properties": {
+                                                                      "id": {
+                                                                          "type": "integer"
+                                                                      },
+                                                                      "value": {
+                                                                          "contentEncoding": "base64",
+                                                                          "type": "string"
+                                                                      }
+                                                                  },
+                                                                  "required": [
+                                                                      "id",
+                                                                      "value"
+                                                                  ],
+                                                                  "type": "object"
+                                                              },
+                                                              "maxItems": 4,
+                                                              "minItems": 1,
+                                                              "type": [
+                                                                  "array",
+                                                                  "null"
+                                                              ]
+                                                          },
+                                                          "typeEvent": {
+                                                              "type": "integer"
+                                                          }
+                                                      },
+                                                      "required": [],
+                                                      "type": [
+                                                          "object",
+                                                          "null"
+                                                      ]
+                                                  },
+                                                  "trailers": {
+                                                      "properties": {
+                                                          "connection": {
+                                                              "properties": {
+                                                                  "pivotAngle": {
+                                                                      "type": "number"
+                                                                  },
+                                                                  "pivotOffset": {
+                                                                      "type": "number"
+                                                                  },
+                                                                  "pivots": {
+                                                                      "type": "boolean"
+                                                                  }
+                                                              },
+                                                              "required": [
+                                                                  "pivotOffset",
+                                                                  "pivotAngle",
+                                                                  "pivots"
+                                                              ],
+                                                              "type": "object"
+                                                          },
+                                                          "sspRights": {
+                                                              "type": "integer"
+                                                          },
+                                                          "units": {
+                                                              "items": {
+                                                                  "properties": {
+                                                                      "bumperHeights": {
+                                                                          "properties": {
+                                                                              "front": {
+                                                                                  "type": "number"
+                                                                              },
+                                                                              "rear": {
+                                                                                  "type": "number"
+                                                                              }
+                                                                          },
+                                                                          "required": [
+                                                                              "front",
+                                                                              "rear"
+                                                                          ],
+                                                                          "type": [
+                                                                              "object",
+                                                                              "null"
+                                                                          ]
+                                                                      },
+                                                                      "centerOfGravity": {
+                                                                          "type": [
+                                                                              "number",
+                                                                              "null"
+                                                                          ]
+                                                                      },
+                                                                      "crumbData": {
+                                                                          "items": {
+                                                                              "properties": {
+                                                                                  "elevationOffset": {
+                                                                                      "type": "number"
+                                                                                  },
+                                                                                  "heading": {
+                                                                                      "type": [
+                                                                                          "number",
+                                                                                          "null"
+                                                                                      ]
+                                                                                  },
+                                                                                  "latOffset": {
+                                                                                      "type": "number"
+                                                                                  },
+                                                                                  "lonOffset": {
+                                                                                      "type": "number"
+                                                                                  },
+                                                                                  "posAccuracy": {
+                                                                                      "properties": {
+                                                                                          "orientation": {
+                                                                                              "type": "number"
+                                                                                          },
+                                                                                          "semiMajor": {
+                                                                                              "type": "number"
+                                                                                          },
+                                                                                          "semiMinor": {
+                                                                                              "type": "number"
+                                                                                          }
+                                                                                      },
+                                                                                      "required": [
+                                                                                          "semiMajor",
+                                                                                          "semiMinor",
+                                                                                          "orientation"
+                                                                                      ],
+                                                                                      "type": [
+                                                                                          "object",
+                                                                                          "null"
+                                                                                      ]
+                                                                                  },
+                                                                                  "speed": {
+                                                                                      "type": [
+                                                                                          "number",
+                                                                                          "null"
+                                                                                      ]
+                                                                                  },
+                                                                                  "timeOffset": {
+                                                                                      "type": "number"
+                                                                                  }
+                                                                              },
+                                                                              "required": [
+                                                                                  "elevationOffset",
+                                                                                  "latOffset",
+                                                                                  "lonOffset",
+                                                                                  "timeOffset"
+                                                                              ],
+                                                                              "type": "object"
+                                                                          },
+                                                                          "maxItems": 23,
+                                                                          "minItems": 1,
+                                                                          "type": [
+                                                                              "array",
+                                                                              "null"
+                                                                          ]
+                                                                      },
+                                                                      "elevationOffset": {
+                                                                          "type": [
+                                                                              "number",
+                                                                              "null"
+                                                                          ]
+                                                                      },
+                                                                      "frontPivot": {
+                                                                          "properties": {
+                                                                              "pivotAngle": {
+                                                                                  "type": "number"
+                                                                              },
+                                                                              "pivotOffset": {
+                                                                                  "type": "number"
+                                                                              },
+                                                                              "pivots": {
+                                                                                  "type": "boolean"
+                                                                              }
+                                                                          },
+                                                                          "required": [
+                                                                              "pivotOffset",
+                                                                              "pivotAngle",
+                                                                              "pivots"
+                                                                          ],
+                                                                          "type": "object"
+                                                                      },
+                                                                      "height": {
+                                                                          "type": [
+                                                                              "number",
+                                                                              "null"
+                                                                          ]
+                                                                      },
+                                                                      "isDolly": {
+                                                                          "type": "boolean"
+                                                                      },
+                                                                      "length": {
+                                                                          "type": [
+                                                                              "integer",
+                                                                              "null"
+                                                                          ]
+                                                                      },
+                                                                      "mass": {
+                                                                          "type": [
+                                                                              "integer",
+                                                                              "null"
+                                                                          ]
+                                                                      },
+                                                                      "positionOffset": {
+                                                                          "properties": {
+                                                                              "x": {
+                                                                                  "type": "number"
+                                                                              },
+                                                                              "y": {
+                                                                                  "type": "number"
+                                                                              }
+                                                                          },
+                                                                          "required": [
+                                                                              "x",
+                                                                              "y"
+                                                                          ],
+                                                                          "type": "object"
+                                                                      },
+                                                                      "rearPivot": {
+                                                                          "properties": {
+                                                                              "pivotAngle": {
+                                                                                  "type": "number"
+                                                                              },
+                                                                              "pivotOffset": {
+                                                                                  "type": "number"
+                                                                              },
+                                                                              "pivots": {
+                                                                                  "type": "boolean"
+                                                                              }
+                                                                          },
+                                                                          "required": [
+                                                                              "pivotOffset",
+                                                                              "pivotAngle",
+                                                                              "pivots"
+                                                                          ],
+                                                                          "type": [
+                                                                              "object",
+                                                                              "null"
+                                                                          ]
+                                                                      },
+                                                                      "rearWheelOffset": {
+                                                                          "type": [
+                                                                              "number",
+                                                                              "null"
+                                                                          ]
+                                                                      },
+                                                                      "width": {
+                                                                          "type": [
+                                                                              "integer",
+                                                                              "null"
+                                                                          ]
+                                                                      }
+                                                                  },
+                                                                  "required": [
+                                                                      "isDolly",
+                                                                      "frontPivot",
+                                                                      "positionOffset"
+                                                                  ],
+                                                                  "type": "object"
+                                                              },
+                                                              "maxItems": 8,
+                                                              "minItems": 1,
+                                                              "type": "array"
+                                                          }
+                                                      },
+                                                      "required": [
+                                                          "connection",
+                                                          "sspRights",
+                                                          "units"
+                                                      ],
+                                                      "type": [
+                                                          "object",
+                                                          "null"
+                                                      ]
+                                                  },
+                                                  "vehicleAlerts": {
+                                                      "properties": {
+                                                          "events": {
+                                                              "properties": {
+                                                                  "event": {
+                                                                      "properties": {
+                                                                          "peEmergencyLightsActive": {
+                                                                              "type": "boolean"
+                                                                          },
+                                                                          "peEmergencyResponse": {
+                                                                              "type": "boolean"
+                                                                          },
+                                                                          "peEmergencySoundActive": {
+                                                                              "type": "boolean"
+                                                                          },
+                                                                          "peNonEmergencyLightsActive": {
+                                                                              "type": "boolean"
+                                                                          },
+                                                                          "peNonEmergencySoundActive": {
+                                                                              "type": "boolean"
+                                                                          },
+                                                                          "peUnavailable": {
+                                                                              "type": "boolean"
+                                                                          }
+                                                                      },
+                                                                      "required": [
+                                                                          "peUnavailable",
+                                                                          "peEmergencyResponse",
+                                                                          "peEmergencyLightsActive",
+                                                                          "peEmergencySoundActive",
+                                                                          "peNonEmergencyLightsActive",
+                                                                          "peNonEmergencySoundActive"
+                                                                      ],
+                                                                      "type": "object"
+                                                                  },
+                                                                  "sspRights": {
+                                                                      "type": "integer"
+                                                                  }
+                                                              },
+                                                              "required": [
+                                                                  "event",
+                                                                  "sspRights"
+                                                              ],
+                                                              "type": [
+                                                                  "object",
+                                                                  "null"
+                                                              ]
+                                                          },
+                                                          "lightsUse": {
+                                                              "enum": [
+                                                                  "UNAVAILABLE",
+                                                                  "NOTINUSE",
+                                                                  "INUSE",
+                                                                  "YELLOWCAUTIONLIGHTS",
+                                                                  "SCHOOLBUSLIGHTS",
+                                                                  "ARROWSIGNSACTIVE",
+                                                                  "SLOWMOVINGVEHICLE",
+                                                                  "FREQSTOPS"
+                                                              ],
+                                                              "type": "string"
+                                                          },
+                                                          "multi": {
+                                                              "enum": [
+                                                                  "UNAVAILABLE",
+                                                                  "SINGLEVEHICLE",
+                                                                  "MULTIVEHICLE",
+                                                                  "RESERVED"
+                                                              ],
+                                                              "type": "string"
+                                                          },
+                                                          "responseType": {
+                                                              "enum": [
+                                                                  "NOTINUSEORNOTEQUIPPED",
+                                                                  "EMERGENCY",
+                                                                  "NONEMERGENCY",
+                                                                  "PURSUIT",
+                                                                  "STATIONARY",
+                                                                  "SLOWMOVING",
+                                                                  "STOPANDGOMOVEMENT",
+                                                                  null
+                                                              ],
+                                                              "type": [
+                                                                  "string",
+                                                                  "null"
+                                                              ]
+                                                          },
+                                                          "sirenUse": {
+                                                              "enum": [
+                                                                  "UNAVAILABLE",
+                                                                  "NOTINUSE",
+                                                                  "INUSE",
+                                                                  "RESERVED"
+                                                              ],
+                                                              "type": "string"
+                                                          },
+                                                          "sspRights": {
+                                                              "type": "number"
+                                                          }
+                                                      },
+                                                      "required": [
+                                                          "sspRights",
+                                                          "lightsUse",
+                                                          "multi",
+                                                          "sirenUse"
+                                                      ],
+                                                      "type": [
+                                                          "object",
+                                                          "null"
+                                                      ]
+                                                  }
+                                              },
+                                              "required": [],
+                                              "type": "object"
+                                          }
+                                      },
+                                      "required": [
+                                          "id",
+                                          "value"
+                                      ],
+                                      "type": "object"
+                                  },
+                                  {
+                                      "properties": {
+                                          "id": {
+                                              "const": "SupplementalVehicleExtensions",
+                                              "type": "string"
+                                          },
+                                          "value": {
+                                              "properties": {
+                                                  "classDetails": {
+                                                      "properties": {
+                                                          "fuelType": {
+                                                              "enum": [
+                                                                  "unknownFuel",
+                                                                  "gasoline",
+                                                                  "ethanol",
+                                                                  "diesel",
+                                                                  "electric",
+                                                                  "hybrid",
+                                                                  "hydrogen",
+                                                                  "natGasLiquid",
+                                                                  "natGasComp",
+                                                                  "propane",
+                                                                  null
+                                                              ],
+                                                              "type": [
+                                                                  "string",
+                                                                  "null"
+                                                              ]
+                                                          },
+                                                          "hpmsType": {
+                                                              "enum": [
+                                                                  "none",
+                                                                  "unknown",
+                                                                  "special",
+                                                                  "moto",
+                                                                  "car",
+                                                                  "carOther",
+                                                                  "bus",
+                                                                  "axleCnt2",
+                                                                  "axleCnt3",
+                                                                  "axleCnt4",
+                                                                  "axleCnt4Trailer",
+                                                                  "axleCnt5Trailer",
+                                                                  "axleCnt6Trailer",
+                                                                  "axleCnt5MultiTrailer",
+                                                                  "axleCnt6MultiTrailer",
+                                                                  "axleCnt7MultiTrailer",
+                                                                  null
+                                                              ],
+                                                              "type": [
+                                                                  "string",
+                                                                  "null"
+                                                              ]
+                                                          },
+                                                          "iso3883": {
+                                                              "type": [
+                                                                  "integer",
+                                                                  "null"
+                                                              ]
+                                                          },
+                                                          "keyType": {
+                                                              "type": [
+                                                                  "integer",
+                                                                  "null"
+                                                              ]
+                                                          },
+                                                          "regional": {
+                                                              "items": {
+                                                                  "contentEncoding": "base64",
+                                                                  "type": "string"
+                                                              },
+                                                              "maxItems": 4,
+                                                              "minItems": 1,
+                                                              "type": [
+                                                                  "array",
+                                                                  "null"
+                                                              ]
+                                                          },
+                                                          "responderType": {
+                                                              "enum": [
+                                                                  "emergency_vehicle_units",
+                                                                  "federal_law_enforcement_units",
+                                                                  "state_police_units",
+                                                                  "county_police_units",
+                                                                  "local_police_units",
+                                                                  "ambulance_units",
+                                                                  "rescue_units",
+                                                                  "fire_units",
+                                                                  "hAZMAT_units",
+                                                                  "light_tow_unit",
+                                                                  "heavy_tow_unit",
+                                                                  "freeway_service_patrols",
+                                                                  "transportation_response_units",
+                                                                  "private_contractor_response_units",
+                                                                  null
+                                                              ],
+                                                              "type": [
+                                                                  "string",
+                                                                  "null"
+                                                              ]
+                                                          },
+                                                          "responseEquip": {
+                                                              "properties": {
+                                                                  "name": {
+                                                                      "type": "string"
+                                                                  },
+                                                                  "value": {
+                                                                      "type": [
+                                                                          "integer",
+                                                                          "null"
+                                                                      ]
+                                                                  }
+                                                              },
+                                                              "required": [
+                                                                  "name"
+                                                              ],
+                                                              "type": [
+                                                                  "object",
+                                                                  "null"
+                                                              ]
+                                                          },
+                                                          "role": {
+                                                              "enum": [
+                                                                  "basicVehicle",
+                                                                  "publicTransport",
+                                                                  "specialTransport",
+                                                                  "dangerousGoods",
+                                                                  "roadWork",
+                                                                  "roadRescue",
+                                                                  "emergency",
+                                                                  "safetyCar",
+                                                                  "none_unknown",
+                                                                  "truck",
+                                                                  "motorcycle",
+                                                                  "roadSideSource",
+                                                                  "police",
+                                                                  "fire",
+                                                                  "ambulance",
+                                                                  "dot",
+                                                                  "transit",
+                                                                  "slowMoving",
+                                                                  "stopNgo",
+                                                                  "cyclist",
+                                                                  "pedestrian",
+                                                                  "nonMotorized",
+                                                                  "military",
+                                                                  null
+                                                              ],
+                                                              "type": [
+                                                                  "string",
+                                                                  "null"
+                                                              ]
+                                                          },
+                                                          "vehicleType": {
+                                                              "properties": {
+                                                                  "name": {
+                                                                      "type": "string"
+                                                                  },
+                                                                  "value": {
+                                                                      "type": [
+                                                                          "integer",
+                                                                          "null"
+                                                                      ]
+                                                                  }
+                                                              },
+                                                              "required": [
+                                                                  "name"
+                                                              ],
+                                                              "type": [
+                                                                  "object",
+                                                                  "null"
+                                                              ]
+                                                          }
+                                                      },
+                                                      "required": [],
+                                                      "type": [
+                                                          "object",
+                                                          "null"
+                                                      ]
+                                                  },
+                                                  "classification": {
+                                                      "type": [
+                                                          "integer",
+                                                          "null"
+                                                      ]
+                                                  },
+                                                  "obstacle": {
+                                                      "properties": {
+                                                          "dateTime": {
+                                                              "properties": {
+                                                                  "day": {
+                                                                      "type": [
+                                                                          "integer",
+                                                                          "null"
+                                                                      ]
+                                                                  },
+                                                                  "hour": {
+                                                                      "type": [
+                                                                          "integer",
+                                                                          "null"
+                                                                      ]
+                                                                  },
+                                                                  "minute": {
+                                                                      "type": [
+                                                                          "integer",
+                                                                          "null"
+                                                                      ]
+                                                                  },
+                                                                  "month": {
+                                                                      "type": [
+                                                                          "integer",
+                                                                          "null"
+                                                                      ]
+                                                                  },
+                                                                  "offset": {
+                                                                      "type": [
+                                                                          "integer",
+                                                                          "null"
+                                                                      ]
+                                                                  },
+                                                                  "second": {
+                                                                      "type": [
+                                                                          "integer",
+                                                                          "null"
+                                                                      ]
+                                                                  },
+                                                                  "year": {
+                                                                      "type": [
+                                                                          "integer",
+                                                                          "null"
+                                                                      ]
+                                                                  }
+                                                              },
+                                                              "required": [],
+                                                              "type": [
+                                                                  "object",
+                                                                  "null"
+                                                              ]
+                                                          },
+                                                          "description": {
+                                                              "type": [
+                                                                  "integer",
+                                                                  "null"
+                                                              ]
+                                                          },
+                                                          "locationDetails": {
+                                                              "properties": {
+                                                                  "name": {
+                                                                      "type": "string"
+                                                                  },
+                                                                  "value": {
+                                                                      "type": [
+                                                                          "integer",
+                                                                          "null"
+                                                                      ]
+                                                                  }
+                                                              },
+                                                              "required": [
+                                                                  "name"
+                                                              ],
+                                                              "type": [
+                                                                  "object",
+                                                                  "null"
+                                                              ]
+                                                          },
+                                                          "obDirect": {
+                                                              "type": "number"
+                                                          },
+                                                          "obDist": {
+                                                              "type": "integer"
+                                                          },
+                                                          "vertEvent": {
+                                                              "properties": {
+                                                                  "leftFront": {
+                                                                      "type": "boolean"
+                                                                  },
+                                                                  "leftRear": {
+                                                                      "type": "boolean"
+                                                                  },
+                                                                  "notEquipped": {
+                                                                      "type": "boolean"
+                                                                  },
+                                                                  "rightFront": {
+                                                                      "type": "boolean"
+                                                                  },
+                                                                  "rightRear": {
+                                                                      "type": "boolean"
+                                                                  }
+                                                              },
+                                                              "required": [
+                                                                  "rightRear",
+                                                                  "rightFront",
+                                                                  "leftRear",
+                                                                  "leftFront",
+                                                                  "notEquipped"
+                                                              ],
+                                                              "type": [
+                                                                  "object",
+                                                                  "null"
+                                                              ]
+                                                          }
+                                                      },
+                                                      "required": [
+                                                          "obDirect",
+                                                          "obDist"
+                                                      ],
+                                                      "type": [
+                                                          "object",
+                                                          "null"
+                                                      ]
+                                                  },
+                                                  "regional": {
+                                                      "items": {
+                                                          "contentEncoding": "base64",
+                                                          "type": "string"
+                                                      },
+                                                      "maxItems": 4,
+                                                      "minItems": 1,
+                                                      "type": [
+                                                          "array",
+                                                          "null"
+                                                      ]
+                                                  },
+                                                  "speedProfile": {
+                                                      "properties": {
+                                                          "speedReports": {
+                                                              "items": {
+                                                                  "type": "integer"
+                                                              },
+                                                              "maxItems": 20,
+                                                              "minItems": 1,
+                                                              "type": "array"
+                                                          }
+                                                      },
+                                                      "required": [],
+                                                      "type": [
+                                                          "object",
+                                                          "null"
+                                                      ]
+                                                  },
+                                                  "status": {
+                                                      "properties": {
+                                                          "locationDetails": {
+                                                              "properties": {
+                                                                  "name": {
+                                                                      "type": "string"
+                                                                  },
+                                                                  "value": {
+                                                                      "type": [
+                                                                          "integer",
+                                                                          "null"
+                                                                      ]
+                                                                  }
+                                                              },
+                                                              "required": [
+                                                                  "name"
+                                                              ],
+                                                              "type": [
+                                                                  "object",
+                                                                  "null"
+                                                              ]
+                                                          },
+                                                          "statusDetails": {
+                                                              "type": "integer"
+                                                          }
+                                                      },
+                                                      "required": [
+                                                          "statusDetails"
+                                                      ],
+                                                      "type": [
+                                                          "object",
+                                                          "null"
+                                                      ]
+                                                  },
+                                                  "theRTCM": {
+                                                      "properties": {
+                                                          "msgs": {
+                                                              "items": {
+                                                                  "type": "string"
+                                                              },
+                                                              "maxItems": 5,
+                                                              "minItems": 1,
+                                                              "type": "array"
+                                                          },
+                                                          "rtcmHeader": {
+                                                              "properties": {
+                                                                  "offsetSet": {
+                                                                      "properties": {
+                                                                          "antOffsetX": {
+                                                                              "type": "number"
+                                                                          },
+                                                                          "antOffsetY": {
+                                                                              "type": "number"
+                                                                          },
+                                                                          "antOffsetZ": {
+                                                                              "type": "number"
+                                                                          }
+                                                                      },
+                                                                      "required": [
+                                                                          "antOffsetX",
+                                                                          "antOffsetY",
+                                                                          "antOffsetZ"
+                                                                      ],
+                                                                      "type": "object"
+                                                                  },
+                                                                  "status": {
+                                                                      "properties": {
+                                                                          "aPDOPofUnder5": {
+                                                                              "type": "boolean"
+                                                                          },
+                                                                          "baseStationType": {
+                                                                              "type": "boolean"
+                                                                          },
+                                                                          "inViewOfUnder5": {
+                                                                              "type": "boolean"
+                                                                          },
+                                                                          "isHealthy": {
+                                                                              "type": "boolean"
+                                                                          },
+                                                                          "isMonitored": {
+                                                                              "type": "boolean"
+                                                                          },
+                                                                          "localCorrectionsPresent": {
+                                                                              "type": "boolean"
+                                                                          },
+                                                                          "networkCorrectionsPresent": {
+                                                                              "type": "boolean"
+                                                                          },
+                                                                          "unavailable": {
+                                                                              "type": "boolean"
+                                                                          }
+                                                                      },
+                                                                      "required": [
+                                                                          "unavailable",
+                                                                          "isHealthy",
+                                                                          "isMonitored",
+                                                                          "baseStationType",
+                                                                          "aPDOPofUnder5",
+                                                                          "inViewOfUnder5",
+                                                                          "localCorrectionsPresent",
+                                                                          "networkCorrectionsPresent"
+                                                                      ],
+                                                                      "type": "object"
+                                                                  }
+                                                              },
+                                                              "required": [
+                                                                  "status",
+                                                                  "offsetSet"
+                                                              ],
+                                                              "type": [
+                                                                  "object",
+                                                                  "null"
+                                                              ]
+                                                          }
+                                                      },
+                                                      "required": [
+                                                          "msgs"
+                                                      ],
+                                                      "type": "object"
+                                                  },
+                                                  "vehicleData": {
+                                                      "properties": {
+                                                          "bumpers": {
+                                                              "properties": {
+                                                                  "front": {
+                                                                      "type": "number"
+                                                                  },
+                                                                  "rear": {
+                                                                      "type": "number"
+                                                                  }
+                                                              },
+                                                              "required": [
+                                                                  "front",
+                                                                  "rear"
+                                                              ],
+                                                              "type": [
+                                                                  "object",
+                                                                  "null"
+                                                              ]
+                                                          },
+                                                          "height": {
+                                                              "type": [
+                                                                  "number",
+                                                                  "null"
+                                                              ]
+                                                          },
+                                                          "mass": {
+                                                              "type": [
+                                                                  "integer",
+                                                                  "null"
+                                                              ]
+                                                          },
+                                                          "trailerWeight": {
+                                                              "type": [
+                                                                  "integer",
+                                                                  "null"
+                                                              ]
+                                                          }
+                                                      },
+                                                      "required": [],
+                                                      "type": [
+                                                          "object",
+                                                          "null"
+                                                      ]
+                                                  },
+                                                  "weatherProbe": {
+                                                      "properties": {
+                                                          "airPressure": {
+                                                              "type": [
+                                                                  "integer",
+                                                                  "null"
+                                                              ]
+                                                          },
+                                                          "airTemp": {
+                                                              "type": [
+                                                                  "integer",
+                                                                  "null"
+                                                              ]
+                                                          },
+                                                          "rainRates": {
+                                                              "properties": {
+                                                                  "rateFront": {
+                                                                      "type": "integer"
+                                                                  },
+                                                                  "rateRear": {
+                                                                      "type": [
+                                                                          "integer",
+                                                                          "null"
+                                                                      ]
+                                                                  },
+                                                                  "statusFront": {
+                                                                      "enum": [
+                                                                          "UNAVAILABLE",
+                                                                          "OFF",
+                                                                          "INTERMITTENT",
+                                                                          "LOW",
+                                                                          "HIGH",
+                                                                          "WASHERINUSE",
+                                                                          "AUTOMATICPRESENT"
+                                                                      ],
+                                                                      "type": "string"
+                                                                  },
+                                                                  "statusRear": {
+                                                                      "enum": [
+                                                                          "UNAVAILABLE",
+                                                                          "OFF",
+                                                                          "INTERMITTENT",
+                                                                          "LOW",
+                                                                          "HIGH",
+                                                                          "WASHERINUSE",
+                                                                          "AUTOMATICPRESENT",
+                                                                          null
+                                                                      ],
+                                                                      "type": [
+                                                                          "string",
+                                                                          "null"
+                                                                      ]
+                                                                  }
+                                                              },
+                                                              "required": [
+                                                                  "rateFront",
+                                                                  "statusFront"
+                                                              ],
+                                                              "type": [
+                                                                  "object",
+                                                                  "null"
+                                                              ]
+                                                          }
+                                                      },
+                                                      "required": [],
+                                                      "type": [
+                                                          "object",
+                                                          "null"
+                                                      ]
+                                                  },
+                                                  "weatherReport": {
+                                                      "properties": {
+                                                          "friction": {
+                                                              "type": [
+                                                                  "integer",
+                                                                  "null"
+                                                              ]
+                                                          },
+                                                          "isRaining": {
+                                                              "enum": [
+                                                                  "NA",
+                                                                  "PRECIP",
+                                                                  "NOPRECIP",
+                                                                  "ERROR"
+                                                              ],
+                                                              "type": "string"
+                                                          },
+                                                          "precipSituation": {
+                                                              "enum": [
+                                                                  "NA",
+                                                                  "OTHER",
+                                                                  "UNKNOWN",
+                                                                  "NOPRECIPITATION",
+                                                                  "UNIDENTIFIEDSLIGHT",
+                                                                  "UNIDENTIFIEDMODERATE",
+                                                                  "UNIDENTIFIEDHEAVY",
+                                                                  "SNOWSLIGHT",
+                                                                  "SNOWMODERATE",
+                                                                  "SNOWHEAVY",
+                                                                  "RAINSLIGHT",
+                                                                  "RAINMODERATE",
+                                                                  "RAINHEAVY",
+                                                                  "FROZENPRECIPITATIONSLIGHT",
+                                                                  "FROZENPRECIPITATIONMODERATE",
+                                                                  "FROZENPRECIPITATIONHEAVY",
+                                                                  null
+                                                              ],
+                                                              "type": [
+                                                                  "string",
+                                                                  "null"
+                                                              ]
+                                                          },
+                                                          "rainRate": {
+                                                              "type": [
+                                                                  "number",
+                                                                  "null"
+                                                              ]
+                                                          },
+                                                          "roadFriction": {
+                                                              "type": [
+                                                                  "number",
+                                                                  "null"
+                                                              ]
+                                                          },
+                                                          "solarRadiation": {
+                                                              "type": [
+                                                                  "integer",
+                                                                  "null"
+                                                              ]
+                                                          }
+                                                      },
+                                                      "required": [
+                                                          "isRaining"
+                                                      ],
+                                                      "type": [
+                                                          "object",
+                                                          "null"
+                                                      ]
+                                                  }
+                                              },
+                                              "required": [],
+                                              "type": "object"
+                                          }
+                                      },
+                                      "required": [
+                                          "id",
+                                          "value"
+                                      ],
+                                      "type": "object"
+                                  }
+                              ]
+                          },
+                          "maxItems": 8,
+                          "minItems": 1,
+                          "type": [
+                              "array",
+                              "null"
+                          ]
+                      }
+                  },
+                  "required": [
+                      "coreData",
+                      "partII"
+                  ],
+                  "type": "object"
+              },
+              "dataType": {
+                  "type": "string"
+              }
+          },
+          "required": [
+              "dataType",
+              "data"
+          ],
+          "type": "object"
+      }
   },
   "required": [
-    "metadata",
-    "payload"
+      "metadata",
+      "payload"
   ],
   "type": "object"
 }

--- a/docs/schemas/schema-bsm.json
+++ b/docs/schemas/schema-bsm.json
@@ -1,2207 +1,2211 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
-  "properties": {
-      "metadata": {
-          "properties": {
-              "@class": {
-                  "type": "string"
-              },
-              "bsmSource": {
-                  "enum": [
-                      "EV",
-                      "RV",
-                      "unknown"
-                  ],
-                  "type": "string"
-              },
-              "encodings": {
-                  "items": {
-                      "properties": {
-                          "elementName": {
-                              "type": "string"
-                          },
-                          "elementType": {
-                              "type": "string"
-                          },
-                          "encodingRule": {
-                              "enum": [
-                                  "UPER",
-                                  "COER"
-                              ],
-                              "type": "string"
-                          }
-                      },
-                      "required": [
-                          "elementName",
-                          "elementType",
-                          "encodingRule"
-                      ],
-                      "type": "object"
-                  },
-                  "type": [
-                      "array",
-                      "null"
-                  ]
-              },
-              "logFileName": {
-                  "type": "string"
-              },
-              "maxDurationTime": {
-                  "type": [
-                      "integer",
-                      "null"
-                  ]
-              },
-              "odePacketID": {
-                  "type": [
-                      "string",
-                      "null"
-                  ]
-              },
-              "odeReceivedAt": {
-                  "type": "string"
-              },
-              "odeTimStartDateTime": {
-                  "type": [
-                      "string",
-                      "null"
-                  ]
-              },
-              "originIp": {
-                  "type": [
-                      "string",
-                      "null"
-                  ]
-              },
-              "payloadType": {
-                  "type": "string"
-              },
-              "receivedMessageDetails": {
-                  "properties": {
-                      "locationData": {
-                          "properties": {
-                              "elevation": {
-                                  "type": "string"
-                              },
-                              "heading": {
-                                  "type": "string"
-                              },
-                              "latitude": {
-                                  "type": "string"
-                              },
-                              "longitude": {
-                                  "type": "string"
-                              },
-                              "speed": {
-                                  "type": "string"
-                              }
-                          },
-                          "required": [
-                              "latitude",
-                              "longitude",
-                              "elevation",
-                              "speed",
-                              "heading"
-                          ],
-                          "type": "object"
-                      },
-                      "rxSource": {
-                          "enum": [
-                              "RSU",
-                              "SAT",
-                              "RV",
-                              "SNMP",
-                              "NA",
-                              "UNKNOWN"
-                          ],
-                          "type": "string"
-                      }
-                  },
-                  "required": [
-                      "locationData",
-                      "rxSource"
-                  ],
-                  "type": "object"
-              },
-              "recordGeneratedAt": {
-                  "type": "string"
-              },
-              "recordGeneratedBy": {
-                  "enum": [
-                      "TMC",
-                      "OBU",
-                      "RSU",
-                      "TMC_VIA_SAT",
-                      "TMC_VIA_SNMP",
-                      "UNKNOWN",
-                      null
-                  ],
-                  "type": [
-                      "string",
-                      "null"
-                  ]
-              },
-              "recordType": {
-                  "enum": [
-                      "bsmLogDuringEvent",
-                      "rxMsg",
-                      "dnMsg",
-                      "bsmTx",
-                      "driverAlert",
-                      "spatTx",
-                      "timMsg",
-                      "unsupported"
-                  ],
-                  "type": "string"
-              },
-              "sanitized": {
-                  "type": "boolean"
-              },
-              "schemaVersion": {
-                  "const": 6,
-                  "type": "integer"
-              },
-              "securityResultCode": {
-                  "enum": [
-                      "success",
-                      "unknown",
-                      "inconsistentInputParameters",
-                      "spduParsingInvalidInput",
-                      "spduParsingUnsupportedCriticalInformationField",
-                      "spduParsingCertificateNotFound",
-                      "spduParsingGenerationTimeNotAvailable",
-                      "spduParsingGenerationLocationNotAvailable",
-                      "spduCertificateChainNotEnoughInformationToConstructChain",
-                      "spduCertificateChainChainEndedAtUntrustedRoot",
-                      "spduCertificateChainChainWasTooLongForImplementation",
-                      "spduCertificateChainCertificateRevoked",
-                      "spduCertificateChainOverdueCRL",
-                      "spduCertificateChainInconsistentExpiryTimes",
-                      "spduCertificateChainInconsistentStartTimes",
-                      "spduCertificateChainInconsistentChainPermissions",
-                      "spduCryptoVerificationFailure",
-                      "spduConsistencyFutureCertificateAtGenerationTime",
-                      "spduConsistencyExpiredCertificateAtGenerationTime",
-                      "spduConsistencyExpiryDateTooEarly",
-                      "spduConsistencyExpiryDateTooLate",
-                      "spduConsistencyGenerationLocationOutsideValidityRegion",
-                      "spduConsistencyNoGenerationLocation",
-                      "spduConsistencyUnauthorizedPSID",
-                      "spduInternalConsistencyExpiryTimeBeforeGenerationTime",
-                      "spduInternalConsistencyextDataHashDoesntMatch",
-                      "spduInternalConsistencynoExtDataHashProvided",
-                      "spduInternalConsistencynoExtDataHashPresent",
-                      "spduLocalConsistencyPSIDsDontMatch",
-                      "spduLocalConsistencyChainWasTooLongForSDEE",
-                      "spduRelevanceGenerationTimeTooFarInPast",
-                      "spduRelevanceGenerationTimeTooFarInFuture",
-                      "spduRelevanceExpiryTimeInPast",
-                      "spduRelevanceGenerationLocationTooDistant",
-                      "spduRelevanceReplayedSpdu",
-                      "spduCertificateExpired"
-                  ],
-                  "type": "string"
-              },
-              "serialId": {
-                  "properties": {
-                      "bundleId": {
-                          "type": "integer"
-                      },
-                      "bundleSize": {
-                          "type": "integer"
-                      },
-                      "recordId": {
-                          "type": "integer"
-                      },
-                      "serialNumber": {
-                          "type": "integer"
-                      },
-                      "streamId": {
-                          "type": "string"
-                      }
-                  },
-                  "required": [
-                      "streamId",
-                      "bundleSize",
-                      "bundleId",
-                      "recordId",
-                      "serialNumber"
-                  ],
-                  "type": "object"
-              }
-          },
-          "required": [
-              "@class",
-              "bsmSource",
-              "logFileName",
-              "recordType",
-              "securityResultCode",
-              "receivedMessageDetails",
-              "payloadType",
-              "serialId",
-              "odeReceivedAt",
-              "schemaVersion",
-              "recordGeneratedAt",
-              "sanitized"
-          ],
-          "type": "object"
-      },
-      "payload": {
-          "properties": {
-              "data": {
-                  "properties": {
-                      "coreData": {
-                          "properties": {
-                              "accelSet": {
-                                  "properties": {
-                                      "accelLat": {
-                                          "type": [
-                                              "number",
-                                              "null"
-                                          ]
-                                      },
-                                      "accelLong": {
-                                          "type": "number"
-                                      },
-                                      "accelVert": {
-                                          "type": [
-                                              "number",
-                                              "null"
-                                          ]
-                                      },
-                                      "accelYaw": {
-                                          "type": "number"
-                                      }
-                                  },
-                                  "required": [
-                                      "accelLong",
-                                      "accelYaw"
-                                  ],
-                                  "type": "object"
-                              },
-                              "accuracy": {
-                                  "properties": {
-                                      "orientation": {
-                                          "type": [
-                                              "number",
-                                              "null"
-                                          ]
-                                      },
-                                      "semiMajor": {
-                                          "type": [
-                                              "number",
-                                              "null"
-                                          ]
-                                      },
-                                      "semiMinor": {
-                                          "type": [
-                                              "number",
-                                              "null"
-                                          ]
-                                      }
-                                  },
-                                  "required": [],
-                                  "type": "object"
-                              },
-                              "angle": {
-                                  "type": [
-                                      "number",
-                                      "null"
-                                  ]
-                              },
-                              "brakes": {
-                                  "properties": {
-                                      "abs": {
-                                          "type": "string"
-                                      },
-                                      "auxBrakes": {
-                                          "type": "string"
-                                      },
-                                      "brakeBoost": {
-                                          "type": "string"
-                                      },
-                                      "scs": {
-                                          "type": "string"
-                                      },
-                                      "traction": {
-                                          "type": "string"
-                                      },
-                                      "wheelBrakes": {
-                                          "properties": {
-                                              "leftFront": {
-                                                  "type": "boolean"
-                                              },
-                                              "leftRear": {
-                                                  "type": "boolean"
-                                              },
-                                              "rightFront": {
-                                                  "type": "boolean"
-                                              },
-                                              "rightRear": {
-                                                  "type": "boolean"
-                                              },
-                                              "unavailable": {
-                                                  "type": "boolean"
-                                              }
-                                          },
-                                          "required": [
-                                              "unavailable",
-                                              "leftFront",
-                                              "leftRear",
-                                              "rightFront",
-                                              "rightRear"
-                                          ],
-                                          "type": "object"
-                                      }
-                                  },
-                                  "required": [
-                                      "wheelBrakes",
-                                      "traction",
-                                      "abs",
-                                      "scs",
-                                      "brakeBoost",
-                                      "auxBrakes"
-                                  ],
-                                  "type": "object"
-                              },
-                              "heading": {
-                                  "type": "number"
-                              },
-                              "id": {
-                                  "type": "string"
-                              },
-                              "msgCnt": {
-                                  "type": "integer"
-                              },
-                              "position": {
-                                  "properties": {
-                                      "elevation": {
-                                          "type": [
-                                              "number",
-                                              "null"
-                                          ]
-                                      },
-                                      "latitude": {
-                                          "type": "number"
-                                      },
-                                      "longitude": {
-                                          "type": "number"
-                                      }
-                                  },
-                                  "required": [
-                                      "latitude",
-                                      "longitude"
-                                  ],
-                                  "type": "object"
-                              },
-                              "secMark": {
-                                  "type": "integer"
-                              },
-                              "size": {
-                                  "properties": {
-                                      "length": {
-                                          "type": [
-                                              "integer",
-                                              "null"
-                                          ]
-                                      },
-                                      "width": {
-                                          "type": [
-                                              "integer",
-                                              "null"
-                                          ]
-                                      }
-                                  },
-                                  "required": [],
-                                  "type": "object"
-                              },
-                              "speed": {
-                                  "type": "number"
-                              },
-                              "transmission": {
-                                  "enum": [
-                                      "NEUTRAL",
-                                      "PARK",
-                                      "FORWARDGEARS",
-                                      "REVERSEGEARS",
-                                      "RESERVED1",
-                                      "RESERVED2",
-                                      "RESERVED3",
-                                      "UNAVAILABLE"
-                                  ],
-                                  "type": "string"
-                              }
-                          },
-                          "required": [
-                              "msgCnt",
-                              "id",
-                              "secMark",
-                              "position",
-                              "accelSet",
-                              "accuracy",
-                              "transmission",
-                              "speed",
-                              "heading",
-                              "brakes",
-                              "size"
-                          ],
-                          "type": "object"
-                      },
-                      "partII": {
-                          "items": {
-                              "oneOf": [
-                                  {
-                                      "properties": {
-                                          "id": {
-                                              "const": "VehicleSafetyExtensions",
-                                              "type": "string"
-                                          },
-                                          "value": {
-                                              "properties": {
-                                                  "events": {
-                                                      "properties": {
-                                                          "eventABSactivated": {
-                                                              "type": "boolean"
-                                                          },
-                                                          "eventAirBagDeployment": {
-                                                              "type": "boolean"
-                                                          },
-                                                          "eventDisabledVehicle": {
-                                                              "type": "boolean"
-                                                          },
-                                                          "eventFlatTire": {
-                                                              "type": "boolean"
-                                                          },
-                                                          "eventHardBraking": {
-                                                              "type": "boolean"
-                                                          },
-                                                          "eventHazardLights": {
-                                                              "type": "boolean"
-                                                          },
-                                                          "eventHazardousMaterials": {
-                                                              "type": "boolean"
-                                                          },
-                                                          "eventLightsChanged": {
-                                                              "type": "boolean"
-                                                          },
-                                                          "eventReserved1": {
-                                                              "type": "boolean"
-                                                          },
-                                                          "eventStabilityControlactivated": {
-                                                              "type": "boolean"
-                                                          },
-                                                          "eventStopLineViolation": {
-                                                              "type": "boolean"
-                                                          },
-                                                          "eventTractionControlLoss": {
-                                                              "type": "boolean"
-                                                          },
-                                                          "eventWipersChanged": {
-                                                              "type": "boolean"
-                                                          }
-                                                      },
-                                                      "required": [
-                                                          "eventHazardLights",
-                                                          "eventStopLineViolation",
-                                                          "eventABSactivated",
-                                                          "eventTractionControlLoss",
-                                                          "eventStabilityControlactivated",
-                                                          "eventHazardousMaterials",
-                                                          "eventReserved1",
-                                                          "eventHardBraking",
-                                                          "eventLightsChanged",
-                                                          "eventWipersChanged",
-                                                          "eventFlatTire",
-                                                          "eventDisabledVehicle",
-                                                          "eventAirBagDeployment"
-                                                      ],
-                                                      "type": [
-                                                          "object",
-                                                          "null"
-                                                      ]
-                                                  },
-                                                  "lights": {
-                                                      "properties": {
-                                                          "automaticLightControlOn": {
-                                                              "type": "boolean"
-                                                          },
-                                                          "daytimeRunningLightsOn": {
-                                                              "type": "boolean"
-                                                          },
-                                                          "fogLightOn": {
-                                                              "type": "boolean"
-                                                          },
-                                                          "hazardSignalOn": {
-                                                              "type": "boolean"
-                                                          },
-                                                          "highBeamHeadlightsOn": {
-                                                              "type": "boolean"
-                                                          },
-                                                          "leftTurnSignalOn": {
-                                                              "type": "boolean"
-                                                          },
-                                                          "lowBeamHeadlightsOn": {
-                                                              "type": "boolean"
-                                                          },
-                                                          "parkingLightsOn": {
-                                                              "type": "boolean"
-                                                          },
-                                                          "rightTurnSignalOn": {
-                                                              "type": "boolean"
-                                                          }
-                                                      },
-                                                      "required": [
-                                                          "lowBeamHeadlightsOn",
-                                                          "highBeamHeadlightsOn",
-                                                          "leftTurnSignalOn",
-                                                          "rightTurnSignalOn",
-                                                          "hazardSignalOn",
-                                                          "automaticLightControlOn",
-                                                          "daytimeRunningLightsOn",
-                                                          "fogLightOn",
-                                                          "parkingLightsOn"
-                                                      ],
-                                                      "type": [
-                                                          "object",
-                                                          "null"
-                                                      ]
-                                                  },
-                                                  "pathHistory": {
-                                                      "properties": {
-                                                          "crumbData": {
-                                                              "items": {
-                                                                  "properties": {
-                                                                      "elevationOffset": {
-                                                                          "type": "number"
-                                                                      },
-                                                                      "heading": {
-                                                                          "type": [
-                                                                              "number",
-                                                                              "null"
-                                                                          ]
-                                                                      },
-                                                                      "latOffset": {
-                                                                          "type": "number"
-                                                                      },
-                                                                      "lonOffset": {
-                                                                          "type": "number"
-                                                                      },
-                                                                      "posAccuracy": {
-                                                                          "properties": {
-                                                                              "orientation": {
-                                                                                  "type": "number"
-                                                                              },
-                                                                              "semiMajor": {
-                                                                                  "type": "number"
-                                                                              },
-                                                                              "semiMinor": {
-                                                                                  "type": "number"
-                                                                              }
-                                                                          },
-                                                                          "required": [
-                                                                              "semiMajor",
-                                                                              "semiMinor",
-                                                                              "orientation"
-                                                                          ],
-                                                                          "type": [
-                                                                              "object",
-                                                                              "null"
-                                                                          ]
-                                                                      },
-                                                                      "speed": {
-                                                                          "type": [
-                                                                              "number",
-                                                                              "null"
-                                                                          ]
-                                                                      },
-                                                                      "timeOffset": {
-                                                                          "type": "number"
-                                                                      }
-                                                                  },
-                                                                  "required": [
-                                                                      "elevationOffset",
-                                                                      "latOffset",
-                                                                      "lonOffset",
-                                                                      "timeOffset"
-                                                                  ],
-                                                                  "type": "object"
-                                                              },
-                                                              "maxItems": 23,
-                                                              "minItems": 1,
-                                                              "type": "array"
-                                                          },
-                                                          "currGNSSstatus": {
-                                                              "properties": {
-                                                                  "aPDOPofUnder5": {
-                                                                      "type": "boolean"
-                                                                  },
-                                                                  "baseStationType": {
-                                                                      "type": "boolean"
-                                                                  },
-                                                                  "inViewOfUnder5": {
-                                                                      "type": "boolean"
-                                                                  },
-                                                                  "isHealthy": {
-                                                                      "type": "boolean"
-                                                                  },
-                                                                  "isMonitored": {
-                                                                      "type": "boolean"
-                                                                  },
-                                                                  "localCorrectionsPresent": {
-                                                                      "type": "boolean"
-                                                                  },
-                                                                  "networkCorrectionsPresent": {
-                                                                      "type": "boolean"
-                                                                  },
-                                                                  "unavailable": {
-                                                                      "type": "boolean"
-                                                                  }
-                                                              },
-                                                              "required": [
-                                                                  "unavailable",
-                                                                  "isHealthy",
-                                                                  "isMonitored",
-                                                                  "baseStationType",
-                                                                  "aPDOPofUnder5",
-                                                                  "inViewOfUnder5",
-                                                                  "localCorrectionsPresent",
-                                                                  "networkCorrectionsPresent"
-                                                              ],
-                                                              "type": [
-                                                                  "object",
-                                                                  "null"
-                                                              ]
-                                                          },
-                                                          "initialPosition": {
-                                                              "properties": {
-                                                                  "heading": {
-                                                                      "type": [
-                                                                          "number",
-                                                                          "null"
-                                                                      ]
-                                                                  },
-                                                                  "posAccuracy": {
-                                                                      "properties": {
-                                                                          "orientation": {
-                                                                              "type": [
-                                                                                  "number",
-                                                                                  "null"
-                                                                              ]
-                                                                          },
-                                                                          "semiMajor": {
-                                                                              "type": [
-                                                                                  "number",
-                                                                                  "null"
-                                                                              ]
-                                                                          },
-                                                                          "semiMinor": {
-                                                                              "type": [
-                                                                                  "number",
-                                                                                  "null"
-                                                                              ]
-                                                                          }
-                                                                      },
-                                                                      "required": [],
-                                                                      "type": "object"
-                                                                  },
-                                                                  "posConfidence": {
-                                                                      "properties": {
-                                                                          "elevation": {
-                                                                              "enum": [
-                                                                                  "UNAVAILABLE",
-                                                                                  "ELEV_500_00",
-                                                                                  "ELEV_200_00",
-                                                                                  "ELEV_100_00",
-                                                                                  "ELEV_050_00",
-                                                                                  "ELEV_020_00",
-                                                                                  "ELEV_010_00",
-                                                                                  "ELEV_005_00",
-                                                                                  "ELEV_002_00",
-                                                                                  "ELEV_001_00",
-                                                                                  "ELEV_000_50",
-                                                                                  "ELEV_000_20",
-                                                                                  "ELEV_000_10",
-                                                                                  "ELEV_000_05",
-                                                                                  "ELEV_000_02",
-                                                                                  "ELEV_000_01"
-                                                                              ],
-                                                                              "type": "string"
-                                                                          },
-                                                                          "pos": {
-                                                                              "enum": [
-                                                                                  "UNAVAILABLE",
-                                                                                  "A500M",
-                                                                                  "A200M",
-                                                                                  "A100M",
-                                                                                  "A50M",
-                                                                                  "A20M",
-                                                                                  "A10M",
-                                                                                  "A5M",
-                                                                                  "A2M",
-                                                                                  "A1M",
-                                                                                  "A50CM",
-                                                                                  "A20CM",
-                                                                                  "A10CM",
-                                                                                  "A5CM",
-                                                                                  "A2CM",
-                                                                                  "A1CM"
-                                                                              ],
-                                                                              "type": "string"
-                                                                          }
-                                                                      },
-                                                                      "required": [
-                                                                          "pos",
-                                                                          "elevation"
-                                                                      ],
-                                                                      "type": [
-                                                                          "object",
-                                                                          "null"
-                                                                      ]
-                                                                  },
-                                                                  "position": {
-                                                                      "properties": {
-                                                                          "elevation": {
-                                                                              "type": [
-                                                                                  "number",
-                                                                                  "null"
-                                                                              ]
-                                                                          },
-                                                                          "latitude": {
-                                                                              "type": "number"
-                                                                          },
-                                                                          "longitude": {
-                                                                              "type": "number"
-                                                                          }
-                                                                      },
-                                                                      "required": [
-                                                                          "latitude",
-                                                                          "longitude"
-                                                                      ],
-                                                                      "type": "object"
-                                                                  },
-                                                                  "speed": {
-                                                                      "properties": {
-                                                                          "speed": {
-                                                                              "type": "number"
-                                                                          },
-                                                                          "transmission": {
-                                                                              "enum": [
-                                                                                  "NEUTRAL",
-                                                                                  "PARK",
-                                                                                  "FORWARDGEARS",
-                                                                                  "REVERSEGEARS",
-                                                                                  "RESERVED1",
-                                                                                  "RESERVED2",
-                                                                                  "RESERVED3",
-                                                                                  "UNAVAILABLE"
-                                                                              ],
-                                                                              "type": "string"
-                                                                          }
-                                                                      },
-                                                                      "required": [
-                                                                          "speed",
-                                                                          "transmission"
-                                                                      ],
-                                                                      "type": [
-                                                                          "object",
-                                                                          "null"
-                                                                      ]
-                                                                  },
-                                                                  "speedConfidence": {
-                                                                      "properties": {
-                                                                          "heading": {
-                                                                              "enum": [
-                                                                                  "UNAVAILABLE",
-                                                                                  "PREC10DEG",
-                                                                                  "PREC05DEG",
-                                                                                  "PREC01DEG",
-                                                                                  "PREC0_1DEG",
-                                                                                  "PREC0_05DEG",
-                                                                                  "PREC0_01DEG",
-                                                                                  "PREC0_0125DEG"
-                                                                              ],
-                                                                              "type": "string"
-                                                                          },
-                                                                          "speed": {
-                                                                              "enum": [
-                                                                                  "UNAVAILABLE",
-                                                                                  "PREC100MS",
-                                                                                  "PREC10MS",
-                                                                                  "PREC5MS",
-                                                                                  "PREC1MS",
-                                                                                  "PREC0_1MS",
-                                                                                  "PREC0_05MS",
-                                                                                  "PREC0_01MS"
-                                                                              ],
-                                                                              "type": "string"
-                                                                          },
-                                                                          "throttle": {
-                                                                              "enum": [
-                                                                                  "UNAVAILABLE",
-                                                                                  "PREC10PERCENT",
-                                                                                  "PREC1PERCENT",
-                                                                                  "PREC0_5PERCENT"
-                                                                              ],
-                                                                              "type": "string"
-                                                                          }
-                                                                      },
-                                                                      "required": [
-                                                                          "heading",
-                                                                          "speed",
-                                                                          "throttle"
-                                                                      ],
-                                                                      "type": [
-                                                                          "object",
-                                                                          "null"
-                                                                      ]
-                                                                  },
-                                                                  "timeConfidence": {
-                                                                      "enum": [
-                                                                          "UNAVAILABLE",
-                                                                          "TIME_100_000",
-                                                                          "TIME_050_000",
-                                                                          "TIME_020_000",
-                                                                          "TIME_010_000",
-                                                                          "TIME_002_000",
-                                                                          "TIME_001_000",
-                                                                          "TIME_000_500",
-                                                                          "TIME_000_200",
-                                                                          "TIME_000_100",
-                                                                          "TIME_000_050",
-                                                                          "TIME_000_020",
-                                                                          "TIME_000_010",
-                                                                          "TIME_000_005",
-                                                                          "TIME_000_002",
-                                                                          "TIME_000_001",
-                                                                          "TIME_000_000_5",
-                                                                          "TIME_000_000_2",
-                                                                          "TIME_000_000_1",
-                                                                          "TIME_000_000_05",
-                                                                          "TIME_000_000_02",
-                                                                          "TIME_000_000_01",
-                                                                          "TIME_000_000_005",
-                                                                          "TIME_000_000_002",
-                                                                          "TIME_000_000_001",
-                                                                          "TIME_000_000_000_5",
-                                                                          "TIME_000_000_000_2",
-                                                                          "TIME_000_000_000_1",
-                                                                          "TIME_000_000_000_05",
-                                                                          "TIME_000_000_000_02",
-                                                                          "TIME_000_000_000_01",
-                                                                          "TIME_000_000_000_005",
-                                                                          "TIME_000_000_000_002",
-                                                                          "TIME_000_000_000_001",
-                                                                          "TIME_000_000_000_000_5",
-                                                                          "TIME_000_000_000_000_2",
-                                                                          "TIME_000_000_000_000_1",
-                                                                          "TIME_000_000_000_000_05",
-                                                                          "TIME_000_000_000_000_02",
-                                                                          "TIME_000_000_000_000_01",
-                                                                          null
-                                                                      ],
-                                                                      "type": [
-                                                                          "string",
-                                                                          "null"
-                                                                      ]
-                                                                  },
-                                                                  "utcTime": {
-                                                                      "properties": {
-                                                                          "day": {
-                                                                              "type": [
-                                                                                  "integer",
-                                                                                  "null"
-                                                                              ]
-                                                                          },
-                                                                          "hour": {
-                                                                              "type": [
-                                                                                  "integer",
-                                                                                  "null"
-                                                                              ]
-                                                                          },
-                                                                          "minute": {
-                                                                              "type": [
-                                                                                  "integer",
-                                                                                  "null"
-                                                                              ]
-                                                                          },
-                                                                          "month": {
-                                                                              "type": [
-                                                                                  "integer",
-                                                                                  "null"
-                                                                              ]
-                                                                          },
-                                                                          "offset": {
-                                                                              "type": [
-                                                                                  "integer",
-                                                                                  "null"
-                                                                              ]
-                                                                          },
-                                                                          "second": {
-                                                                              "type": [
-                                                                                  "integer",
-                                                                                  "null"
-                                                                              ]
-                                                                          },
-                                                                          "year": {
-                                                                              "type": [
-                                                                                  "integer",
-                                                                                  "null"
-                                                                              ]
-                                                                          }
-                                                                      },
-                                                                      "required": [],
-                                                                      "type": [
-                                                                          "object",
-                                                                          "null"
-                                                                      ]
-                                                                  }
-                                                              },
-                                                              "required": [
-                                                                  "position"
-                                                              ],
-                                                              "type": [
-                                                                  "object",
-                                                                  "null"
-                                                              ]
-                                                          }
-                                                      },
-                                                      "required": [
-                                                          "crumbData"
-                                                      ],
-                                                      "type": [
-                                                          "object",
-                                                          "null"
-                                                      ]
-                                                  },
-                                                  "pathPrediction": {
-                                                      "properties": {
-                                                          "confidence": {
-                                                              "type": "number"
-                                                          },
-                                                          "radiusOfCurve": {
-                                                              "type": "number"
-                                                          }
-                                                      },
-                                                      "required": [
-                                                          "confidence",
-                                                          "radiusOfCurve"
-                                                      ],
-                                                      "type": [
-                                                          "object",
-                                                          "null"
-                                                      ]
-                                                  }
-                                              },
-                                              "required": [],
-                                              "type": "object"
-                                          }
-                                      },
-                                      "required": [
-                                          "id",
-                                          "value"
-                                      ],
-                                      "type": "object"
-                                  },
-                                  {
-                                      "properties": {
-                                          "id": {
-                                              "const": "SpecialVehicleExtensions",
-                                              "type": "string"
-                                          },
-                                          "value": {
-                                              "properties": {
-                                                  "description": {
-                                                      "properties": {
-                                                          "description": {
-                                                              "items": {
-                                                                  "type": "integer"
-                                                              },
-                                                              "maxItems": 8,
-                                                              "minItems": 1,
-                                                              "type": [
-                                                                  "array",
-                                                                  "null"
-                                                              ]
-                                                          },
-                                                          "extent": {
-                                                              "enum": [
-                                                                  "USEINSTANTLYONLY",
-                                                                  "USEFOR3METERS",
-                                                                  "USEFOR10METERS",
-                                                                  "USEFOR50METERS",
-                                                                  "USEFOR100METERS",
-                                                                  "USEFOR500METERS",
-                                                                  "USEFOR1000METERS",
-                                                                  "USEFOR5000METERS",
-                                                                  "USEFOR10000METERS",
-                                                                  "USEFOR50000METERS",
-                                                                  "USEFOR100000METERS",
-                                                                  "USEFOR500000METERS",
-                                                                  "USEFOR1000000METERS",
-                                                                  "USEFOR5000000METERS",
-                                                                  "USEFOR10000000METERS",
-                                                                  "FOREVER",
-                                                                  null
-                                                              ],
-                                                              "type": [
-                                                                  "string",
-                                                                  "null"
-                                                              ]
-                                                          },
-                                                          "heading": {
-                                                              "properties": {
-                                                                  "FROM000_0TO022_5DEGREES": {
-                                                                      "type": "boolean"
-                                                                  },
-                                                                  "FROM022_5TO045_0DEGREES": {
-                                                                      "type": "boolean"
-                                                                  },
-                                                                  "FROM045_0TO067_5DEGREES": {
-                                                                      "type": "boolean"
-                                                                  },
-                                                                  "FROM067_5TO090_0DEGREES": {
-                                                                      "type": "boolean"
-                                                                  },
-                                                                  "FROM090_0TO112_5DEGREES": {
-                                                                      "type": "boolean"
-                                                                  },
-                                                                  "FROM112_5TO135_0DEGREES": {
-                                                                      "type": "boolean"
-                                                                  },
-                                                                  "FROM135_0TO157_5DEGREES": {
-                                                                      "type": "boolean"
-                                                                  },
-                                                                  "FROM157_5TO180_0DEGREES": {
-                                                                      "type": "boolean"
-                                                                  },
-                                                                  "FROM180_0TO202_5DEGREES": {
-                                                                      "type": "boolean"
-                                                                  },
-                                                                  "FROM202_5TO225_0DEGREES": {
-                                                                      "type": "boolean"
-                                                                  },
-                                                                  "FROM225_0TO247_5DEGREES": {
-                                                                      "type": "boolean"
-                                                                  },
-                                                                  "FROM247_5TO270_0DEGREES": {
-                                                                      "type": "boolean"
-                                                                  },
-                                                                  "FROM270_0TO292_5DEGREES": {
-                                                                      "type": "boolean"
-                                                                  },
-                                                                  "FROM292_5TO315_0DEGREES": {
-                                                                      "type": "boolean"
-                                                                  },
-                                                                  "FROM315_0TO337_5DEGREES": {
-                                                                      "type": "boolean"
-                                                                  },
-                                                                  "FROM337_5TO360_0DEGREES": {
-                                                                      "type": "boolean"
-                                                                  }
-                                                              },
-                                                              "required": [
-                                                                  "FROM000_0TO022_5DEGREES",
-                                                                  "FROM022_5TO045_0DEGREES",
-                                                                  "FROM045_0TO067_5DEGREES",
-                                                                  "FROM067_5TO090_0DEGREES",
-                                                                  "FROM090_0TO112_5DEGREES",
-                                                                  "FROM112_5TO135_0DEGREES",
-                                                                  "FROM135_0TO157_5DEGREES",
-                                                                  "FROM157_5TO180_0DEGREES",
-                                                                  "FROM180_0TO202_5DEGREES",
-                                                                  "FROM202_5TO225_0DEGREES",
-                                                                  "FROM225_0TO247_5DEGREES",
-                                                                  "FROM247_5TO270_0DEGREES",
-                                                                  "FROM270_0TO292_5DEGREES",
-                                                                  "FROM292_5TO315_0DEGREES",
-                                                                  "FROM315_0TO337_5DEGREES",
-                                                                  "FROM337_5TO360_0DEGREES"
-                                                              ],
-                                                              "type": [
-                                                                  "object",
-                                                                  "null"
-                                                              ]
-                                                          },
-                                                          "priority": {
-                                                              "type": [
-                                                                  "string",
-                                                                  "null"
-                                                              ]
-                                                          },
-                                                          "regional": {
-                                                              "items": {
-                                                                  "properties": {
-                                                                      "id": {
-                                                                          "type": "integer"
-                                                                      },
-                                                                      "value": {
-                                                                          "contentEncoding": "base64",
-                                                                          "type": "string"
-                                                                      }
-                                                                  },
-                                                                  "required": [
-                                                                      "id",
-                                                                      "value"
-                                                                  ],
-                                                                  "type": "object"
-                                                              },
-                                                              "maxItems": 4,
-                                                              "minItems": 1,
-                                                              "type": [
-                                                                  "array",
-                                                                  "null"
-                                                              ]
-                                                          },
-                                                          "typeEvent": {
-                                                              "type": "integer"
-                                                          }
-                                                      },
-                                                      "required": [],
-                                                      "type": [
-                                                          "object",
-                                                          "null"
-                                                      ]
-                                                  },
-                                                  "trailers": {
-                                                      "properties": {
-                                                          "connection": {
-                                                              "properties": {
-                                                                  "pivotAngle": {
-                                                                      "type": "number"
-                                                                  },
-                                                                  "pivotOffset": {
-                                                                      "type": "number"
-                                                                  },
-                                                                  "pivots": {
-                                                                      "type": "boolean"
-                                                                  }
-                                                              },
-                                                              "required": [
-                                                                  "pivotOffset",
-                                                                  "pivotAngle",
-                                                                  "pivots"
-                                                              ],
-                                                              "type": "object"
-                                                          },
-                                                          "sspRights": {
-                                                              "type": "integer"
-                                                          },
-                                                          "units": {
-                                                              "items": {
-                                                                  "properties": {
-                                                                      "bumperHeights": {
-                                                                          "properties": {
-                                                                              "front": {
-                                                                                  "type": "number"
-                                                                              },
-                                                                              "rear": {
-                                                                                  "type": "number"
-                                                                              }
-                                                                          },
-                                                                          "required": [
-                                                                              "front",
-                                                                              "rear"
-                                                                          ],
-                                                                          "type": [
-                                                                              "object",
-                                                                              "null"
-                                                                          ]
-                                                                      },
-                                                                      "centerOfGravity": {
-                                                                          "type": [
-                                                                              "number",
-                                                                              "null"
-                                                                          ]
-                                                                      },
-                                                                      "crumbData": {
-                                                                          "items": {
-                                                                              "properties": {
-                                                                                  "elevationOffset": {
-                                                                                      "type": "number"
-                                                                                  },
-                                                                                  "heading": {
-                                                                                      "type": [
-                                                                                          "number",
-                                                                                          "null"
-                                                                                      ]
-                                                                                  },
-                                                                                  "latOffset": {
-                                                                                      "type": "number"
-                                                                                  },
-                                                                                  "lonOffset": {
-                                                                                      "type": "number"
-                                                                                  },
-                                                                                  "posAccuracy": {
-                                                                                      "properties": {
-                                                                                          "orientation": {
-                                                                                              "type": "number"
-                                                                                          },
-                                                                                          "semiMajor": {
-                                                                                              "type": "number"
-                                                                                          },
-                                                                                          "semiMinor": {
-                                                                                              "type": "number"
-                                                                                          }
-                                                                                      },
-                                                                                      "required": [
-                                                                                          "semiMajor",
-                                                                                          "semiMinor",
-                                                                                          "orientation"
-                                                                                      ],
-                                                                                      "type": [
-                                                                                          "object",
-                                                                                          "null"
-                                                                                      ]
-                                                                                  },
-                                                                                  "speed": {
-                                                                                      "type": [
-                                                                                          "number",
-                                                                                          "null"
-                                                                                      ]
-                                                                                  },
-                                                                                  "timeOffset": {
-                                                                                      "type": "number"
-                                                                                  }
-                                                                              },
-                                                                              "required": [
-                                                                                  "elevationOffset",
-                                                                                  "latOffset",
-                                                                                  "lonOffset",
-                                                                                  "timeOffset"
-                                                                              ],
-                                                                              "type": "object"
-                                                                          },
-                                                                          "maxItems": 23,
-                                                                          "minItems": 1,
-                                                                          "type": [
-                                                                              "array",
-                                                                              "null"
-                                                                          ]
-                                                                      },
-                                                                      "elevationOffset": {
-                                                                          "type": [
-                                                                              "number",
-                                                                              "null"
-                                                                          ]
-                                                                      },
-                                                                      "frontPivot": {
-                                                                          "properties": {
-                                                                              "pivotAngle": {
-                                                                                  "type": "number"
-                                                                              },
-                                                                              "pivotOffset": {
-                                                                                  "type": "number"
-                                                                              },
-                                                                              "pivots": {
-                                                                                  "type": "boolean"
-                                                                              }
-                                                                          },
-                                                                          "required": [
-                                                                              "pivotOffset",
-                                                                              "pivotAngle",
-                                                                              "pivots"
-                                                                          ],
-                                                                          "type": "object"
-                                                                      },
-                                                                      "height": {
-                                                                          "type": [
-                                                                              "number",
-                                                                              "null"
-                                                                          ]
-                                                                      },
-                                                                      "isDolly": {
-                                                                          "type": "boolean"
-                                                                      },
-                                                                      "length": {
-                                                                          "type": [
-                                                                              "integer",
-                                                                              "null"
-                                                                          ]
-                                                                      },
-                                                                      "mass": {
-                                                                          "type": [
-                                                                              "integer",
-                                                                              "null"
-                                                                          ]
-                                                                      },
-                                                                      "positionOffset": {
-                                                                          "properties": {
-                                                                              "x": {
-                                                                                  "type": "number"
-                                                                              },
-                                                                              "y": {
-                                                                                  "type": "number"
-                                                                              }
-                                                                          },
-                                                                          "required": [
-                                                                              "x",
-                                                                              "y"
-                                                                          ],
-                                                                          "type": "object"
-                                                                      },
-                                                                      "rearPivot": {
-                                                                          "properties": {
-                                                                              "pivotAngle": {
-                                                                                  "type": "number"
-                                                                              },
-                                                                              "pivotOffset": {
-                                                                                  "type": "number"
-                                                                              },
-                                                                              "pivots": {
-                                                                                  "type": "boolean"
-                                                                              }
-                                                                          },
-                                                                          "required": [
-                                                                              "pivotOffset",
-                                                                              "pivotAngle",
-                                                                              "pivots"
-                                                                          ],
-                                                                          "type": [
-                                                                              "object",
-                                                                              "null"
-                                                                          ]
-                                                                      },
-                                                                      "rearWheelOffset": {
-                                                                          "type": [
-                                                                              "number",
-                                                                              "null"
-                                                                          ]
-                                                                      },
-                                                                      "width": {
-                                                                          "type": [
-                                                                              "integer",
-                                                                              "null"
-                                                                          ]
-                                                                      }
-                                                                  },
-                                                                  "required": [
-                                                                      "isDolly",
-                                                                      "frontPivot",
-                                                                      "positionOffset"
-                                                                  ],
-                                                                  "type": "object"
-                                                              },
-                                                              "maxItems": 8,
-                                                              "minItems": 1,
-                                                              "type": "array"
-                                                          }
-                                                      },
-                                                      "required": [
-                                                          "connection",
-                                                          "sspRights",
-                                                          "units"
-                                                      ],
-                                                      "type": [
-                                                          "object",
-                                                          "null"
-                                                      ]
-                                                  },
-                                                  "vehicleAlerts": {
-                                                      "properties": {
-                                                          "events": {
-                                                              "properties": {
-                                                                  "event": {
-                                                                      "properties": {
-                                                                          "peEmergencyLightsActive": {
-                                                                              "type": "boolean"
-                                                                          },
-                                                                          "peEmergencyResponse": {
-                                                                              "type": "boolean"
-                                                                          },
-                                                                          "peEmergencySoundActive": {
-                                                                              "type": "boolean"
-                                                                          },
-                                                                          "peNonEmergencyLightsActive": {
-                                                                              "type": "boolean"
-                                                                          },
-                                                                          "peNonEmergencySoundActive": {
-                                                                              "type": "boolean"
-                                                                          },
-                                                                          "peUnavailable": {
-                                                                              "type": "boolean"
-                                                                          }
-                                                                      },
-                                                                      "required": [
-                                                                          "peUnavailable",
-                                                                          "peEmergencyResponse",
-                                                                          "peEmergencyLightsActive",
-                                                                          "peEmergencySoundActive",
-                                                                          "peNonEmergencyLightsActive",
-                                                                          "peNonEmergencySoundActive"
-                                                                      ],
-                                                                      "type": "object"
-                                                                  },
-                                                                  "sspRights": {
-                                                                      "type": "integer"
-                                                                  }
-                                                              },
-                                                              "required": [
-                                                                  "event",
-                                                                  "sspRights"
-                                                              ],
-                                                              "type": [
-                                                                  "object",
-                                                                  "null"
-                                                              ]
-                                                          },
-                                                          "lightsUse": {
-                                                              "enum": [
-                                                                  "UNAVAILABLE",
-                                                                  "NOTINUSE",
-                                                                  "INUSE",
-                                                                  "YELLOWCAUTIONLIGHTS",
-                                                                  "SCHOOLBUSLIGHTS",
-                                                                  "ARROWSIGNSACTIVE",
-                                                                  "SLOWMOVINGVEHICLE",
-                                                                  "FREQSTOPS"
-                                                              ],
-                                                              "type": "string"
-                                                          },
-                                                          "multi": {
-                                                              "enum": [
-                                                                  "UNAVAILABLE",
-                                                                  "SINGLEVEHICLE",
-                                                                  "MULTIVEHICLE",
-                                                                  "RESERVED"
-                                                              ],
-                                                              "type": "string"
-                                                          },
-                                                          "responseType": {
-                                                              "enum": [
-                                                                  "NOTINUSEORNOTEQUIPPED",
-                                                                  "EMERGENCY",
-                                                                  "NONEMERGENCY",
-                                                                  "PURSUIT",
-                                                                  "STATIONARY",
-                                                                  "SLOWMOVING",
-                                                                  "STOPANDGOMOVEMENT",
-                                                                  null
-                                                              ],
-                                                              "type": [
-                                                                  "string",
-                                                                  "null"
-                                                              ]
-                                                          },
-                                                          "sirenUse": {
-                                                              "enum": [
-                                                                  "UNAVAILABLE",
-                                                                  "NOTINUSE",
-                                                                  "INUSE",
-                                                                  "RESERVED"
-                                                              ],
-                                                              "type": "string"
-                                                          },
-                                                          "sspRights": {
-                                                              "type": "number"
-                                                          }
-                                                      },
-                                                      "required": [
-                                                          "sspRights",
-                                                          "lightsUse",
-                                                          "multi",
-                                                          "sirenUse"
-                                                      ],
-                                                      "type": [
-                                                          "object",
-                                                          "null"
-                                                      ]
-                                                  }
-                                              },
-                                              "required": [],
-                                              "type": "object"
-                                          }
-                                      },
-                                      "required": [
-                                          "id",
-                                          "value"
-                                      ],
-                                      "type": "object"
-                                  },
-                                  {
-                                      "properties": {
-                                          "id": {
-                                              "const": "SupplementalVehicleExtensions",
-                                              "type": "string"
-                                          },
-                                          "value": {
-                                              "properties": {
-                                                  "classDetails": {
-                                                      "properties": {
-                                                          "fuelType": {
-                                                              "enum": [
-                                                                  "unknownFuel",
-                                                                  "gasoline",
-                                                                  "ethanol",
-                                                                  "diesel",
-                                                                  "electric",
-                                                                  "hybrid",
-                                                                  "hydrogen",
-                                                                  "natGasLiquid",
-                                                                  "natGasComp",
-                                                                  "propane",
-                                                                  null
-                                                              ],
-                                                              "type": [
-                                                                  "string",
-                                                                  "null"
-                                                              ]
-                                                          },
-                                                          "hpmsType": {
-                                                              "enum": [
-                                                                  "none",
-                                                                  "unknown",
-                                                                  "special",
-                                                                  "moto",
-                                                                  "car",
-                                                                  "carOther",
-                                                                  "bus",
-                                                                  "axleCnt2",
-                                                                  "axleCnt3",
-                                                                  "axleCnt4",
-                                                                  "axleCnt4Trailer",
-                                                                  "axleCnt5Trailer",
-                                                                  "axleCnt6Trailer",
-                                                                  "axleCnt5MultiTrailer",
-                                                                  "axleCnt6MultiTrailer",
-                                                                  "axleCnt7MultiTrailer",
-                                                                  null
-                                                              ],
-                                                              "type": [
-                                                                  "string",
-                                                                  "null"
-                                                              ]
-                                                          },
-                                                          "iso3883": {
-                                                              "type": [
-                                                                  "integer",
-                                                                  "null"
-                                                              ]
-                                                          },
-                                                          "keyType": {
-                                                              "type": [
-                                                                  "integer",
-                                                                  "null"
-                                                              ]
-                                                          },
-                                                          "regional": {
-                                                              "items": {
-                                                                  "contentEncoding": "base64",
-                                                                  "type": "string"
-                                                              },
-                                                              "maxItems": 4,
-                                                              "minItems": 1,
-                                                              "type": [
-                                                                  "array",
-                                                                  "null"
-                                                              ]
-                                                          },
-                                                          "responderType": {
-                                                              "enum": [
-                                                                  "emergency_vehicle_units",
-                                                                  "federal_law_enforcement_units",
-                                                                  "state_police_units",
-                                                                  "county_police_units",
-                                                                  "local_police_units",
-                                                                  "ambulance_units",
-                                                                  "rescue_units",
-                                                                  "fire_units",
-                                                                  "hAZMAT_units",
-                                                                  "light_tow_unit",
-                                                                  "heavy_tow_unit",
-                                                                  "freeway_service_patrols",
-                                                                  "transportation_response_units",
-                                                                  "private_contractor_response_units",
-                                                                  null
-                                                              ],
-                                                              "type": [
-                                                                  "string",
-                                                                  "null"
-                                                              ]
-                                                          },
-                                                          "responseEquip": {
-                                                              "properties": {
-                                                                  "name": {
-                                                                      "type": "string"
-                                                                  },
-                                                                  "value": {
-                                                                      "type": [
-                                                                          "integer",
-                                                                          "null"
-                                                                      ]
-                                                                  }
-                                                              },
-                                                              "required": [
-                                                                  "name"
-                                                              ],
-                                                              "type": [
-                                                                  "object",
-                                                                  "null"
-                                                              ]
-                                                          },
-                                                          "role": {
-                                                              "enum": [
-                                                                  "basicVehicle",
-                                                                  "publicTransport",
-                                                                  "specialTransport",
-                                                                  "dangerousGoods",
-                                                                  "roadWork",
-                                                                  "roadRescue",
-                                                                  "emergency",
-                                                                  "safetyCar",
-                                                                  "none_unknown",
-                                                                  "truck",
-                                                                  "motorcycle",
-                                                                  "roadSideSource",
-                                                                  "police",
-                                                                  "fire",
-                                                                  "ambulance",
-                                                                  "dot",
-                                                                  "transit",
-                                                                  "slowMoving",
-                                                                  "stopNgo",
-                                                                  "cyclist",
-                                                                  "pedestrian",
-                                                                  "nonMotorized",
-                                                                  "military",
-                                                                  null
-                                                              ],
-                                                              "type": [
-                                                                  "string",
-                                                                  "null"
-                                                              ]
-                                                          },
-                                                          "vehicleType": {
-                                                              "properties": {
-                                                                  "name": {
-                                                                      "type": "string"
-                                                                  },
-                                                                  "value": {
-                                                                      "type": [
-                                                                          "integer",
-                                                                          "null"
-                                                                      ]
-                                                                  }
-                                                              },
-                                                              "required": [
-                                                                  "name"
-                                                              ],
-                                                              "type": [
-                                                                  "object",
-                                                                  "null"
-                                                              ]
-                                                          }
-                                                      },
-                                                      "required": [],
-                                                      "type": [
-                                                          "object",
-                                                          "null"
-                                                      ]
-                                                  },
-                                                  "classification": {
-                                                      "type": [
-                                                          "integer",
-                                                          "null"
-                                                      ]
-                                                  },
-                                                  "obstacle": {
-                                                      "properties": {
-                                                          "dateTime": {
-                                                              "properties": {
-                                                                  "day": {
-                                                                      "type": [
-                                                                          "integer",
-                                                                          "null"
-                                                                      ]
-                                                                  },
-                                                                  "hour": {
-                                                                      "type": [
-                                                                          "integer",
-                                                                          "null"
-                                                                      ]
-                                                                  },
-                                                                  "minute": {
-                                                                      "type": [
-                                                                          "integer",
-                                                                          "null"
-                                                                      ]
-                                                                  },
-                                                                  "month": {
-                                                                      "type": [
-                                                                          "integer",
-                                                                          "null"
-                                                                      ]
-                                                                  },
-                                                                  "offset": {
-                                                                      "type": [
-                                                                          "integer",
-                                                                          "null"
-                                                                      ]
-                                                                  },
-                                                                  "second": {
-                                                                      "type": [
-                                                                          "integer",
-                                                                          "null"
-                                                                      ]
-                                                                  },
-                                                                  "year": {
-                                                                      "type": [
-                                                                          "integer",
-                                                                          "null"
-                                                                      ]
-                                                                  }
-                                                              },
-                                                              "required": [],
-                                                              "type": [
-                                                                  "object",
-                                                                  "null"
-                                                              ]
-                                                          },
-                                                          "description": {
-                                                              "type": [
-                                                                  "integer",
-                                                                  "null"
-                                                              ]
-                                                          },
-                                                          "locationDetails": {
-                                                              "properties": {
-                                                                  "name": {
-                                                                      "type": "string"
-                                                                  },
-                                                                  "value": {
-                                                                      "type": [
-                                                                          "integer",
-                                                                          "null"
-                                                                      ]
-                                                                  }
-                                                              },
-                                                              "required": [
-                                                                  "name"
-                                                              ],
-                                                              "type": [
-                                                                  "object",
-                                                                  "null"
-                                                              ]
-                                                          },
-                                                          "obDirect": {
-                                                              "type": "number"
-                                                          },
-                                                          "obDist": {
-                                                              "type": "integer"
-                                                          },
-                                                          "vertEvent": {
-                                                              "properties": {
-                                                                  "leftFront": {
-                                                                      "type": "boolean"
-                                                                  },
-                                                                  "leftRear": {
-                                                                      "type": "boolean"
-                                                                  },
-                                                                  "notEquipped": {
-                                                                      "type": "boolean"
-                                                                  },
-                                                                  "rightFront": {
-                                                                      "type": "boolean"
-                                                                  },
-                                                                  "rightRear": {
-                                                                      "type": "boolean"
-                                                                  }
-                                                              },
-                                                              "required": [
-                                                                  "rightRear",
-                                                                  "rightFront",
-                                                                  "leftRear",
-                                                                  "leftFront",
-                                                                  "notEquipped"
-                                                              ],
-                                                              "type": [
-                                                                  "object",
-                                                                  "null"
-                                                              ]
-                                                          }
-                                                      },
-                                                      "required": [
-                                                          "obDirect",
-                                                          "obDist"
-                                                      ],
-                                                      "type": [
-                                                          "object",
-                                                          "null"
-                                                      ]
-                                                  },
-                                                  "regional": {
-                                                      "items": {
-                                                          "contentEncoding": "base64",
-                                                          "type": "string"
-                                                      },
-                                                      "maxItems": 4,
-                                                      "minItems": 1,
-                                                      "type": [
-                                                          "array",
-                                                          "null"
-                                                      ]
-                                                  },
-                                                  "speedProfile": {
-                                                      "properties": {
-                                                          "speedReports": {
-                                                              "items": {
-                                                                  "type": "integer"
-                                                              },
-                                                              "maxItems": 20,
-                                                              "minItems": 1,
-                                                              "type": "array"
-                                                          }
-                                                      },
-                                                      "required": [],
-                                                      "type": [
-                                                          "object",
-                                                          "null"
-                                                      ]
-                                                  },
-                                                  "status": {
-                                                      "properties": {
-                                                          "locationDetails": {
-                                                              "properties": {
-                                                                  "name": {
-                                                                      "type": "string"
-                                                                  },
-                                                                  "value": {
-                                                                      "type": [
-                                                                          "integer",
-                                                                          "null"
-                                                                      ]
-                                                                  }
-                                                              },
-                                                              "required": [
-                                                                  "name"
-                                                              ],
-                                                              "type": [
-                                                                  "object",
-                                                                  "null"
-                                                              ]
-                                                          },
-                                                          "statusDetails": {
-                                                              "type": "integer"
-                                                          }
-                                                      },
-                                                      "required": [
-                                                          "statusDetails"
-                                                      ],
-                                                      "type": [
-                                                          "object",
-                                                          "null"
-                                                      ]
-                                                  },
-                                                  "theRTCM": {
-                                                      "properties": {
-                                                          "msgs": {
-                                                              "items": {
-                                                                  "type": "string"
-                                                              },
-                                                              "maxItems": 5,
-                                                              "minItems": 1,
-                                                              "type": "array"
-                                                          },
-                                                          "rtcmHeader": {
-                                                              "properties": {
-                                                                  "offsetSet": {
-                                                                      "properties": {
-                                                                          "antOffsetX": {
-                                                                              "type": "number"
-                                                                          },
-                                                                          "antOffsetY": {
-                                                                              "type": "number"
-                                                                          },
-                                                                          "antOffsetZ": {
-                                                                              "type": "number"
-                                                                          }
-                                                                      },
-                                                                      "required": [
-                                                                          "antOffsetX",
-                                                                          "antOffsetY",
-                                                                          "antOffsetZ"
-                                                                      ],
-                                                                      "type": "object"
-                                                                  },
-                                                                  "status": {
-                                                                      "properties": {
-                                                                          "aPDOPofUnder5": {
-                                                                              "type": "boolean"
-                                                                          },
-                                                                          "baseStationType": {
-                                                                              "type": "boolean"
-                                                                          },
-                                                                          "inViewOfUnder5": {
-                                                                              "type": "boolean"
-                                                                          },
-                                                                          "isHealthy": {
-                                                                              "type": "boolean"
-                                                                          },
-                                                                          "isMonitored": {
-                                                                              "type": "boolean"
-                                                                          },
-                                                                          "localCorrectionsPresent": {
-                                                                              "type": "boolean"
-                                                                          },
-                                                                          "networkCorrectionsPresent": {
-                                                                              "type": "boolean"
-                                                                          },
-                                                                          "unavailable": {
-                                                                              "type": "boolean"
-                                                                          }
-                                                                      },
-                                                                      "required": [
-                                                                          "unavailable",
-                                                                          "isHealthy",
-                                                                          "isMonitored",
-                                                                          "baseStationType",
-                                                                          "aPDOPofUnder5",
-                                                                          "inViewOfUnder5",
-                                                                          "localCorrectionsPresent",
-                                                                          "networkCorrectionsPresent"
-                                                                      ],
-                                                                      "type": "object"
-                                                                  }
-                                                              },
-                                                              "required": [
-                                                                  "status",
-                                                                  "offsetSet"
-                                                              ],
-                                                              "type": [
-                                                                  "object",
-                                                                  "null"
-                                                              ]
-                                                          }
-                                                      },
-                                                      "required": [
-                                                          "msgs"
-                                                      ],
-                                                      "type": "object"
-                                                  },
-                                                  "vehicleData": {
-                                                      "properties": {
-                                                          "bumpers": {
-                                                              "properties": {
-                                                                  "front": {
-                                                                      "type": "number"
-                                                                  },
-                                                                  "rear": {
-                                                                      "type": "number"
-                                                                  }
-                                                              },
-                                                              "required": [
-                                                                  "front",
-                                                                  "rear"
-                                                              ],
-                                                              "type": [
-                                                                  "object",
-                                                                  "null"
-                                                              ]
-                                                          },
-                                                          "height": {
-                                                              "type": [
-                                                                  "number",
-                                                                  "null"
-                                                              ]
-                                                          },
-                                                          "mass": {
-                                                              "type": [
-                                                                  "integer",
-                                                                  "null"
-                                                              ]
-                                                          },
-                                                          "trailerWeight": {
-                                                              "type": [
-                                                                  "integer",
-                                                                  "null"
-                                                              ]
-                                                          }
-                                                      },
-                                                      "required": [],
-                                                      "type": [
-                                                          "object",
-                                                          "null"
-                                                      ]
-                                                  },
-                                                  "weatherProbe": {
-                                                      "properties": {
-                                                          "airPressure": {
-                                                              "type": [
-                                                                  "integer",
-                                                                  "null"
-                                                              ]
-                                                          },
-                                                          "airTemp": {
-                                                              "type": [
-                                                                  "integer",
-                                                                  "null"
-                                                              ]
-                                                          },
-                                                          "rainRates": {
-                                                              "properties": {
-                                                                  "rateFront": {
-                                                                      "type": "integer"
-                                                                  },
-                                                                  "rateRear": {
-                                                                      "type": [
-                                                                          "integer",
-                                                                          "null"
-                                                                      ]
-                                                                  },
-                                                                  "statusFront": {
-                                                                      "enum": [
-                                                                          "UNAVAILABLE",
-                                                                          "OFF",
-                                                                          "INTERMITTENT",
-                                                                          "LOW",
-                                                                          "HIGH",
-                                                                          "WASHERINUSE",
-                                                                          "AUTOMATICPRESENT"
-                                                                      ],
-                                                                      "type": "string"
-                                                                  },
-                                                                  "statusRear": {
-                                                                      "enum": [
-                                                                          "UNAVAILABLE",
-                                                                          "OFF",
-                                                                          "INTERMITTENT",
-                                                                          "LOW",
-                                                                          "HIGH",
-                                                                          "WASHERINUSE",
-                                                                          "AUTOMATICPRESENT",
-                                                                          null
-                                                                      ],
-                                                                      "type": [
-                                                                          "string",
-                                                                          "null"
-                                                                      ]
-                                                                  }
-                                                              },
-                                                              "required": [
-                                                                  "rateFront",
-                                                                  "statusFront"
-                                                              ],
-                                                              "type": [
-                                                                  "object",
-                                                                  "null"
-                                                              ]
-                                                          }
-                                                      },
-                                                      "required": [],
-                                                      "type": [
-                                                          "object",
-                                                          "null"
-                                                      ]
-                                                  },
-                                                  "weatherReport": {
-                                                      "properties": {
-                                                          "friction": {
-                                                              "type": [
-                                                                  "integer",
-                                                                  "null"
-                                                              ]
-                                                          },
-                                                          "isRaining": {
-                                                              "enum": [
-                                                                  "NA",
-                                                                  "PRECIP",
-                                                                  "NOPRECIP",
-                                                                  "ERROR"
-                                                              ],
-                                                              "type": "string"
-                                                          },
-                                                          "precipSituation": {
-                                                              "enum": [
-                                                                  "NA",
-                                                                  "OTHER",
-                                                                  "UNKNOWN",
-                                                                  "NOPRECIPITATION",
-                                                                  "UNIDENTIFIEDSLIGHT",
-                                                                  "UNIDENTIFIEDMODERATE",
-                                                                  "UNIDENTIFIEDHEAVY",
-                                                                  "SNOWSLIGHT",
-                                                                  "SNOWMODERATE",
-                                                                  "SNOWHEAVY",
-                                                                  "RAINSLIGHT",
-                                                                  "RAINMODERATE",
-                                                                  "RAINHEAVY",
-                                                                  "FROZENPRECIPITATIONSLIGHT",
-                                                                  "FROZENPRECIPITATIONMODERATE",
-                                                                  "FROZENPRECIPITATIONHEAVY",
-                                                                  null
-                                                              ],
-                                                              "type": [
-                                                                  "string",
-                                                                  "null"
-                                                              ]
-                                                          },
-                                                          "rainRate": {
-                                                              "type": [
-                                                                  "number",
-                                                                  "null"
-                                                              ]
-                                                          },
-                                                          "roadFriction": {
-                                                              "type": [
-                                                                  "number",
-                                                                  "null"
-                                                              ]
-                                                          },
-                                                          "solarRadiation": {
-                                                              "type": [
-                                                                  "integer",
-                                                                  "null"
-                                                              ]
-                                                          }
-                                                      },
-                                                      "required": [
-                                                          "isRaining"
-                                                      ],
-                                                      "type": [
-                                                          "object",
-                                                          "null"
-                                                      ]
-                                                  }
-                                              },
-                                              "required": [],
-                                              "type": "object"
-                                          }
-                                      },
-                                      "required": [
-                                          "id",
-                                          "value"
-                                      ],
-                                      "type": "object"
-                                  }
-                              ]
-                          },
-                          "maxItems": 8,
-                          "minItems": 1,
-                          "type": [
-                              "array",
-                              "null"
-                          ]
-                      }
-                  },
-                  "required": [
-                      "coreData",
-                      "partII"
-                  ],
-                  "type": "object"
-              },
-              "dataType": {
-                  "type": "string"
-              }
-          },
-          "required": [
-              "dataType",
-              "data"
-          ],
-          "type": "object"
-      }
-  },
-  "required": [
-      "metadata",
-      "payload"
-  ],
-  "type": "object"
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "properties": {
+        "metadata": {
+            "properties": {
+                "@class": {
+                    "type": "string"
+                },
+                "bsmSource": {
+                    "enum": [
+                        "EV",
+                        "RV",
+                        "unknown"
+                    ],
+                    "type": "string"
+                },
+                "encodings": {
+                    "items": {
+                        "properties": {
+                            "elementName": {
+                                "type": "string"
+                            },
+                            "elementType": {
+                                "type": "string"
+                            },
+                            "encodingRule": {
+                                "enum": [
+                                    "UPER",
+                                    "COER"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "elementName",
+                            "elementType",
+                            "encodingRule"
+                        ],
+                        "type": "object"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "logFileName": {
+                    "type": "string"
+                },
+                "maxDurationTime": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "odePacketID": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "odeReceivedAt": {
+                    "type": "string"
+                },
+                "odeTimStartDateTime": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "originIp": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "payloadType": {
+                    "type": "string"
+                },
+                "receivedMessageDetails": {
+                    "properties": {
+                        "locationData": {
+                            "properties": {
+                                "elevation": {
+                                    "type": "string"
+                                },
+                                "heading": {
+                                    "type": "string"
+                                },
+                                "latitude": {
+                                    "type": "string"
+                                },
+                                "longitude": {
+                                    "type": "string"
+                                },
+                                "speed": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "latitude",
+                                "longitude",
+                                "elevation",
+                                "speed",
+                                "heading"
+                            ],
+                            "type": "object"
+                        },
+                        "rxSource": {
+                            "enum": [
+                                "RSU",
+                                "SAT",
+                                "RV",
+                                "SNMP",
+                                "NA",
+                                "UNKNOWN"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "locationData",
+                        "rxSource"
+                    ],
+                    "type": "object"
+                },
+                "recordGeneratedAt": {
+                    "type": "string"
+                },
+                "recordGeneratedBy": {
+                    "enum": [
+                        "TMC",
+                        "OBU",
+                        "RSU",
+                        "TMC_VIA_SAT",
+                        "TMC_VIA_SNMP",
+                        "UNKNOWN",
+                        null
+                    ],
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "recordType": {
+                    "enum": [
+                        "bsmLogDuringEvent",
+                        "rxMsg",
+                        "dnMsg",
+                        "bsmTx",
+                        "driverAlert",
+                        "spatTx",
+                        "timMsg",
+                        "unsupported"
+                    ],
+                    "type": "string"
+                },
+                "sanitized": {
+                    "type": "boolean"
+                },
+                "schemaVersion": {
+                    "const": 6,
+                    "type": "integer"
+                },
+                "securityResultCode": {
+                    "enum": [
+                        "success",
+                        "unknown",
+                        "inconsistentInputParameters",
+                        "spduParsingInvalidInput",
+                        "spduParsingUnsupportedCriticalInformationField",
+                        "spduParsingCertificateNotFound",
+                        "spduParsingGenerationTimeNotAvailable",
+                        "spduParsingGenerationLocationNotAvailable",
+                        "spduCertificateChainNotEnoughInformationToConstructChain",
+                        "spduCertificateChainChainEndedAtUntrustedRoot",
+                        "spduCertificateChainChainWasTooLongForImplementation",
+                        "spduCertificateChainCertificateRevoked",
+                        "spduCertificateChainOverdueCRL",
+                        "spduCertificateChainInconsistentExpiryTimes",
+                        "spduCertificateChainInconsistentStartTimes",
+                        "spduCertificateChainInconsistentChainPermissions",
+                        "spduCryptoVerificationFailure",
+                        "spduConsistencyFutureCertificateAtGenerationTime",
+                        "spduConsistencyExpiredCertificateAtGenerationTime",
+                        "spduConsistencyExpiryDateTooEarly",
+                        "spduConsistencyExpiryDateTooLate",
+                        "spduConsistencyGenerationLocationOutsideValidityRegion",
+                        "spduConsistencyNoGenerationLocation",
+                        "spduConsistencyUnauthorizedPSID",
+                        "spduInternalConsistencyExpiryTimeBeforeGenerationTime",
+                        "spduInternalConsistencyextDataHashDoesntMatch",
+                        "spduInternalConsistencynoExtDataHashProvided",
+                        "spduInternalConsistencynoExtDataHashPresent",
+                        "spduLocalConsistencyPSIDsDontMatch",
+                        "spduLocalConsistencyChainWasTooLongForSDEE",
+                        "spduRelevanceGenerationTimeTooFarInPast",
+                        "spduRelevanceGenerationTimeTooFarInFuture",
+                        "spduRelevanceExpiryTimeInPast",
+                        "spduRelevanceGenerationLocationTooDistant",
+                        "spduRelevanceReplayedSpdu",
+                        "spduCertificateExpired"
+                    ],
+                    "type": "string"
+                },
+                "serialId": {
+                    "properties": {
+                        "bundleId": {
+                            "type": "integer"
+                        },
+                        "bundleSize": {
+                            "type": "integer"
+                        },
+                        "recordId": {
+                            "type": "integer"
+                        },
+                        "serialNumber": {
+                            "type": "integer"
+                        },
+                        "streamId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "streamId",
+                        "bundleSize",
+                        "bundleId",
+                        "recordId",
+                        "serialNumber"
+                    ],
+                    "type": "object"
+                }
+            },
+            "required": [
+                "@class",
+                "bsmSource",
+                "logFileName",
+                "recordType",
+                "securityResultCode",
+                "receivedMessageDetails",
+                "payloadType",
+                "serialId",
+                "odeReceivedAt",
+                "schemaVersion",
+                "recordGeneratedAt",
+                "sanitized"
+            ],
+            "type": "object"
+        },
+        "payload": {
+            "properties": {
+                "@class": {
+                    "type": "string"
+                },
+                "data": {
+                    "properties": {
+                        "coreData": {
+                            "properties": {
+                                "accelSet": {
+                                    "properties": {
+                                        "accelLat": {
+                                            "type": [
+                                                "number",
+                                                "null"
+                                            ]
+                                        },
+                                        "accelLong": {
+                                            "type": "number"
+                                        },
+                                        "accelVert": {
+                                            "type": [
+                                                "number",
+                                                "null"
+                                            ]
+                                        },
+                                        "accelYaw": {
+                                            "type": "number"
+                                        }
+                                    },
+                                    "required": [
+                                        "accelLong",
+                                        "accelYaw"
+                                    ],
+                                    "type": "object"
+                                },
+                                "accuracy": {
+                                    "properties": {
+                                        "orientation": {
+                                            "type": [
+                                                "number",
+                                                "null"
+                                            ]
+                                        },
+                                        "semiMajor": {
+                                            "type": [
+                                                "number",
+                                                "null"
+                                            ]
+                                        },
+                                        "semiMinor": {
+                                            "type": [
+                                                "number",
+                                                "null"
+                                            ]
+                                        }
+                                    },
+                                    "required": [],
+                                    "type": "object"
+                                },
+                                "angle": {
+                                    "type": [
+                                        "number",
+                                        "null"
+                                    ]
+                                },
+                                "brakes": {
+                                    "properties": {
+                                        "abs": {
+                                            "type": "string"
+                                        },
+                                        "auxBrakes": {
+                                            "type": "string"
+                                        },
+                                        "brakeBoost": {
+                                            "type": "string"
+                                        },
+                                        "scs": {
+                                            "type": "string"
+                                        },
+                                        "traction": {
+                                            "type": "string"
+                                        },
+                                        "wheelBrakes": {
+                                            "properties": {
+                                                "leftFront": {
+                                                    "type": "boolean"
+                                                },
+                                                "leftRear": {
+                                                    "type": "boolean"
+                                                },
+                                                "rightFront": {
+                                                    "type": "boolean"
+                                                },
+                                                "rightRear": {
+                                                    "type": "boolean"
+                                                },
+                                                "unavailable": {
+                                                    "type": "boolean"
+                                                }
+                                            },
+                                            "required": [
+                                                "unavailable",
+                                                "leftFront",
+                                                "leftRear",
+                                                "rightFront",
+                                                "rightRear"
+                                            ],
+                                            "type": "object"
+                                        }
+                                    },
+                                    "required": [
+                                        "wheelBrakes",
+                                        "traction",
+                                        "abs",
+                                        "scs",
+                                        "brakeBoost",
+                                        "auxBrakes"
+                                    ],
+                                    "type": "object"
+                                },
+                                "heading": {
+                                    "type": "number"
+                                },
+                                "id": {
+                                    "type": "string"
+                                },
+                                "msgCnt": {
+                                    "type": "integer"
+                                },
+                                "position": {
+                                    "properties": {
+                                        "elevation": {
+                                            "type": [
+                                                "number",
+                                                "null"
+                                            ]
+                                        },
+                                        "latitude": {
+                                            "type": "number"
+                                        },
+                                        "longitude": {
+                                            "type": "number"
+                                        }
+                                    },
+                                    "required": [
+                                        "latitude",
+                                        "longitude"
+                                    ],
+                                    "type": "object"
+                                },
+                                "secMark": {
+                                    "type": "integer"
+                                },
+                                "size": {
+                                    "properties": {
+                                        "length": {
+                                            "type": [
+                                                "integer",
+                                                "null"
+                                            ]
+                                        },
+                                        "width": {
+                                            "type": [
+                                                "integer",
+                                                "null"
+                                            ]
+                                        }
+                                    },
+                                    "required": [],
+                                    "type": "object"
+                                },
+                                "speed": {
+                                    "type": "number"
+                                },
+                                "transmission": {
+                                    "enum": [
+                                        "NEUTRAL",
+                                        "PARK",
+                                        "FORWARDGEARS",
+                                        "REVERSEGEARS",
+                                        "RESERVED1",
+                                        "RESERVED2",
+                                        "RESERVED3",
+                                        "UNAVAILABLE"
+                                    ],
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "msgCnt",
+                                "id",
+                                "secMark",
+                                "position",
+                                "accelSet",
+                                "accuracy",
+                                "transmission",
+                                "speed",
+                                "heading",
+                                "brakes",
+                                "size"
+                            ],
+                            "type": "object"
+                        },
+                        "partII": {
+                            "items": {
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "id": {
+                                                "const": "VehicleSafetyExtensions",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "properties": {
+                                                    "events": {
+                                                        "properties": {
+                                                            "eventABSactivated": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "eventAirBagDeployment": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "eventDisabledVehicle": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "eventFlatTire": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "eventHardBraking": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "eventHazardLights": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "eventHazardousMaterials": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "eventLightsChanged": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "eventReserved1": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "eventStabilityControlactivated": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "eventStopLineViolation": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "eventTractionControlLoss": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "eventWipersChanged": {
+                                                                "type": "boolean"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "eventHazardLights",
+                                                            "eventStopLineViolation",
+                                                            "eventABSactivated",
+                                                            "eventTractionControlLoss",
+                                                            "eventStabilityControlactivated",
+                                                            "eventHazardousMaterials",
+                                                            "eventReserved1",
+                                                            "eventHardBraking",
+                                                            "eventLightsChanged",
+                                                            "eventWipersChanged",
+                                                            "eventFlatTire",
+                                                            "eventDisabledVehicle",
+                                                            "eventAirBagDeployment"
+                                                        ],
+                                                        "type": [
+                                                            "object",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "lights": {
+                                                        "properties": {
+                                                            "automaticLightControlOn": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "daytimeRunningLightsOn": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "fogLightOn": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "hazardSignalOn": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "highBeamHeadlightsOn": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "leftTurnSignalOn": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "lowBeamHeadlightsOn": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "parkingLightsOn": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "rightTurnSignalOn": {
+                                                                "type": "boolean"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "lowBeamHeadlightsOn",
+                                                            "highBeamHeadlightsOn",
+                                                            "leftTurnSignalOn",
+                                                            "rightTurnSignalOn",
+                                                            "hazardSignalOn",
+                                                            "automaticLightControlOn",
+                                                            "daytimeRunningLightsOn",
+                                                            "fogLightOn",
+                                                            "parkingLightsOn"
+                                                        ],
+                                                        "type": [
+                                                            "object",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "pathHistory": {
+                                                        "properties": {
+                                                            "crumbData": {
+                                                                "items": {
+                                                                    "properties": {
+                                                                        "elevationOffset": {
+                                                                            "type": "number"
+                                                                        },
+                                                                        "heading": {
+                                                                            "type": [
+                                                                                "number",
+                                                                                "null"
+                                                                            ]
+                                                                        },
+                                                                        "latOffset": {
+                                                                            "type": "number"
+                                                                        },
+                                                                        "lonOffset": {
+                                                                            "type": "number"
+                                                                        },
+                                                                        "posAccuracy": {
+                                                                            "properties": {
+                                                                                "orientation": {
+                                                                                    "type": "number"
+                                                                                },
+                                                                                "semiMajor": {
+                                                                                    "type": "number"
+                                                                                },
+                                                                                "semiMinor": {
+                                                                                    "type": "number"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "semiMajor",
+                                                                                "semiMinor",
+                                                                                "orientation"
+                                                                            ],
+                                                                            "type": [
+                                                                                "object",
+                                                                                "null"
+                                                                            ]
+                                                                        },
+                                                                        "speed": {
+                                                                            "type": [
+                                                                                "number",
+                                                                                "null"
+                                                                            ]
+                                                                        },
+                                                                        "timeOffset": {
+                                                                            "type": "number"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "elevationOffset",
+                                                                        "latOffset",
+                                                                        "lonOffset",
+                                                                        "timeOffset"
+                                                                    ],
+                                                                    "type": "object"
+                                                                },
+                                                                "maxItems": 23,
+                                                                "minItems": 1,
+                                                                "type": "array"
+                                                            },
+                                                            "currGNSSstatus": {
+                                                                "properties": {
+                                                                    "aPDOPofUnder5": {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    "baseStationType": {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    "inViewOfUnder5": {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    "isHealthy": {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    "isMonitored": {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    "localCorrectionsPresent": {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    "networkCorrectionsPresent": {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    "unavailable": {
+                                                                        "type": "boolean"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "unavailable",
+                                                                    "isHealthy",
+                                                                    "isMonitored",
+                                                                    "baseStationType",
+                                                                    "aPDOPofUnder5",
+                                                                    "inViewOfUnder5",
+                                                                    "localCorrectionsPresent",
+                                                                    "networkCorrectionsPresent"
+                                                                ],
+                                                                "type": [
+                                                                    "object",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "initialPosition": {
+                                                                "properties": {
+                                                                    "heading": {
+                                                                        "type": [
+                                                                            "number",
+                                                                            "null"
+                                                                        ]
+                                                                    },
+                                                                    "posAccuracy": {
+                                                                        "properties": {
+                                                                            "orientation": {
+                                                                                "type": [
+                                                                                    "number",
+                                                                                    "null"
+                                                                                ]
+                                                                            },
+                                                                            "semiMajor": {
+                                                                                "type": [
+                                                                                    "number",
+                                                                                    "null"
+                                                                                ]
+                                                                            },
+                                                                            "semiMinor": {
+                                                                                "type": [
+                                                                                    "number",
+                                                                                    "null"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [],
+                                                                        "type": "object"
+                                                                    },
+                                                                    "posConfidence": {
+                                                                        "properties": {
+                                                                            "elevation": {
+                                                                                "enum": [
+                                                                                    "UNAVAILABLE",
+                                                                                    "ELEV_500_00",
+                                                                                    "ELEV_200_00",
+                                                                                    "ELEV_100_00",
+                                                                                    "ELEV_050_00",
+                                                                                    "ELEV_020_00",
+                                                                                    "ELEV_010_00",
+                                                                                    "ELEV_005_00",
+                                                                                    "ELEV_002_00",
+                                                                                    "ELEV_001_00",
+                                                                                    "ELEV_000_50",
+                                                                                    "ELEV_000_20",
+                                                                                    "ELEV_000_10",
+                                                                                    "ELEV_000_05",
+                                                                                    "ELEV_000_02",
+                                                                                    "ELEV_000_01"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            "pos": {
+                                                                                "enum": [
+                                                                                    "UNAVAILABLE",
+                                                                                    "A500M",
+                                                                                    "A200M",
+                                                                                    "A100M",
+                                                                                    "A50M",
+                                                                                    "A20M",
+                                                                                    "A10M",
+                                                                                    "A5M",
+                                                                                    "A2M",
+                                                                                    "A1M",
+                                                                                    "A50CM",
+                                                                                    "A20CM",
+                                                                                    "A10CM",
+                                                                                    "A5CM",
+                                                                                    "A2CM",
+                                                                                    "A1CM"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "pos",
+                                                                            "elevation"
+                                                                        ],
+                                                                        "type": [
+                                                                            "object",
+                                                                            "null"
+                                                                        ]
+                                                                    },
+                                                                    "position": {
+                                                                        "properties": {
+                                                                            "elevation": {
+                                                                                "type": [
+                                                                                    "number",
+                                                                                    "null"
+                                                                                ]
+                                                                            },
+                                                                            "latitude": {
+                                                                                "type": "number"
+                                                                            },
+                                                                            "longitude": {
+                                                                                "type": "number"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "latitude",
+                                                                            "longitude"
+                                                                        ],
+                                                                        "type": "object"
+                                                                    },
+                                                                    "speed": {
+                                                                        "properties": {
+                                                                            "speed": {
+                                                                                "type": "number"
+                                                                            },
+                                                                            "transmission": {
+                                                                                "enum": [
+                                                                                    "NEUTRAL",
+                                                                                    "PARK",
+                                                                                    "FORWARDGEARS",
+                                                                                    "REVERSEGEARS",
+                                                                                    "RESERVED1",
+                                                                                    "RESERVED2",
+                                                                                    "RESERVED3",
+                                                                                    "UNAVAILABLE"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "speed",
+                                                                            "transmission"
+                                                                        ],
+                                                                        "type": [
+                                                                            "object",
+                                                                            "null"
+                                                                        ]
+                                                                    },
+                                                                    "speedConfidence": {
+                                                                        "properties": {
+                                                                            "heading": {
+                                                                                "enum": [
+                                                                                    "UNAVAILABLE",
+                                                                                    "PREC10DEG",
+                                                                                    "PREC05DEG",
+                                                                                    "PREC01DEG",
+                                                                                    "PREC0_1DEG",
+                                                                                    "PREC0_05DEG",
+                                                                                    "PREC0_01DEG",
+                                                                                    "PREC0_0125DEG"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            "speed": {
+                                                                                "enum": [
+                                                                                    "UNAVAILABLE",
+                                                                                    "PREC100MS",
+                                                                                    "PREC10MS",
+                                                                                    "PREC5MS",
+                                                                                    "PREC1MS",
+                                                                                    "PREC0_1MS",
+                                                                                    "PREC0_05MS",
+                                                                                    "PREC0_01MS"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            "throttle": {
+                                                                                "enum": [
+                                                                                    "UNAVAILABLE",
+                                                                                    "PREC10PERCENT",
+                                                                                    "PREC1PERCENT",
+                                                                                    "PREC0_5PERCENT"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "heading",
+                                                                            "speed",
+                                                                            "throttle"
+                                                                        ],
+                                                                        "type": [
+                                                                            "object",
+                                                                            "null"
+                                                                        ]
+                                                                    },
+                                                                    "timeConfidence": {
+                                                                        "enum": [
+                                                                            "UNAVAILABLE",
+                                                                            "TIME_100_000",
+                                                                            "TIME_050_000",
+                                                                            "TIME_020_000",
+                                                                            "TIME_010_000",
+                                                                            "TIME_002_000",
+                                                                            "TIME_001_000",
+                                                                            "TIME_000_500",
+                                                                            "TIME_000_200",
+                                                                            "TIME_000_100",
+                                                                            "TIME_000_050",
+                                                                            "TIME_000_020",
+                                                                            "TIME_000_010",
+                                                                            "TIME_000_005",
+                                                                            "TIME_000_002",
+                                                                            "TIME_000_001",
+                                                                            "TIME_000_000_5",
+                                                                            "TIME_000_000_2",
+                                                                            "TIME_000_000_1",
+                                                                            "TIME_000_000_05",
+                                                                            "TIME_000_000_02",
+                                                                            "TIME_000_000_01",
+                                                                            "TIME_000_000_005",
+                                                                            "TIME_000_000_002",
+                                                                            "TIME_000_000_001",
+                                                                            "TIME_000_000_000_5",
+                                                                            "TIME_000_000_000_2",
+                                                                            "TIME_000_000_000_1",
+                                                                            "TIME_000_000_000_05",
+                                                                            "TIME_000_000_000_02",
+                                                                            "TIME_000_000_000_01",
+                                                                            "TIME_000_000_000_005",
+                                                                            "TIME_000_000_000_002",
+                                                                            "TIME_000_000_000_001",
+                                                                            "TIME_000_000_000_000_5",
+                                                                            "TIME_000_000_000_000_2",
+                                                                            "TIME_000_000_000_000_1",
+                                                                            "TIME_000_000_000_000_05",
+                                                                            "TIME_000_000_000_000_02",
+                                                                            "TIME_000_000_000_000_01",
+                                                                            null
+                                                                        ],
+                                                                        "type": [
+                                                                            "string",
+                                                                            "null"
+                                                                        ]
+                                                                    },
+                                                                    "utcTime": {
+                                                                        "properties": {
+                                                                            "day": {
+                                                                                "type": [
+                                                                                    "integer",
+                                                                                    "null"
+                                                                                ]
+                                                                            },
+                                                                            "hour": {
+                                                                                "type": [
+                                                                                    "integer",
+                                                                                    "null"
+                                                                                ]
+                                                                            },
+                                                                            "minute": {
+                                                                                "type": [
+                                                                                    "integer",
+                                                                                    "null"
+                                                                                ]
+                                                                            },
+                                                                            "month": {
+                                                                                "type": [
+                                                                                    "integer",
+                                                                                    "null"
+                                                                                ]
+                                                                            },
+                                                                            "offset": {
+                                                                                "type": [
+                                                                                    "integer",
+                                                                                    "null"
+                                                                                ]
+                                                                            },
+                                                                            "second": {
+                                                                                "type": [
+                                                                                    "integer",
+                                                                                    "null"
+                                                                                ]
+                                                                            },
+                                                                            "year": {
+                                                                                "type": [
+                                                                                    "integer",
+                                                                                    "null"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [],
+                                                                        "type": [
+                                                                            "object",
+                                                                            "null"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "position"
+                                                                ],
+                                                                "type": [
+                                                                    "object",
+                                                                    "null"
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "crumbData"
+                                                        ],
+                                                        "type": [
+                                                            "object",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "pathPrediction": {
+                                                        "properties": {
+                                                            "confidence": {
+                                                                "type": "number"
+                                                            },
+                                                            "radiusOfCurve": {
+                                                                "type": "number"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "confidence",
+                                                            "radiusOfCurve"
+                                                        ],
+                                                        "type": [
+                                                            "object",
+                                                            "null"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [],
+                                                "type": "object"
+                                            }
+                                        },
+                                        "required": [
+                                            "id",
+                                            "value"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "properties": {
+                                            "id": {
+                                                "const": "SpecialVehicleExtensions",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "properties": {
+                                                    "description": {
+                                                        "properties": {
+                                                            "description": {
+                                                                "items": {
+                                                                    "type": "integer"
+                                                                },
+                                                                "maxItems": 8,
+                                                                "minItems": 1,
+                                                                "type": [
+                                                                    "array",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "extent": {
+                                                                "enum": [
+                                                                    "USEINSTANTLYONLY",
+                                                                    "USEFOR3METERS",
+                                                                    "USEFOR10METERS",
+                                                                    "USEFOR50METERS",
+                                                                    "USEFOR100METERS",
+                                                                    "USEFOR500METERS",
+                                                                    "USEFOR1000METERS",
+                                                                    "USEFOR5000METERS",
+                                                                    "USEFOR10000METERS",
+                                                                    "USEFOR50000METERS",
+                                                                    "USEFOR100000METERS",
+                                                                    "USEFOR500000METERS",
+                                                                    "USEFOR1000000METERS",
+                                                                    "USEFOR5000000METERS",
+                                                                    "USEFOR10000000METERS",
+                                                                    "FOREVER",
+                                                                    null
+                                                                ],
+                                                                "type": [
+                                                                    "string",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "heading": {
+                                                                "properties": {
+                                                                    "FROM000_0TO022_5DEGREES": {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    "FROM022_5TO045_0DEGREES": {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    "FROM045_0TO067_5DEGREES": {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    "FROM067_5TO090_0DEGREES": {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    "FROM090_0TO112_5DEGREES": {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    "FROM112_5TO135_0DEGREES": {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    "FROM135_0TO157_5DEGREES": {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    "FROM157_5TO180_0DEGREES": {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    "FROM180_0TO202_5DEGREES": {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    "FROM202_5TO225_0DEGREES": {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    "FROM225_0TO247_5DEGREES": {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    "FROM247_5TO270_0DEGREES": {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    "FROM270_0TO292_5DEGREES": {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    "FROM292_5TO315_0DEGREES": {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    "FROM315_0TO337_5DEGREES": {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    "FROM337_5TO360_0DEGREES": {
+                                                                        "type": "boolean"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "FROM000_0TO022_5DEGREES",
+                                                                    "FROM022_5TO045_0DEGREES",
+                                                                    "FROM045_0TO067_5DEGREES",
+                                                                    "FROM067_5TO090_0DEGREES",
+                                                                    "FROM090_0TO112_5DEGREES",
+                                                                    "FROM112_5TO135_0DEGREES",
+                                                                    "FROM135_0TO157_5DEGREES",
+                                                                    "FROM157_5TO180_0DEGREES",
+                                                                    "FROM180_0TO202_5DEGREES",
+                                                                    "FROM202_5TO225_0DEGREES",
+                                                                    "FROM225_0TO247_5DEGREES",
+                                                                    "FROM247_5TO270_0DEGREES",
+                                                                    "FROM270_0TO292_5DEGREES",
+                                                                    "FROM292_5TO315_0DEGREES",
+                                                                    "FROM315_0TO337_5DEGREES",
+                                                                    "FROM337_5TO360_0DEGREES"
+                                                                ],
+                                                                "type": [
+                                                                    "object",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "priority": {
+                                                                "type": [
+                                                                    "string",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "regional": {
+                                                                "items": {
+                                                                    "properties": {
+                                                                        "id": {
+                                                                            "type": "integer"
+                                                                        },
+                                                                        "value": {
+                                                                            "contentEncoding": "base64",
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "id",
+                                                                        "value"
+                                                                    ],
+                                                                    "type": "object"
+                                                                },
+                                                                "maxItems": 4,
+                                                                "minItems": 1,
+                                                                "type": [
+                                                                    "array",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "typeEvent": {
+                                                                "type": "integer"
+                                                            }
+                                                        },
+                                                        "required": [],
+                                                        "type": [
+                                                            "object",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "trailers": {
+                                                        "properties": {
+                                                            "connection": {
+                                                                "properties": {
+                                                                    "pivotAngle": {
+                                                                        "type": "number"
+                                                                    },
+                                                                    "pivotOffset": {
+                                                                        "type": "number"
+                                                                    },
+                                                                    "pivots": {
+                                                                        "type": "boolean"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "pivotOffset",
+                                                                    "pivotAngle",
+                                                                    "pivots"
+                                                                ],
+                                                                "type": "object"
+                                                            },
+                                                            "sspRights": {
+                                                                "type": "integer"
+                                                            },
+                                                            "units": {
+                                                                "items": {
+                                                                    "properties": {
+                                                                        "bumperHeights": {
+                                                                            "properties": {
+                                                                                "front": {
+                                                                                    "type": "number"
+                                                                                },
+                                                                                "rear": {
+                                                                                    "type": "number"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "front",
+                                                                                "rear"
+                                                                            ],
+                                                                            "type": [
+                                                                                "object",
+                                                                                "null"
+                                                                            ]
+                                                                        },
+                                                                        "centerOfGravity": {
+                                                                            "type": [
+                                                                                "number",
+                                                                                "null"
+                                                                            ]
+                                                                        },
+                                                                        "crumbData": {
+                                                                            "items": {
+                                                                                "properties": {
+                                                                                    "elevationOffset": {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    "heading": {
+                                                                                        "type": [
+                                                                                            "number",
+                                                                                            "null"
+                                                                                        ]
+                                                                                    },
+                                                                                    "latOffset": {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    "lonOffset": {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    "posAccuracy": {
+                                                                                        "properties": {
+                                                                                            "orientation": {
+                                                                                                "type": "number"
+                                                                                            },
+                                                                                            "semiMajor": {
+                                                                                                "type": "number"
+                                                                                            },
+                                                                                            "semiMinor": {
+                                                                                                "type": "number"
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "semiMajor",
+                                                                                            "semiMinor",
+                                                                                            "orientation"
+                                                                                        ],
+                                                                                        "type": [
+                                                                                            "object",
+                                                                                            "null"
+                                                                                        ]
+                                                                                    },
+                                                                                    "speed": {
+                                                                                        "type": [
+                                                                                            "number",
+                                                                                            "null"
+                                                                                        ]
+                                                                                    },
+                                                                                    "timeOffset": {
+                                                                                        "type": "number"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "elevationOffset",
+                                                                                    "latOffset",
+                                                                                    "lonOffset",
+                                                                                    "timeOffset"
+                                                                                ],
+                                                                                "type": "object"
+                                                                            },
+                                                                            "maxItems": 23,
+                                                                            "minItems": 1,
+                                                                            "type": [
+                                                                                "array",
+                                                                                "null"
+                                                                            ]
+                                                                        },
+                                                                        "elevationOffset": {
+                                                                            "type": [
+                                                                                "number",
+                                                                                "null"
+                                                                            ]
+                                                                        },
+                                                                        "frontPivot": {
+                                                                            "properties": {
+                                                                                "pivotAngle": {
+                                                                                    "type": "number"
+                                                                                },
+                                                                                "pivotOffset": {
+                                                                                    "type": "number"
+                                                                                },
+                                                                                "pivots": {
+                                                                                    "type": "boolean"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "pivotOffset",
+                                                                                "pivotAngle",
+                                                                                "pivots"
+                                                                            ],
+                                                                            "type": "object"
+                                                                        },
+                                                                        "height": {
+                                                                            "type": [
+                                                                                "number",
+                                                                                "null"
+                                                                            ]
+                                                                        },
+                                                                        "isDolly": {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        "length": {
+                                                                            "type": [
+                                                                                "integer",
+                                                                                "null"
+                                                                            ]
+                                                                        },
+                                                                        "mass": {
+                                                                            "type": [
+                                                                                "integer",
+                                                                                "null"
+                                                                            ]
+                                                                        },
+                                                                        "positionOffset": {
+                                                                            "properties": {
+                                                                                "x": {
+                                                                                    "type": "number"
+                                                                                },
+                                                                                "y": {
+                                                                                    "type": "number"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "x",
+                                                                                "y"
+                                                                            ],
+                                                                            "type": "object"
+                                                                        },
+                                                                        "rearPivot": {
+                                                                            "properties": {
+                                                                                "pivotAngle": {
+                                                                                    "type": "number"
+                                                                                },
+                                                                                "pivotOffset": {
+                                                                                    "type": "number"
+                                                                                },
+                                                                                "pivots": {
+                                                                                    "type": "boolean"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "pivotOffset",
+                                                                                "pivotAngle",
+                                                                                "pivots"
+                                                                            ],
+                                                                            "type": [
+                                                                                "object",
+                                                                                "null"
+                                                                            ]
+                                                                        },
+                                                                        "rearWheelOffset": {
+                                                                            "type": [
+                                                                                "number",
+                                                                                "null"
+                                                                            ]
+                                                                        },
+                                                                        "width": {
+                                                                            "type": [
+                                                                                "integer",
+                                                                                "null"
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "isDolly",
+                                                                        "frontPivot",
+                                                                        "positionOffset"
+                                                                    ],
+                                                                    "type": "object"
+                                                                },
+                                                                "maxItems": 8,
+                                                                "minItems": 1,
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "connection",
+                                                            "sspRights",
+                                                            "units"
+                                                        ],
+                                                        "type": [
+                                                            "object",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "vehicleAlerts": {
+                                                        "properties": {
+                                                            "events": {
+                                                                "properties": {
+                                                                    "event": {
+                                                                        "properties": {
+                                                                            "peEmergencyLightsActive": {
+                                                                                "type": "boolean"
+                                                                            },
+                                                                            "peEmergencyResponse": {
+                                                                                "type": "boolean"
+                                                                            },
+                                                                            "peEmergencySoundActive": {
+                                                                                "type": "boolean"
+                                                                            },
+                                                                            "peNonEmergencyLightsActive": {
+                                                                                "type": "boolean"
+                                                                            },
+                                                                            "peNonEmergencySoundActive": {
+                                                                                "type": "boolean"
+                                                                            },
+                                                                            "peUnavailable": {
+                                                                                "type": "boolean"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "peUnavailable",
+                                                                            "peEmergencyResponse",
+                                                                            "peEmergencyLightsActive",
+                                                                            "peEmergencySoundActive",
+                                                                            "peNonEmergencyLightsActive",
+                                                                            "peNonEmergencySoundActive"
+                                                                        ],
+                                                                        "type": "object"
+                                                                    },
+                                                                    "sspRights": {
+                                                                        "type": "integer"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "event",
+                                                                    "sspRights"
+                                                                ],
+                                                                "type": [
+                                                                    "object",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "lightsUse": {
+                                                                "enum": [
+                                                                    "UNAVAILABLE",
+                                                                    "NOTINUSE",
+                                                                    "INUSE",
+                                                                    "YELLOWCAUTIONLIGHTS",
+                                                                    "SCHOOLBUSLIGHTS",
+                                                                    "ARROWSIGNSACTIVE",
+                                                                    "SLOWMOVINGVEHICLE",
+                                                                    "FREQSTOPS"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "multi": {
+                                                                "enum": [
+                                                                    "UNAVAILABLE",
+                                                                    "SINGLEVEHICLE",
+                                                                    "MULTIVEHICLE",
+                                                                    "RESERVED"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "responseType": {
+                                                                "enum": [
+                                                                    "NOTINUSEORNOTEQUIPPED",
+                                                                    "EMERGENCY",
+                                                                    "NONEMERGENCY",
+                                                                    "PURSUIT",
+                                                                    "STATIONARY",
+                                                                    "SLOWMOVING",
+                                                                    "STOPANDGOMOVEMENT",
+                                                                    null
+                                                                ],
+                                                                "type": [
+                                                                    "string",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "sirenUse": {
+                                                                "enum": [
+                                                                    "UNAVAILABLE",
+                                                                    "NOTINUSE",
+                                                                    "INUSE",
+                                                                    "RESERVED"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "sspRights": {
+                                                                "type": "number"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "sspRights",
+                                                            "lightsUse",
+                                                            "multi",
+                                                            "sirenUse"
+                                                        ],
+                                                        "type": [
+                                                            "object",
+                                                            "null"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [],
+                                                "type": "object"
+                                            }
+                                        },
+                                        "required": [
+                                            "id",
+                                            "value"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "properties": {
+                                            "id": {
+                                                "const": "SupplementalVehicleExtensions",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "properties": {
+                                                    "classDetails": {
+                                                        "properties": {
+                                                            "fuelType": {
+                                                                "enum": [
+                                                                    "unknownFuel",
+                                                                    "gasoline",
+                                                                    "ethanol",
+                                                                    "diesel",
+                                                                    "electric",
+                                                                    "hybrid",
+                                                                    "hydrogen",
+                                                                    "natGasLiquid",
+                                                                    "natGasComp",
+                                                                    "propane",
+                                                                    null
+                                                                ],
+                                                                "type": [
+                                                                    "string",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "hpmsType": {
+                                                                "enum": [
+                                                                    "none",
+                                                                    "unknown",
+                                                                    "special",
+                                                                    "moto",
+                                                                    "car",
+                                                                    "carOther",
+                                                                    "bus",
+                                                                    "axleCnt2",
+                                                                    "axleCnt3",
+                                                                    "axleCnt4",
+                                                                    "axleCnt4Trailer",
+                                                                    "axleCnt5Trailer",
+                                                                    "axleCnt6Trailer",
+                                                                    "axleCnt5MultiTrailer",
+                                                                    "axleCnt6MultiTrailer",
+                                                                    "axleCnt7MultiTrailer",
+                                                                    null
+                                                                ],
+                                                                "type": [
+                                                                    "string",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "iso3883": {
+                                                                "type": [
+                                                                    "integer",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "keyType": {
+                                                                "type": [
+                                                                    "integer",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "regional": {
+                                                                "items": {
+                                                                    "contentEncoding": "base64",
+                                                                    "type": "string"
+                                                                },
+                                                                "maxItems": 4,
+                                                                "minItems": 1,
+                                                                "type": [
+                                                                    "array",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "responderType": {
+                                                                "enum": [
+                                                                    "emergency_vehicle_units",
+                                                                    "federal_law_enforcement_units",
+                                                                    "state_police_units",
+                                                                    "county_police_units",
+                                                                    "local_police_units",
+                                                                    "ambulance_units",
+                                                                    "rescue_units",
+                                                                    "fire_units",
+                                                                    "hAZMAT_units",
+                                                                    "light_tow_unit",
+                                                                    "heavy_tow_unit",
+                                                                    "freeway_service_patrols",
+                                                                    "transportation_response_units",
+                                                                    "private_contractor_response_units",
+                                                                    null
+                                                                ],
+                                                                "type": [
+                                                                    "string",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "responseEquip": {
+                                                                "properties": {
+                                                                    "name": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "value": {
+                                                                        "type": [
+                                                                            "integer",
+                                                                            "null"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "name"
+                                                                ],
+                                                                "type": [
+                                                                    "object",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "role": {
+                                                                "enum": [
+                                                                    "basicVehicle",
+                                                                    "publicTransport",
+                                                                    "specialTransport",
+                                                                    "dangerousGoods",
+                                                                    "roadWork",
+                                                                    "roadRescue",
+                                                                    "emergency",
+                                                                    "safetyCar",
+                                                                    "none_unknown",
+                                                                    "truck",
+                                                                    "motorcycle",
+                                                                    "roadSideSource",
+                                                                    "police",
+                                                                    "fire",
+                                                                    "ambulance",
+                                                                    "dot",
+                                                                    "transit",
+                                                                    "slowMoving",
+                                                                    "stopNgo",
+                                                                    "cyclist",
+                                                                    "pedestrian",
+                                                                    "nonMotorized",
+                                                                    "military",
+                                                                    null
+                                                                ],
+                                                                "type": [
+                                                                    "string",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "vehicleType": {
+                                                                "properties": {
+                                                                    "name": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "value": {
+                                                                        "type": [
+                                                                            "integer",
+                                                                            "null"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "name"
+                                                                ],
+                                                                "type": [
+                                                                    "object",
+                                                                    "null"
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [],
+                                                        "type": [
+                                                            "object",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "classification": {
+                                                        "type": [
+                                                            "integer",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "obstacle": {
+                                                        "properties": {
+                                                            "dateTime": {
+                                                                "properties": {
+                                                                    "day": {
+                                                                        "type": [
+                                                                            "integer",
+                                                                            "null"
+                                                                        ]
+                                                                    },
+                                                                    "hour": {
+                                                                        "type": [
+                                                                            "integer",
+                                                                            "null"
+                                                                        ]
+                                                                    },
+                                                                    "minute": {
+                                                                        "type": [
+                                                                            "integer",
+                                                                            "null"
+                                                                        ]
+                                                                    },
+                                                                    "month": {
+                                                                        "type": [
+                                                                            "integer",
+                                                                            "null"
+                                                                        ]
+                                                                    },
+                                                                    "offset": {
+                                                                        "type": [
+                                                                            "integer",
+                                                                            "null"
+                                                                        ]
+                                                                    },
+                                                                    "second": {
+                                                                        "type": [
+                                                                            "integer",
+                                                                            "null"
+                                                                        ]
+                                                                    },
+                                                                    "year": {
+                                                                        "type": [
+                                                                            "integer",
+                                                                            "null"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [],
+                                                                "type": [
+                                                                    "object",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "description": {
+                                                                "type": [
+                                                                    "integer",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "locationDetails": {
+                                                                "properties": {
+                                                                    "name": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "value": {
+                                                                        "type": [
+                                                                            "integer",
+                                                                            "null"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "name"
+                                                                ],
+                                                                "type": [
+                                                                    "object",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "obDirect": {
+                                                                "type": "number"
+                                                            },
+                                                            "obDist": {
+                                                                "type": "integer"
+                                                            },
+                                                            "vertEvent": {
+                                                                "properties": {
+                                                                    "leftFront": {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    "leftRear": {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    "notEquipped": {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    "rightFront": {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    "rightRear": {
+                                                                        "type": "boolean"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "rightRear",
+                                                                    "rightFront",
+                                                                    "leftRear",
+                                                                    "leftFront",
+                                                                    "notEquipped"
+                                                                ],
+                                                                "type": [
+                                                                    "object",
+                                                                    "null"
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "obDirect",
+                                                            "obDist"
+                                                        ],
+                                                        "type": [
+                                                            "object",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "regional": {
+                                                        "items": {
+                                                            "contentEncoding": "base64",
+                                                            "type": "string"
+                                                        },
+                                                        "maxItems": 4,
+                                                        "minItems": 1,
+                                                        "type": [
+                                                            "array",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "speedProfile": {
+                                                        "properties": {
+                                                            "speedReports": {
+                                                                "items": {
+                                                                    "type": "integer"
+                                                                },
+                                                                "maxItems": 20,
+                                                                "minItems": 1,
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "required": [],
+                                                        "type": [
+                                                            "object",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "status": {
+                                                        "properties": {
+                                                            "locationDetails": {
+                                                                "properties": {
+                                                                    "name": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "value": {
+                                                                        "type": [
+                                                                            "integer",
+                                                                            "null"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "name"
+                                                                ],
+                                                                "type": [
+                                                                    "object",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "statusDetails": {
+                                                                "type": "integer"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "statusDetails"
+                                                        ],
+                                                        "type": [
+                                                            "object",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "theRTCM": {
+                                                        "properties": {
+                                                            "msgs": {
+                                                                "items": {
+                                                                    "type": "string"
+                                                                },
+                                                                "maxItems": 5,
+                                                                "minItems": 1,
+                                                                "type": "array"
+                                                            },
+                                                            "rtcmHeader": {
+                                                                "properties": {
+                                                                    "offsetSet": {
+                                                                        "properties": {
+                                                                            "antOffsetX": {
+                                                                                "type": "number"
+                                                                            },
+                                                                            "antOffsetY": {
+                                                                                "type": "number"
+                                                                            },
+                                                                            "antOffsetZ": {
+                                                                                "type": "number"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "antOffsetX",
+                                                                            "antOffsetY",
+                                                                            "antOffsetZ"
+                                                                        ],
+                                                                        "type": "object"
+                                                                    },
+                                                                    "status": {
+                                                                        "properties": {
+                                                                            "aPDOPofUnder5": {
+                                                                                "type": "boolean"
+                                                                            },
+                                                                            "baseStationType": {
+                                                                                "type": "boolean"
+                                                                            },
+                                                                            "inViewOfUnder5": {
+                                                                                "type": "boolean"
+                                                                            },
+                                                                            "isHealthy": {
+                                                                                "type": "boolean"
+                                                                            },
+                                                                            "isMonitored": {
+                                                                                "type": "boolean"
+                                                                            },
+                                                                            "localCorrectionsPresent": {
+                                                                                "type": "boolean"
+                                                                            },
+                                                                            "networkCorrectionsPresent": {
+                                                                                "type": "boolean"
+                                                                            },
+                                                                            "unavailable": {
+                                                                                "type": "boolean"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "unavailable",
+                                                                            "isHealthy",
+                                                                            "isMonitored",
+                                                                            "baseStationType",
+                                                                            "aPDOPofUnder5",
+                                                                            "inViewOfUnder5",
+                                                                            "localCorrectionsPresent",
+                                                                            "networkCorrectionsPresent"
+                                                                        ],
+                                                                        "type": "object"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "status",
+                                                                    "offsetSet"
+                                                                ],
+                                                                "type": [
+                                                                    "object",
+                                                                    "null"
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "msgs"
+                                                        ],
+                                                        "type": "object"
+                                                    },
+                                                    "vehicleData": {
+                                                        "properties": {
+                                                            "bumpers": {
+                                                                "properties": {
+                                                                    "front": {
+                                                                        "type": "number"
+                                                                    },
+                                                                    "rear": {
+                                                                        "type": "number"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "front",
+                                                                    "rear"
+                                                                ],
+                                                                "type": [
+                                                                    "object",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "height": {
+                                                                "type": [
+                                                                    "number",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "mass": {
+                                                                "type": [
+                                                                    "integer",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "trailerWeight": {
+                                                                "type": [
+                                                                    "integer",
+                                                                    "null"
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [],
+                                                        "type": [
+                                                            "object",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "weatherProbe": {
+                                                        "properties": {
+                                                            "airPressure": {
+                                                                "type": [
+                                                                    "integer",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "airTemp": {
+                                                                "type": [
+                                                                    "integer",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "rainRates": {
+                                                                "properties": {
+                                                                    "rateFront": {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    "rateRear": {
+                                                                        "type": [
+                                                                            "integer",
+                                                                            "null"
+                                                                        ]
+                                                                    },
+                                                                    "statusFront": {
+                                                                        "enum": [
+                                                                            "UNAVAILABLE",
+                                                                            "OFF",
+                                                                            "INTERMITTENT",
+                                                                            "LOW",
+                                                                            "HIGH",
+                                                                            "WASHERINUSE",
+                                                                            "AUTOMATICPRESENT"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    "statusRear": {
+                                                                        "enum": [
+                                                                            "UNAVAILABLE",
+                                                                            "OFF",
+                                                                            "INTERMITTENT",
+                                                                            "LOW",
+                                                                            "HIGH",
+                                                                            "WASHERINUSE",
+                                                                            "AUTOMATICPRESENT",
+                                                                            null
+                                                                        ],
+                                                                        "type": [
+                                                                            "string",
+                                                                            "null"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "rateFront",
+                                                                    "statusFront"
+                                                                ],
+                                                                "type": [
+                                                                    "object",
+                                                                    "null"
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [],
+                                                        "type": [
+                                                            "object",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "weatherReport": {
+                                                        "properties": {
+                                                            "friction": {
+                                                                "type": [
+                                                                    "integer",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "isRaining": {
+                                                                "enum": [
+                                                                    "NA",
+                                                                    "PRECIP",
+                                                                    "NOPRECIP",
+                                                                    "ERROR"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "precipSituation": {
+                                                                "enum": [
+                                                                    "NA",
+                                                                    "OTHER",
+                                                                    "UNKNOWN",
+                                                                    "NOPRECIPITATION",
+                                                                    "UNIDENTIFIEDSLIGHT",
+                                                                    "UNIDENTIFIEDMODERATE",
+                                                                    "UNIDENTIFIEDHEAVY",
+                                                                    "SNOWSLIGHT",
+                                                                    "SNOWMODERATE",
+                                                                    "SNOWHEAVY",
+                                                                    "RAINSLIGHT",
+                                                                    "RAINMODERATE",
+                                                                    "RAINHEAVY",
+                                                                    "FROZENPRECIPITATIONSLIGHT",
+                                                                    "FROZENPRECIPITATIONMODERATE",
+                                                                    "FROZENPRECIPITATIONHEAVY",
+                                                                    null
+                                                                ],
+                                                                "type": [
+                                                                    "string",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "rainRate": {
+                                                                "type": [
+                                                                    "number",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "roadFriction": {
+                                                                "type": [
+                                                                    "number",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "solarRadiation": {
+                                                                "type": [
+                                                                    "integer",
+                                                                    "null"
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "isRaining"
+                                                        ],
+                                                        "type": [
+                                                            "object",
+                                                            "null"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [],
+                                                "type": "object"
+                                            }
+                                        },
+                                        "required": [
+                                            "id",
+                                            "value"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ]
+                            },
+                            "maxItems": 8,
+                            "minItems": 1,
+                            "type": [
+                                "array",
+                                "null"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "coreData",
+                        "partII"
+                    ],
+                    "type": "object"
+                },
+                "dataType": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "@class",
+                "dataType",
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "metadata",
+        "payload"
+    ],
+    "type": "object"
 }

--- a/docs/schemas/schema-map.json
+++ b/docs/schemas/schema-map.json
@@ -121,6 +121,9 @@
         },
         "payload": {
             "properties": {
+                "@class": {
+                    "type": "string"
+                },
                 "data": {
                     "properties": {
                         "dataParameters": {
@@ -2098,6 +2101,7 @@
                 }
             },
             "required": [
+                "@class",
                 "dataType",
                 "data"
             ],

--- a/docs/schemas/schema-map.json
+++ b/docs/schemas/schema-map.json
@@ -3,6 +3,9 @@
     "properties": {
         "metadata": {
             "properties": {
+                "@class": {
+                    "type": "string"
+                },
                 "encodings": {
                     "type": "null"
                 },
@@ -97,6 +100,7 @@
                 }
             },
             "required": [
+                "@class",
                 "mapSource",
                 "originIp",
                 "logFileName",

--- a/docs/schemas/schema-spat.json
+++ b/docs/schemas/schema-spat.json
@@ -266,10 +266,14 @@
         "payload": {
             "type": "object",
             "required": [
+                "@class",
                 "dataType",
                 "data"
             ],
             "properties": {
+                "@class": {
+                    "type": "string"
+                },
                 "dataType": {
                     "type": "string"
                 },

--- a/docs/schemas/schema-spat.json
+++ b/docs/schemas/schema-spat.json
@@ -9,6 +9,7 @@
         "metadata": {
             "type": "object",
             "required": [
+                "@class",
                 "spatSource",
                 "logFileName",
                 "recordType",
@@ -22,6 +23,9 @@
                 "sanitized"
             ],
             "properties": {
+                "@class": {
+                    "type": "string"
+                },
                 "spatSource": {
                     "type": "string",
                     "enum": [
@@ -105,7 +109,6 @@
                     "required": [
                         "rxSource"
                     ],
-                    "additionalProperties": false,
                     "properties": {
                         "locationData": {
                             "type": [
@@ -119,7 +122,6 @@
                                 "speed",
                                 "heading"
                             ],
-                            "additionalProperties": false,
                             "properties": {
                                 "latitude": {
                                     "type": "string"
@@ -163,7 +165,6 @@
                             "elementType",
                             "encodingRule"
                         ],
-                        "additionalProperties": false,
                         "properties": {
                             "elementName": {
                                 "type": "string"
@@ -193,7 +194,6 @@
                         "recordId",
                         "serialNumber"
                     ],
-                    "additionalProperties": false,
                     "properties": {
                         "streamId": {
                             "type": "string"
@@ -261,8 +261,7 @@
                 "sanitized": {
                     "type": "boolean"
                 }
-            },
-            "additionalProperties": false
+            }
         },
         "payload": {
             "type": "object",
@@ -330,29 +329,75 @@
                                                     "id": {
                                                         "type": "integer"
                                                     }
-                                                },
-                                                "additionalProperties": false
+                                                }
                                             },
                                             "revision": {
                                                 "type": "integer"
                                             },
                                             "status": {
-                                                "type": "string",
-                                                "enum": [
-                                                    "MANUALCONTROLISENABLED",
-                                                    "STOPTIMEISACTIVATED",
-                                                    "FAILUREFLASH",
-                                                    "PREEMPTISACTIVE",
-                                                    "SIGNALPRIORITYISACTIVE",
-                                                    "FIXEDTIMEOPERATION",
-                                                    "TRAFFICDEPENDENTOPERATION",
-                                                    "STANDBYOPERATION",
-                                                    "FAILUREMODE",
-                                                    "OFF",
-                                                    "RECENTMAPMESSAGEUPDATE",
-                                                    "RECENTCHANGEINMAPASSIGNEDLANESIDSUSED",
-                                                    "NOVALIDMAPISAVAILABLEATTHISTIME",
-                                                    "NOVALIDSPATISAVAILABLEATTHISTIME"
+                                                "properties": {
+                                                    "manualControlIsEnabled": {
+                                                        "type": "boolean"
+                                                    },
+                                                    "stopTimeIsActivated": {
+                                                        "type": "boolean"
+                                                    },
+                                                    "failureFlash": {
+                                                        "type": "boolean"
+                                                    },
+                                                    "preemptIsActive": {
+                                                        "type": "boolean"
+                                                    },
+                                                    "signalPriorityIsActive": {
+                                                        "type": "boolean"
+                                                    },
+                                                    "fixedTimeOperation": {
+                                                        "type": "boolean"
+                                                    },
+                                                    "trafficDependentOperation": {
+                                                        "type": "boolean"
+                                                    },
+                                                    "standbyOperation": {
+                                                        "type": "boolean"
+                                                    },
+                                                    "failureMode": {
+                                                        "type": "boolean"
+                                                    },
+                                                    "off": {
+                                                        "type": "boolean"
+                                                    },
+                                                    "recentMAPmessageUpdate": {
+                                                        "type": "boolean"
+                                                    },
+                                                    "recentChangeInMAPassignedLanesIDsUsed": {
+                                                        "type": "boolean"
+                                                    },
+                                                    "noValidMAPisAvailableAtThisTime": {
+                                                        "type": "boolean"
+                                                    },
+                                                    "noValidSPATisAvailableAtThisTime": {
+                                                        "type": "boolean"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "manualControlIsEnabled",
+                                                    "stopTimeIsActivated",
+                                                    "failureFlash",
+                                                    "preemptIsActive",
+                                                    "signalPriorityIsActive",
+                                                    "fixedTimeOperation",
+                                                    "trafficDependentOperation",
+                                                    "standbyOperation",
+                                                    "failureMode",
+                                                    "off",
+                                                    "recentMAPmessageUpdate",
+                                                    "recentChangeInMAPassignedLanesIDsUsed",
+                                                    "noValidMAPisAvailableAtThisTime",
+                                                    "noValidSPATisAvailableAtThisTime"
+                                                ],
+                                                "type": [
+                                                    "object",
+                                                    "null"
                                                 ]
                                             },
                                             "moy": {
@@ -382,8 +427,7 @@
                                                             "type": "integer"
                                                         }
                                                     }
-                                                },
-                                                "additionalProperties": false
+                                                }
                                             },
                                             "states": {
                                                 "type": "object",
@@ -481,8 +525,7 @@
                                                                                                     "null"
                                                                                                 ]
                                                                                             }
-                                                                                        },
-                                                                                        "additionalProperties": false
+                                                                                        }
                                                                                     },
                                                                                     "speeds": {
                                                                                         "type": [
@@ -548,19 +591,15 @@
                                                                                                                 "null"
                                                                                                             ]
                                                                                                         }
-                                                                                                    },
-                                                                                                    "additionalProperties": false
+                                                                                                    }
                                                                                                 }
                                                                                             }
-                                                                                        },
-                                                                                        "additionalProperties": false
+                                                                                        }
                                                                                     }
-                                                                                },
-                                                                                "additionalProperties": false
+                                                                                }
                                                                             }
                                                                         }
-                                                                    },
-                                                                    "additionalProperties": false
+                                                                    }
                                                                 },
                                                                 "maneuverAssistList": {
                                                                     "type": [
@@ -606,19 +645,15 @@
                                                                                             "null"
                                                                                         ]
                                                                                     }
-                                                                                },
-                                                                                "additionalProperties": false
+                                                                                }
                                                                             }
                                                                         }
-                                                                    },
-                                                                    "additionalProperties": false
+                                                                    }
                                                                 }
-                                                            },
-                                                            "additionalProperties": false
+                                                            }
                                                         }
                                                     }
-                                                },
-                                                "additionalProperties": false
+                                                }
                                             },
                                             "maneuverAssistList": {
                                                 "type": [
@@ -664,25 +699,19 @@
                                                                         "null"
                                                                     ]
                                                                 }
-                                                            },
-                                                            "additionalProperties": false
+                                                            }
                                                         }
                                                     }
-                                                },
-                                                "additionalProperties": false
+                                                }
                                             }
-                                        },
-                                        "additionalProperties": false
+                                        }
                                     }
                                 }
                             }
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 }
-            },
-            "additionalProperties": false
+            }
         }
-    },
-    "additionalProperties": false
+    }
 }

--- a/docs/schemas/schema-srm.json
+++ b/docs/schemas/schema-srm.json
@@ -1,450 +1,451 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "type": "object",
-  "properties": {
-      "metadata": {
-          "type": "object",
-          "properties": {
-              "originIp": {
-                  "type": "string"
-              },
-              "srmSource": {
-                  "type": "string"
-              },
-              "logFileName": {
-                  "type": "string"
-              },
-              "recordType": {
-                  "type": "string"
-              },
-              "securityResultCode": {
-                  "type": [
-                      "string",
-                      "null"
-                  ]
-              },
-              "receivedMessageDetails": {
-                  "type": "object",
-                  "properties": {
-                      "locationData": {
-                          "type": "null"
-                      },
-                      "rxSource": {
-                          "type": "string"
-                      }
-                  },
-                  "required": [
-                      "rxSource"
-                  ]
-              },
-              "encodings": {
-                  "type": "null"
-              },
-              "payloadType": {
-                  "type": "string"
-              },
-              "serialId": {
-                  "type": "object",
-                  "properties": {
-                      "streamId": {
-                          "type": "string"
-                      },
-                      "bundleSize": {
-                          "type": "integer"
-                      },
-                      "bundleId": {
-                          "type": "integer"
-                      },
-                      "recordId": {
-                          "type": "integer"
-                      },
-                      "serialNumber": {
-                          "type": "integer"
-                      }
-                  },
-                  "required": [
-                      "streamId",
-                      "bundleSize",
-                      "bundleId",
-                      "recordId",
-                      "serialNumber"
-                  ]
-              },
-              "odeReceivedAt": {
-                  "type": "string"
-              },
-              "schemaVersion": {
-                  "type": "integer"
-              },
-              "maxDurationTime": {
-                  "type": "integer"
-              },
-              "odePacketID": {
-                  "type": "string"
-              },
-              "odeTimStartDateTime": {
-                  "type": "string"
-              },
-              "recordGeneratedAt": {
-                  "type": "string"
-              },
-              "recordGeneratedBy": {
-                  "type": "null"
-              },
-              "sanitized": {
-                  "type": "boolean"
-              }
-          },
-          "required": [
-              "originIp",
-              "srmSource",
-              "logFileName",
-              "recordType",
-              "receivedMessageDetails",
-              "payloadType",
-              "serialId",
-              "odeReceivedAt",
-              "schemaVersion",
-              "maxDurationTime",
-              "odePacketID",
-              "odeTimStartDateTime",
-              "recordGeneratedAt",
-              "sanitized"
-          ]
-      },
-      "payload": {
-          "type": "object",
-          "properties": {
-              "dataType": {
-                  "type": "string"
-              },
-              "data": {
-                  "type": "object",
-                  "properties": {
-                      "timeStamp": {
-                          "type": [
-                              "integer",
-                              "null"
-                          ]
-                      },
-                      "second": {
-                          "type": [
-                              "integer",
-                              "null"
-                          ]
-                      },
-                      "sequenceNumber": {
-                          "type": [
-                              "integer",
-                              "null"
-                          ]
-                      },
-                      "requests": {
-                          "type": [
-                              "object",
-                              "null"
-                          ],
-                          "properties": {
-                              "signalRequestPackage": {
-                                  "type": "array",
-                                  "items": [
-                                      {
-                                          "type": "object",
-                                          "properties": {
-                                              "request": {
-                                                  "type": "object",
-                                                  "properties": {
-                                                      "id": {
-                                                          "type": "object",
-                                                          "properties": {
-                                                              "region": {
-                                                                  "type": [
-                                                                      "integer",
-                                                                      "null"
-                                                                  ]
-                                                              },
-                                                              "id": {
-                                                                  "type": [
-                                                                      "integer",
-                                                                      "null"
-                                                                  ]
-                                                              }
-                                                          },
-                                                          "required": [
-                                                              "id"
-                                                          ]
-                                                      },
-                                                      "requestID": {
-                                                          "type": "integer"
-                                                      },
-                                                      "requestType": {
-                                                          "type": "string"
-                                                      },
-                                                      "inBoundLane": {
-                                                          "type": "object",
-                                                          "properties": {
-                                                              "lane": {
-                                                                  "type": [
-                                                                      "integer",
-                                                                      "null"
-                                                                  ]
-                                                              },
-                                                              "approach": {
-                                                                  "type": [
-                                                                      "integer",
-                                                                      "null"
-                                                                  ]
-                                                              },
-                                                              "connection": {
-                                                                  "type": [
-                                                                      "integer",
-                                                                      "null"
-                                                                  ]
-                                                              }
-                                                          },
-                                                          "required": [
-                                                              "lane"
-                                                          ]
-                                                      },
-                                                      "outBoundLane": {
-                                                          "type": [
-                                                              "object",
-                                                              "null"
-                                                          ],
-                                                          "properties": {
-                                                              "lane": {
-                                                                  "type": [
-                                                                      "integer",
-                                                                      "null"
-                                                                  ]
-                                                              },
-                                                              "approach": {
-                                                                  "type": [
-                                                                      "integer",
-                                                                      "null"
-                                                                  ]
-                                                              },
-                                                              "connection": {
-                                                                  "type": [
-                                                                      "integer",
-                                                                      "null"
-                                                                  ]
-                                                              }
-                                                          },
-                                                          "required": [
-                                                              "lane"
-                                                          ]
-                                                      }
-                                                  },
-                                                  "required": [
-                                                      "id",
-                                                      "requestID",
-                                                      "requestType",
-                                                      "inBoundLane"
-                                                  ]
-                                              },
-                                              "minute": {
-                                                  "type": [
-                                                      "integer",
-                                                      "null"
-                                                  ]
-                                              },
-                                              "second": {
-                                                  "type": [
-                                                      "integer",
-                                                      "null"
-                                                  ]
-                                              },
-                                              "duration": {
-                                                  "type": [
-                                                      "integer",
-                                                      "null"
-                                                  ]
-                                              }
-                                          },
-                                          "required": [
-                                              "request"
-                                          ]
-                                      }
-                                  ]
-                              }
-                          },
-                          "required": [
-                              "signalRequestPackage"
-                          ]
-                      },
-                      "requestor": {
-                          "type": "object",
-                          "properties": {
-                              "id": {
-                                  "type": "object",
-                                  "properties": {
-                                      "entityID": {
-                                          "type": [
-                                              "string",
-                                              "null"
-                                          ]
-                                      },
-                                      "stationID": {
-                                          "type": [
-                                              "integer",
-                                              "null"
-                                          ]
-                                      }
-                                  },
-                                  "required": [
-                                      "stationID"
-                                  ]
-                              },
-                              "type": {
-                                  "type": [
-                                      "object",
-                                      "null"
-                                  ],
-                                  "properties": {
-                                      "role": {
-                                          "type": "string"
-                                      },
-                                      "subrole": {
-                                          "type": [
-                                              "string",
-                                              "null"
-                                          ]
-                                      },
-                                      "request": {
-                                          "type": [
-                                              "string",
-                                              "null"
-                                          ]
-                                      },
-                                      "iso3883": {
-                                          "type": [
-                                              "integer",
-                                              "null"
-                                          ]
-                                      },
-                                      "hpmsType": {
-                                          "type": [
-                                              "string",
-                                              "null"
-                                          ]
-                                      }
-                                  },
-                                  "required": [
-                                      "role"
-                                  ]
-                              },
-                              "position": {
-                                  "type": [
-                                      "object",
-                                      "null"
-                                  ],
-                                  "properties": {
-                                      "position": {
-                                          "type": "object",
-                                          "properties": {
-                                              "latitude": {
-                                                  "type": "number"
-                                              },
-                                              "longitude": {
-                                                  "type": "number"
-                                              },
-                                              "elevation": {
-                                                  "type": [
-                                                      "number",
-                                                      "null"
-                                                  ]
-                                              }
-                                          },
-                                          "required": [
-                                              "latitude",
-                                              "longitude"
-                                          ]
-                                      },
-                                      "heading": {
-                                          "type": [
-                                              "number",
-                                              "null"
-                                          ]
-                                      },
-                                      "speed": {
-                                          "type": [
-                                              "object",
-                                              "null"
-                                          ],
-                                          "properties": {
-                                              "transmisson": {
-                                                  "type": [
-                                                      "string",
-                                                      "null"
-                                                  ]
-                                              },
-                                              "speed": {
-                                                  "type": [
-                                                      "number",
-                                                      "null"
-                                                  ]
-                                              }
-                                          },
-                                          "required": [
-                                              "transmisson",
-                                              "speed"
-                                          ]
-                                      }
-                                  },
-                                  "required": [
-                                      "position"
-                                  ]
-                              },
-                              "name": {
-                                  "type": [
-                                      "string",
-                                      "null"
-                                  ]
-                              },
-                              "routeName": {
-                                  "type": [
-                                      "string",
-                                      "null"
-                                  ]
-                              },
-                              "transitStatus": {
-                                  "type": [
-                                      "string",
-                                      "null"
-                                  ]
-                              },
-                              "transitOccupancy": {
-                                  "type": [
-                                      "string",
-                                      "null"
-                                  ]
-                              },
-                              "transitSchedule": {
-                                  "type": [
-                                      "integer",
-                                      "null"
-                                  ]
-                              }
-                          },
-                          "required": [
-                              "id"
-                          ]
-                      }
-                  },
-                  "required": [
-                      "requestor"
-                  ]
-              }
-          },
-          "required": [
-              "dataType",
-              "data"
-          ]
-      }
-  },
-  "required": [
-      "metadata",
-      "payload"
-  ]
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+        "metadata": {
+            "type": "object",
+            "properties": {
+                "@class": {
+                    "type": "string"
+                },
+                "originIp": {
+                    "type": "string"
+                },
+                "srmSource": {
+                    "type": "string"
+                },
+                "logFileName": {
+                    "type": "string"
+                },
+                "recordType": {
+                    "type": "string"
+                },
+                "securityResultCode": {
+                    "type": "string"
+                },
+                "receivedMessageDetails": {
+                    "type": "object",
+                    "properties": {
+                        "locationData": {
+                            "type": "null"
+                        },
+                        "rxSource": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "rxSource"
+                    ]
+                },
+                "encodings": {
+                    "type": "null"
+                },
+                "payloadType": {
+                    "type": "string"
+                },
+                "serialId": {
+                    "type": "object",
+                    "properties": {
+                        "streamId": {
+                            "type": "string"
+                        },
+                        "bundleSize": {
+                            "type": "integer"
+                        },
+                        "bundleId": {
+                            "type": "integer"
+                        },
+                        "recordId": {
+                            "type": "integer"
+                        },
+                        "serialNumber": {
+                            "type": "integer"
+                        }
+                    },
+                    "required": [
+                        "streamId",
+                        "bundleSize",
+                        "bundleId",
+                        "recordId",
+                        "serialNumber"
+                    ]
+                },
+                "odeReceivedAt": {
+                    "type": "string"
+                },
+                "schemaVersion": {
+                    "type": "integer"
+                },
+                "maxDurationTime": {
+                    "type": "integer"
+                },
+                "odePacketID": {
+                    "type": "string"
+                },
+                "odeTimStartDateTime": {
+                    "type": "string"
+                },
+                "recordGeneratedAt": {
+                    "type": "string"
+                },
+                "recordGeneratedBy": {
+                    "type": "null"
+                },
+                "sanitized": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "@class",
+                "originIp",
+                "srmSource",
+                "logFileName",
+                "recordType",
+                "receivedMessageDetails",
+                "payloadType",
+                "serialId",
+                "odeReceivedAt",
+                "schemaVersion",
+                "maxDurationTime",
+                "odePacketID",
+                "odeTimStartDateTime",
+                "recordGeneratedAt",
+                "sanitized"
+            ]
+        },
+        "payload": {
+            "type": "object",
+            "properties": {
+                "dataType": {
+                    "type": "string"
+                },
+                "data": {
+                    "type": "object",
+                    "properties": {
+                        "timeStamp": {
+                            "type": [
+                                "integer",
+                                "null"
+                            ]
+                        },
+                        "second": {
+                            "type": [
+                                "integer",
+                                "null"
+                            ]
+                        },
+                        "sequenceNumber": {
+                            "type": [
+                                "integer",
+                                "null"
+                            ]
+                        },
+                        "requests": {
+                            "type": [
+                                "object",
+                                "null"
+                            ],
+                            "properties": {
+                                "signalRequestPackage": {
+                                    "type": "array",
+                                    "items": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "request": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "id": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "region": {
+                                                                    "type": [
+                                                                        "integer",
+                                                                        "null"
+                                                                    ]
+                                                                },
+                                                                "id": {
+                                                                    "type": [
+                                                                        "integer",
+                                                                        "null"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "id"
+                                                            ]
+                                                        },
+                                                        "requestID": {
+                                                            "type": "integer"
+                                                        },
+                                                        "requestType": {
+                                                            "type": "string"
+                                                        },
+                                                        "inBoundLane": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "lane": {
+                                                                    "type": [
+                                                                        "integer",
+                                                                        "null"
+                                                                    ]
+                                                                },
+                                                                "approach": {
+                                                                    "type": [
+                                                                        "integer",
+                                                                        "null"
+                                                                    ]
+                                                                },
+                                                                "connection": {
+                                                                    "type": [
+                                                                        "integer",
+                                                                        "null"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lane"
+                                                            ]
+                                                        },
+                                                        "outBoundLane": {
+                                                            "type": [
+                                                                "object",
+                                                                "null"
+                                                            ],
+                                                            "properties": {
+                                                                "lane": {
+                                                                    "type": [
+                                                                        "integer",
+                                                                        "null"
+                                                                    ]
+                                                                },
+                                                                "approach": {
+                                                                    "type": [
+                                                                        "integer",
+                                                                        "null"
+                                                                    ]
+                                                                },
+                                                                "connection": {
+                                                                    "type": [
+                                                                        "integer",
+                                                                        "null"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lane"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "id",
+                                                        "requestID",
+                                                        "requestType",
+                                                        "inBoundLane"
+                                                    ]
+                                                },
+                                                "minute": {
+                                                    "type": [
+                                                        "integer",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "second": {
+                                                    "type": [
+                                                        "integer",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "duration": {
+                                                    "type": [
+                                                        "integer",
+                                                        "null"
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "request"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "signalRequestPackage"
+                            ]
+                        },
+                        "requestor": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "object",
+                                    "properties": {
+                                        "entityID": {
+                                            "type": [
+                                                "string",
+                                                "null"
+                                            ]
+                                        },
+                                        "stationID": {
+                                            "type": [
+                                                "integer",
+                                                "null"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "stationID"
+                                    ]
+                                },
+                                "type": {
+                                    "type": [
+                                        "object",
+                                        "null"
+                                    ],
+                                    "properties": {
+                                        "role": {
+                                            "type": "string"
+                                        },
+                                        "subrole": {
+                                            "type": [
+                                                "string",
+                                                "null"
+                                            ]
+                                        },
+                                        "request": {
+                                            "type": [
+                                                "string",
+                                                "null"
+                                            ]
+                                        },
+                                        "iso3883": {
+                                            "type": [
+                                                "integer",
+                                                "null"
+                                            ]
+                                        },
+                                        "hpmsType": {
+                                            "type": [
+                                                "string",
+                                                "null"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "role"
+                                    ]
+                                },
+                                "position": {
+                                    "type": [
+                                        "object",
+                                        "null"
+                                    ],
+                                    "properties": {
+                                        "position": {
+                                            "type": "object",
+                                            "properties": {
+                                                "latitude": {
+                                                    "type": "number"
+                                                },
+                                                "longitude": {
+                                                    "type": "number"
+                                                },
+                                                "elevation": {
+                                                    "type": [
+                                                        "number",
+                                                        "null"
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "latitude",
+                                                "longitude"
+                                            ]
+                                        },
+                                        "heading": {
+                                            "type": [
+                                                "number",
+                                                "null"
+                                            ]
+                                        },
+                                        "speed": {
+                                            "type": [
+                                                "object",
+                                                "null"
+                                            ],
+                                            "properties": {
+                                                "transmisson": {
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "speed": {
+                                                    "type": [
+                                                        "number",
+                                                        "null"
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "transmisson",
+                                                "speed"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "position"
+                                    ]
+                                },
+                                "name": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "routeName": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "transitStatus": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "transitOccupancy": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "transitSchedule": {
+                                    "type": [
+                                        "integer",
+                                        "null"
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "id"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "requestor"
+                    ]
+                }
+            },
+            "required": [
+                "dataType",
+                "data"
+            ]
+        }
+    },
+    "required": [
+        "metadata",
+        "payload"
+    ]
 }

--- a/docs/schemas/schema-srm.json
+++ b/docs/schemas/schema-srm.json
@@ -116,6 +116,9 @@
         "payload": {
             "type": "object",
             "properties": {
+                "@class": {
+                    "type": "string"
+                },
                 "dataType": {
                     "type": "string"
                 },
@@ -439,6 +442,7 @@
                 }
             },
             "required": [
+                "@class",
                 "dataType",
                 "data"
             ]

--- a/docs/schemas/schema-ssm.json
+++ b/docs/schemas/schema-ssm.json
@@ -1,380 +1,381 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "type": "object",
-  "properties": {
-      "metadata": {
-          "type": "object",
-          "properties": {
-              "originIp": {
-                  "type": "string"
-              },
-              "ssmSource": {
-                  "type": "string"
-              },
-              "logFileName": {
-                  "type": "string"
-              },
-              "recordType": {
-                  "type": "string"
-              },
-              "securityResultCode": {
-                  "type": [
-                      "string",
-                      "null"
-                  ]
-              },
-              "receivedMessageDetails": {
-                  "type": "object",
-                  "properties": {
-                      "locationData": {
-                          "type": [
-                              "object",
-                              "null"
-                          ]
-                      },
-                      "rxSource": {
-                          "type": "string"
-                      }
-                  },
-                  "required": [
-                      "rxSource"
-                  ]
-              },
-              "encodings": {
-                  "type": [
-                      "array",
-                      "null"
-                  ]
-              },
-              "payloadType": {
-                  "type": "string"
-              },
-              "serialId": {
-                  "type": "object",
-                  "properties": {
-                      "streamId": {
-                          "type": "string"
-                      },
-                      "bundleSize": {
-                          "type": "integer"
-                      },
-                      "bundleId": {
-                          "type": "integer"
-                      },
-                      "recordId": {
-                          "type": "integer"
-                      },
-                      "serialNumber": {
-                          "type": "integer"
-                      }
-                  },
-                  "required": [
-                      "streamId",
-                      "bundleSize",
-                      "bundleId",
-                      "recordId",
-                      "serialNumber"
-                  ]
-              },
-              "odeReceivedAt": {
-                  "type": "string"
-              },
-              "schemaVersion": {
-                  "type": "integer"
-              },
-              "maxDurationTime": {
-                  "type": "integer"
-              },
-              "odePacketID": {
-                  "type": "string"
-              },
-              "odeTimStartDateTime": {
-                  "type": "string"
-              },
-              "recordGeneratedAt": {
-                  "type": "string"
-              },
-              "recordGeneratedBy": {
-                  "type": [
-                      "string",
-                      "null"
-                  ]
-              },
-              "sanitized": {
-                  "type": "boolean"
-              }
-          },
-          "required": [
-              "originIp",
-              "ssmSource",
-              "logFileName",
-              "recordType",
-              "receivedMessageDetails",
-              "payloadType",
-              "serialId",
-              "odeReceivedAt",
-              "schemaVersion",
-              "maxDurationTime",
-              "odePacketID",
-              "odeTimStartDateTime",
-              "recordGeneratedAt",
-              "sanitized"
-          ]
-      },
-      "payload": {
-          "type": "object",
-          "properties": {
-              "dataType": {
-                  "type": "string"
-              },
-              "data": {
-                  "type": "object",
-                  "properties": {
-                      "timeStamp": {
-                          "type": [
-                              "integer",
-                              "null"
-                          ]
-                      },
-                      "second": {
-                          "type": "integer"
-                      },
-                      "sequenceNumber": {
-                          "type": [
-                              "integer",
-                              "null"
-                          ]
-                      },
-                      "status": {
-                          "type": "object",
-                          "properties": {
-                              "signalStatus": {
-                                  "type": "array",
-                                  "items": [
-                                      {
-                                          "type": "object",
-                                          "properties": {
-                                              "sequenceNumber": {
-                                                  "type": "integer"
-                                              },
-                                              "id": {
-                                                  "type": "object",
-                                                  "properties": {
-                                                      "region": {
-                                                          "type": [
-                                                              "integer",
-                                                              "null"
-                                                          ]
-                                                      },
-                                                      "id": {
-                                                          "type": [
-                                                              "integer",
-                                                              "null"
-                                                          ]
-                                                      }
-                                                  },
-                                                  "required": [
-                                                      "id"
-                                                  ]
-                                              },
-                                              "sigStatus": {
-                                                  "type": "object",
-                                                  "properties": {
-                                                      "signalStatusPackage": {
-                                                          "type": "array",
-                                                          "items": [
-                                                              {
-                                                                  "type": "object",
-                                                                  "properties": {
-                                                                      "requester": {
-                                                                          "type": [
-                                                                              "object",
-                                                                              "null"
-                                                                          ],
-                                                                          "properties": {
-                                                                              "id": {
-                                                                                  "type": "object",
-                                                                                  "properties": {
-                                                                                      "entityID": {
-                                                                                          "type": [
-                                                                                              "string",
-                                                                                              "null"
-                                                                                          ]
-                                                                                      },
-                                                                                      "stationID": {
-                                                                                          "type": [
-                                                                                              "integer",
-                                                                                              "null"
-                                                                                          ]
-                                                                                      }
-                                                                                  },
-                                                                                  "required": [
-                                                                                      "stationID"
-                                                                                  ]
-                                                                              },
-                                                                              "request": {
-                                                                                  "type": "integer"
-                                                                              },
-                                                                              "sequenceNumber": {
-                                                                                  "type": "integer"
-                                                                              },
-                                                                              "role": {
-                                                                                  "type": [
-                                                                                      "string",
-                                                                                      "null"
-                                                                                  ]
-                                                                              },
-                                                                              "typeData": {
-                                                                                  "type": [
-                                                                                      "object",
-                                                                                      "null"
-                                                                                  ],
-                                                                                  "properties": {
-                                                                                      "role": {
-                                                                                          "type": "string"
-                                                                                      },
-                                                                                      "subrole": {
-                                                                                          "type": [
-                                                                                              "string",
-                                                                                              "null"
-                                                                                          ]
-                                                                                      },
-                                                                                      "request": {
-                                                                                          "type": [
-                                                                                              "string",
-                                                                                              "null"
-                                                                                          ]
-                                                                                      },
-                                                                                      "iso3883": {
-                                                                                          "type": [
-                                                                                              "integer",
-                                                                                              "null"
-                                                                                          ]
-                                                                                      },
-                                                                                      "hpmsType": {
-                                                                                          "type": [
-                                                                                              "string",
-                                                                                              "null"
-                                                                                          ]
-                                                                                      }
-                                                                                  },
-                                                                                  "required": [
-                                                                                      "role"
-                                                                                  ]
-                                                                              }
-                                                                          },
-                                                                          "required": [
-                                                                              "id",
-                                                                              "request",
-                                                                              "sequenceNumber"
-                                                                          ]
-                                                                      },
-                                                                      "inboundOn": {
-                                                                          "type": "object",
-                                                                          "properties": {
-                                                                              "lane": {
-                                                                                  "type": "integer"
-                                                                              },
-                                                                              "approach": {
-                                                                                  "type": [
-                                                                                      "integer",
-                                                                                      "null"
-                                                                                  ]
-                                                                              },
-                                                                              "connection": {
-                                                                                  "type": [
-                                                                                      "integer",
-                                                                                      "null"
-                                                                                  ]
-                                                                              }
-                                                                          },
-                                                                          "required": [
-                                                                              "lane"
-                                                                          ]
-                                                                      },
-                                                                      "outboundOn": {
-                                                                          "type": [
-                                                                              "object",
-                                                                              "null"
-                                                                          ],
-                                                                          "properties": {
-                                                                              "lane": {
-                                                                                  "type": "integer"
-                                                                              },
-                                                                              "approach": {
-                                                                                  "type": "integer"
-                                                                              },
-                                                                              "connection": {
-                                                                                  "type": "integer"
-                                                                              }
-                                                                          },
-                                                                          "required": [
-                                                                              "lane"
-                                                                          ]
-                                                                      },
-                                                                      "minute": {
-                                                                          "type": [
-                                                                              "integer",
-                                                                              "null"
-                                                                          ]
-                                                                      },
-                                                                      "second": {
-                                                                          "type": [
-                                                                              "integer",
-                                                                              "null"
-                                                                          ]
-                                                                      },
-                                                                      "duration": {
-                                                                          "type": [
-                                                                              "integer",
-                                                                              "null"
-                                                                          ]
-                                                                      },
-                                                                      "status": {
-                                                                          "type": "string"
-                                                                      }
-                                                                  },
-                                                                  "required": [
-                                                                      "inboundOn",
-                                                                      "status"
-                                                                  ]
-                                                              }
-                                                          ]
-                                                      }
-                                                  },
-                                                  "required": [
-                                                      "signalStatusPackage"
-                                                  ]
-                                              }
-                                          },
-                                          "required": [
-                                              "sequenceNumber",
-                                              "id",
-                                              "sigStatus"
-                                          ]
-                                      }
-                                  ]
-                              }
-                          },
-                          "required": [
-                              "signalStatus"
-                          ]
-                      }
-                  },
-                  "required": [
-                      "second",
-                      "status"
-                  ]
-              }
-          },
-          "required": [
-              "dataType",
-              "data"
-          ]
-      }
-  },
-  "required": [
-      "metadata",
-      "payload"
-  ]
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+        "metadata": {
+            "type": "object",
+            "properties": {
+                "@class": {
+                    "type": "string"
+                },
+                "originIp": {
+                    "type": "string"
+                },
+                "ssmSource": {
+                    "type": "string"
+                },
+                "logFileName": {
+                    "type": "string"
+                },
+                "recordType": {
+                    "type": "string"
+                },
+                "securityResultCode": {
+                    "type": "string"
+                },
+                "receivedMessageDetails": {
+                    "type": "object",
+                    "properties": {
+                        "locationData": {
+                            "type": [
+                                "object",
+                                "null"
+                            ]
+                        },
+                        "rxSource": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "rxSource"
+                    ]
+                },
+                "encodings": {
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "payloadType": {
+                    "type": "string"
+                },
+                "serialId": {
+                    "type": "object",
+                    "properties": {
+                        "streamId": {
+                            "type": "string"
+                        },
+                        "bundleSize": {
+                            "type": "integer"
+                        },
+                        "bundleId": {
+                            "type": "integer"
+                        },
+                        "recordId": {
+                            "type": "integer"
+                        },
+                        "serialNumber": {
+                            "type": "integer"
+                        }
+                    },
+                    "required": [
+                        "streamId",
+                        "bundleSize",
+                        "bundleId",
+                        "recordId",
+                        "serialNumber"
+                    ]
+                },
+                "odeReceivedAt": {
+                    "type": "string"
+                },
+                "schemaVersion": {
+                    "type": "integer"
+                },
+                "maxDurationTime": {
+                    "type": "integer"
+                },
+                "odePacketID": {
+                    "type": "string"
+                },
+                "odeTimStartDateTime": {
+                    "type": "string"
+                },
+                "recordGeneratedAt": {
+                    "type": "string"
+                },
+                "recordGeneratedBy": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "sanitized": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "@class",
+                "originIp",
+                "ssmSource",
+                "logFileName",
+                "recordType",
+                "receivedMessageDetails",
+                "payloadType",
+                "serialId",
+                "odeReceivedAt",
+                "schemaVersion",
+                "maxDurationTime",
+                "odePacketID",
+                "odeTimStartDateTime",
+                "recordGeneratedAt",
+                "sanitized"
+            ]
+        },
+        "payload": {
+            "type": "object",
+            "properties": {
+                "dataType": {
+                    "type": "string"
+                },
+                "data": {
+                    "type": "object",
+                    "properties": {
+                        "timeStamp": {
+                            "type": [
+                                "integer",
+                                "null"
+                            ]
+                        },
+                        "second": {
+                            "type": "integer"
+                        },
+                        "sequenceNumber": {
+                            "type": [
+                                "integer",
+                                "null"
+                            ]
+                        },
+                        "status": {
+                            "type": "object",
+                            "properties": {
+                                "signalStatus": {
+                                    "type": "array",
+                                    "items": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "sequenceNumber": {
+                                                    "type": "integer"
+                                                },
+                                                "id": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "region": {
+                                                            "type": [
+                                                                "integer",
+                                                                "null"
+                                                            ]
+                                                        },
+                                                        "id": {
+                                                            "type": [
+                                                                "integer",
+                                                                "null"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "id"
+                                                    ]
+                                                },
+                                                "sigStatus": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "signalStatusPackage": {
+                                                            "type": "array",
+                                                            "items": [
+                                                                {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "requester": {
+                                                                            "type": [
+                                                                                "object",
+                                                                                "null"
+                                                                            ],
+                                                                            "properties": {
+                                                                                "id": {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "entityID": {
+                                                                                            "type": [
+                                                                                                "string",
+                                                                                                "null"
+                                                                                            ]
+                                                                                        },
+                                                                                        "stationID": {
+                                                                                            "type": [
+                                                                                                "integer",
+                                                                                                "null"
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "stationID"
+                                                                                    ]
+                                                                                },
+                                                                                "request": {
+                                                                                    "type": "integer"
+                                                                                },
+                                                                                "sequenceNumber": {
+                                                                                    "type": "integer"
+                                                                                },
+                                                                                "role": {
+                                                                                    "type": [
+                                                                                        "string",
+                                                                                        "null"
+                                                                                    ]
+                                                                                },
+                                                                                "typeData": {
+                                                                                    "type": [
+                                                                                        "object",
+                                                                                        "null"
+                                                                                    ],
+                                                                                    "properties": {
+                                                                                        "role": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "subrole": {
+                                                                                            "type": [
+                                                                                                "string",
+                                                                                                "null"
+                                                                                            ]
+                                                                                        },
+                                                                                        "request": {
+                                                                                            "type": [
+                                                                                                "string",
+                                                                                                "null"
+                                                                                            ]
+                                                                                        },
+                                                                                        "iso3883": {
+                                                                                            "type": [
+                                                                                                "integer",
+                                                                                                "null"
+                                                                                            ]
+                                                                                        },
+                                                                                        "hpmsType": {
+                                                                                            "type": [
+                                                                                                "string",
+                                                                                                "null"
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "role"
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "id",
+                                                                                "request",
+                                                                                "sequenceNumber"
+                                                                            ]
+                                                                        },
+                                                                        "inboundOn": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "lane": {
+                                                                                    "type": "integer"
+                                                                                },
+                                                                                "approach": {
+                                                                                    "type": [
+                                                                                        "integer",
+                                                                                        "null"
+                                                                                    ]
+                                                                                },
+                                                                                "connection": {
+                                                                                    "type": [
+                                                                                        "integer",
+                                                                                        "null"
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "lane"
+                                                                            ]
+                                                                        },
+                                                                        "outboundOn": {
+                                                                            "type": [
+                                                                                "object",
+                                                                                "null"
+                                                                            ],
+                                                                            "properties": {
+                                                                                "lane": {
+                                                                                    "type": "integer"
+                                                                                },
+                                                                                "approach": {
+                                                                                    "type": "integer"
+                                                                                },
+                                                                                "connection": {
+                                                                                    "type": "integer"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "lane"
+                                                                            ]
+                                                                        },
+                                                                        "minute": {
+                                                                            "type": [
+                                                                                "integer",
+                                                                                "null"
+                                                                            ]
+                                                                        },
+                                                                        "second": {
+                                                                            "type": [
+                                                                                "integer",
+                                                                                "null"
+                                                                            ]
+                                                                        },
+                                                                        "duration": {
+                                                                            "type": [
+                                                                                "integer",
+                                                                                "null"
+                                                                            ]
+                                                                        },
+                                                                        "status": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "inboundOn",
+                                                                        "status"
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "signalStatusPackage"
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "sequenceNumber",
+                                                "id",
+                                                "sigStatus"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "signalStatus"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "second",
+                        "status"
+                    ]
+                }
+            },
+            "required": [
+                "dataType",
+                "data"
+            ]
+        }
+    },
+    "required": [
+        "metadata",
+        "payload"
+    ]
 }

--- a/docs/schemas/schema-ssm.json
+++ b/docs/schemas/schema-ssm.json
@@ -125,6 +125,9 @@
         "payload": {
             "type": "object",
             "properties": {
+                "@class": {
+                    "type": "string"
+                },
                 "dataType": {
                     "type": "string"
                 },
@@ -369,6 +372,7 @@
                 }
             },
             "required": [
+                "@class",
                 "dataType",
                 "data"
             ]

--- a/docs/schemas/schema-tim.json
+++ b/docs/schemas/schema-tim.json
@@ -1,487 +1,521 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {
-    "metadata": {
-      "properties": {
-        "logFileName": {
-          "type": "string"
-        },
-        "maxDurationTime": {
-          "type": "string"
-        },
-        "odePacketID": {
-          "type": "string"
-        },
-        "odeReceivedAt": {
-          "type": "string"
-        },
-        "odeTimStartDateTime": {
-          "type": "string"
-        },
-        "originIp": {
-          "type": "string"
-        },
-        "payloadType": {
-          "type": "string"
-        },
-        "receivedMessageDetails": {
-          "type": "string"
-        },
-        "recordGeneratedAt": {
-          "type": "string"
-        },
-        "recordGeneratedBy": {
-          "type": "string"
-        },
-        "recordType": {
-          "type": "string"
-        },
-        "sanitized": {
-          "type": "string"
-        },
-        "schemaVersion": {
-          "type": "string"
-        },
-        "securityResultCode": {
-          "type": "string"
-        },
-        "serialId": {
+      "metadata": {
           "properties": {
-            "bundleId": {
-              "type": "string"
-            },
-            "bundleSize": {
-              "type": "string"
-            },
-            "recordId": {
-              "type": "string"
-            },
-            "serialNumber": {
-              "type": "string"
-            },
-            "streamId": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "recordId",
-            "serialNumber",
-            "streamId",
-            "bundleSize",
-            "bundleId"
-          ],
-          "type": "object"
-        }
-      },
-      "required": [
-        "securityResultCode",
-        "recordGeneratedBy",
-        "schemaVersion",
-        "odePacketID",
-        "sanitized",
-        "recordGeneratedAt",
-        "recordType",
-        "maxDurationTime",
-        "odeTimStartDateTime",
-        "receivedMessageDetails",
-        "payloadType",
-        "serialId",
-        "logFileName",
-        "odeReceivedAt",
-        "originIp"
-      ],
-      "type": "object"
-    },
-    "payload": {
-      "properties": {
-        "data": {
-          "properties": {
-            "MessageFrame": {
-              "properties": {
-                "messageId": {
+              "@class": {
                   "type": "string"
-                },
-                "value": {
+              },
+              "logFileName": {
+                  "type": "string"
+              },
+              "maxDurationTime": {
+                  "type": "string"
+              },
+              "odePacketID": {
+                  "type": "string"
+              },
+              "odeReceivedAt": {
+                  "type": "string"
+              },
+              "odeTimStartDateTime": {
+                  "type": "string"
+              },
+              "originIp": {
+                  "type": "string"
+              },
+              "payloadType": {
+                  "type": "string"
+              },
+              "receivedMessageDetails": {
+                  "type": "string"
+              },
+              "recordGeneratedAt": {
+                  "type": "string"
+              },
+              "recordGeneratedBy": {
+                  "type": "string"
+              },
+              "recordType": {
+                  "type": "string"
+              },
+              "sanitized": {
+                  "type": "string"
+              },
+              "schemaVersion": {
+                  "type": "string"
+              },
+              "securityResultCode": {
+                  "type": "string"
+              },
+              "serialId": {
                   "properties": {
-                    "TravelerInformation": {
-                      "properties": {
-                        "dataFrames": {
-                          "properties": {
-                            "TravelerDataFrame": {
-                              "properties": {
-                                "content": {
-                                  "properties": {
-                                    "advisory": {
-                                      "anyOf": [
-                                        {
-                                          "properties": {
-                                            "SEQUENCE": {
-                                              "items": [
-                                                {
-                                                  "properties": {
-                                                    "item": {
-                                                      "properties": {
-                                                        "itis": {
-                                                          "type": "string"
-                                                        }
-                                                      },
-                                                      "required": [
-                                                        "itis"
-                                                      ],
-                                                      "type": "object"
-                                                    }
-                                                  },
-                                                  "required": [
-                                                    "item"
-                                                  ],
-                                                  "type": "object"
-                                                }
-                                              ],
-                                              "type": "array"
-                                            }
-                                          },
-                                          "required": [
-                                            "SEQUENCE"
-                                          ],
-                                          "type": "object"
-                                        },
-                                        {
-                                          "properties": {
-                                            "SEQUENCE": {
-                                              "properties": {
-                                                "item": {
-                                                  "properties": {
-                                                    "itis": {
-                                                      "type": "string"
-                                                    }
-                                                  },
-                                                  "required": [
-                                                    "itis"
-                                                  ],
-                                                  "type": "object"
-                                                }
-                                              },
-                                              "required": [
-                                                "item"
-                                              ],
-                                              "type": "object"
-                                            }
-                                          },
-                                          "required": [
-                                            "SEQUENCE"
-                                          ],
-                                          "type": "object"
-                                        }
-                                      ]
-                                    }
-                                  },
-                                  "required": [
-                                    "advisory"
-                                  ],
-                                  "type": "object"
-                                },
-                                "duratonTime": {
-                                  "type": "string"
-                                },
-                                "frameType": {
-                                  "properties": {
-                                    "advisory": {
-                                      "type": "string"
-                                    }
-                                  },
-                                  "required": [
-                                    "advisory"
-                                  ],
-                                  "type": "object"
-                                },
-                                "msgId": {
-                                  "properties": {
-                                    "roadSignID": {
-                                      "properties": {
-                                        "mutcdCode": {
-                                          "properties": {
-                                            "warning": {
-                                              "type": "string"
-                                            }
-                                          },
-                                          "required": [
-                                            "warning"
-                                          ],
-                                          "type": "object"
-                                        },
-                                        "position": {
-                                          "properties": {
-                                            "lat": {
-                                              "type": "string"
-                                            },
-                                            "long": {
-                                              "type": "string"
-                                            },
-                                            "elevation": {
-                                              "type": ["string", "null"]
-                                            }
-                                          },
-                                          "required": [
-                                            "lat",
-                                            "long"
-                                          ],
-                                          "type": "object"
-                                        },
-                                        "viewAngle": {
-                                          "type": "string"
-                                        }
-                                      },
-                                      "required": [
-                                        "viewAngle",
-                                        "mutcdCode",
-                                        "position"
-                                      ],
-                                      "type": "object"
-                                    }
-                                  },
-                                  "required": [
-                                    "roadSignID"
-                                  ],
-                                  "type": "object"
-                                },
-                                "priority": {
-                                  "type": "string"
-                                },
-                                "regions": {
-                                  "properties": {
-                                    "GeographicalPath": {
-                                      "properties": {
-                                        "anchor": {
-                                          "properties": {
-                                            "lat": {
-                                              "type": "string"
-                                            },
-                                            "long": {
-                                              "type": "string"
-                                            },
-                                            "elevation": {
-                                              "type": ["string", "null"]
-                                            }
-                                          },
-                                          "required": [
-                                            "lat",
-                                            "long"
-                                          ],
-                                          "type": ["object", "null"]
-                                        },
-                                        "closedPath": {
-                                          "properties": {
-                                            "true": {
-                                              "type": ["string", "null"]
-                                            },
-                                            "false": {
-                                              "type": ["string", "null"]
-                                            }
-                                          },
-                                          "type": ["object", "null"]
-                                        },
-                                        "description": {
-                                          "properties": {
-                                            "path": {
-                                              "properties": {
-                                                "offset": {
-                                                  "properties": {
-                                                    "xy": {
-                                                      "properties": {
-                                                        "nodes": {
-                                                          "properties": {
-                                                            "NodeXY": {
-                                                              "items": [
-                                                                {
-                                                                  "properties": {
-                                                                    "delta": {
-                                                                      "properties": {
-                                                                        "node-LatLon": {
-                                                                          "properties": {
-                                                                            "lat": {
-                                                                              "type": "string"
-                                                                            },
-                                                                            "lon": {
-                                                                              "type": "string"
-                                                                            },
-                                                                            "elevation": {
-                                                                              "type": ["string", "null"]
-                                                                            }
-                                                                          },
-                                                                          "required": [
-                                                                            "lon",
-                                                                            "lat"
-                                                                          ],
-                                                                          "type": "object"
-                                                                        }
-                                                                      },
-                                                                      "required": [
-                                                                        "node-LatLon"
-                                                                      ],
-                                                                      "type": "object"
-                                                                    }
-                                                                  },
-                                                                  "required": [
-                                                                    "delta"
-                                                                  ],
-                                                                  "type": "object"
-                                                                }
-                                                              ],
-                                                              "type": "array"
-                                                            }
-                                                          },
-                                                          "required": [
-                                                            "NodeXY"
-                                                          ],
-                                                          "type": "object"
-                                                        }
-                                                      },
-                                                      "required": [
-                                                        "nodes"
-                                                      ],
-                                                      "type": "object"
-                                                    }
-                                                  },
-                                                  "required": [
-                                                    "xy"
-                                                  ],
-                                                  "type": "object"
-                                                }
-                                              },
-                                              "required": [
-                                                "offset"
-                                              ],
-                                              "type": "object"
-                                            }
-                                          },
-                                          "required": [
-                                            "path"
-                                          ],
-                                          "type": ["object", "null"]
-                                        },
-                                        "direction": {
-                                          "type": "string"
-                                        },
-                                        "directionality": {
-                                          "properties": {
-                                            "unavailable": {
-                                              "type": "string"
-                                            },
-                                            "forward": {
-                                              "type": "string"
-                                            },
-                                            "reverse": {
-                                              "type": "string"
-                                            },
-                                            "both": {
-                                              "type": "string"
-                                            }
-                                          },
-                                          "type": ["object", "null"]
-                                        },
-                                        "laneWidth": {
-                                          "type": ["string", "null"]
-                                        }
-                                      },
-                                      "required": [
-                                        "direction"
-                                      ],
-                                      "type": "object"
-                                    }
-                                  },
-                                  "required": [
-                                    "GeographicalPath"
-                                  ],
-                                  "type": "object"
-                                },
-                                "sspLocationRights": {
-                                  "type": "string"
-                                },
-                                "sspMsgRights1": {
-                                  "type": "string"
-                                },
-                                "sspMsgRights2": {
-                                  "type": "string"
-                                },
-                                "sspTimRights": {
-                                  "type": "string"
-                                },
-                                "startTime": {
-                                  "type": "string"
-                                },
-                                "startYear": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": [
-                                "regions",
-                                "duratonTime",
-                                "sspMsgRights1",
-                                "sspMsgRights2",
-                                "sspTimRights",
-                                "startYear",
-                                "sspLocationRights",
-                                "frameType",
-                                "msgId",
-                                "startTime",
-                                "priority",
-                                "content"
-                              ],
-                              "type": "object"
-                            }
-                          },
-                          "required": [
-                            "TravelerDataFrame"
-                          ],
-                          "type": "object"
-                        },
-                        "msgCnt": {
+                      "bundleId": {
                           "type": "string"
-                        },
-                        "packetID": {
-                          "type": "string"
-                        }
                       },
-                      "required": [
-                        "packetID",
-                        "dataFrames",
-                        "msgCnt"
-                      ],
-                      "type": "object"
-                    }
+                      "bundleSize": {
+                          "type": "string"
+                      },
+                      "recordId": {
+                          "type": "string"
+                      },
+                      "serialNumber": {
+                          "type": "string"
+                      },
+                      "streamId": {
+                          "type": "string"
+                      }
                   },
                   "required": [
-                    "TravelerInformation"
+                      "recordId",
+                      "serialNumber",
+                      "streamId",
+                      "bundleSize",
+                      "bundleId"
                   ],
                   "type": "object"
-                }
-              },
-              "required": [
-                "messageId",
-                "value"
-              ],
-              "type": "object"
-            }
+              }
           },
           "required": [
-            "MessageFrame"
+              "@class",
+              "securityResultCode",
+              "recordGeneratedBy",
+              "schemaVersion",
+              "odePacketID",
+              "sanitized",
+              "recordGeneratedAt",
+              "recordType",
+              "maxDurationTime",
+              "odeTimStartDateTime",
+              "receivedMessageDetails",
+              "payloadType",
+              "serialId",
+              "logFileName",
+              "odeReceivedAt",
+              "originIp"
           ],
           "type": "object"
-        },
-        "dataType": {
-          "type": "string"
-        }
       },
-      "required": [
-        "data",
-        "dataType"
-      ],
-      "type": "object"
-    }
+      "payload": {
+          "properties": {
+              "data": {
+                  "properties": {
+                      "MessageFrame": {
+                          "properties": {
+                              "messageId": {
+                                  "type": "string"
+                              },
+                              "value": {
+                                  "properties": {
+                                      "TravelerInformation": {
+                                          "properties": {
+                                              "dataFrames": {
+                                                  "properties": {
+                                                      "TravelerDataFrame": {
+                                                          "properties": {
+                                                              "content": {
+                                                                  "properties": {
+                                                                      "advisory": {
+                                                                          "anyOf": [
+                                                                              {
+                                                                                  "properties": {
+                                                                                      "SEQUENCE": {
+                                                                                          "items": [
+                                                                                              {
+                                                                                                  "properties": {
+                                                                                                      "item": {
+                                                                                                          "properties": {
+                                                                                                              "itis": {
+                                                                                                                  "type": "string"
+                                                                                                              }
+                                                                                                          },
+                                                                                                          "required": [
+                                                                                                              "itis"
+                                                                                                          ],
+                                                                                                          "type": "object"
+                                                                                                      }
+                                                                                                  },
+                                                                                                  "required": [
+                                                                                                      "item"
+                                                                                                  ],
+                                                                                                  "type": "object"
+                                                                                              }
+                                                                                          ],
+                                                                                          "type": "array"
+                                                                                      }
+                                                                                  },
+                                                                                  "required": [
+                                                                                      "SEQUENCE"
+                                                                                  ],
+                                                                                  "type": "object"
+                                                                              },
+                                                                              {
+                                                                                  "properties": {
+                                                                                      "SEQUENCE": {
+                                                                                          "properties": {
+                                                                                              "item": {
+                                                                                                  "properties": {
+                                                                                                      "itis": {
+                                                                                                          "type": "string"
+                                                                                                      }
+                                                                                                  },
+                                                                                                  "required": [
+                                                                                                      "itis"
+                                                                                                  ],
+                                                                                                  "type": "object"
+                                                                                              }
+                                                                                          },
+                                                                                          "required": [
+                                                                                              "item"
+                                                                                          ],
+                                                                                          "type": "object"
+                                                                                      }
+                                                                                  },
+                                                                                  "required": [
+                                                                                      "SEQUENCE"
+                                                                                  ],
+                                                                                  "type": "object"
+                                                                              }
+                                                                          ]
+                                                                      }
+                                                                  },
+                                                                  "required": [
+                                                                      "advisory"
+                                                                  ],
+                                                                  "type": "object"
+                                                              },
+                                                              "duratonTime": {
+                                                                  "type": "string"
+                                                              },
+                                                              "frameType": {
+                                                                  "properties": {
+                                                                      "advisory": {
+                                                                          "type": "string"
+                                                                      }
+                                                                  },
+                                                                  "required": [
+                                                                      "advisory"
+                                                                  ],
+                                                                  "type": "object"
+                                                              },
+                                                              "msgId": {
+                                                                  "properties": {
+                                                                      "roadSignID": {
+                                                                          "properties": {
+                                                                              "mutcdCode": {
+                                                                                  "properties": {
+                                                                                      "warning": {
+                                                                                          "type": "string"
+                                                                                      }
+                                                                                  },
+                                                                                  "required": [
+                                                                                      "warning"
+                                                                                  ],
+                                                                                  "type": "object"
+                                                                              },
+                                                                              "position": {
+                                                                                  "properties": {
+                                                                                      "lat": {
+                                                                                          "type": "string"
+                                                                                      },
+                                                                                      "long": {
+                                                                                          "type": "string"
+                                                                                      },
+                                                                                      "elevation": {
+                                                                                          "type": [
+                                                                                              "string",
+                                                                                              "null"
+                                                                                          ]
+                                                                                      }
+                                                                                  },
+                                                                                  "required": [
+                                                                                      "lat",
+                                                                                      "long"
+                                                                                  ],
+                                                                                  "type": "object"
+                                                                              },
+                                                                              "viewAngle": {
+                                                                                  "type": "string"
+                                                                              }
+                                                                          },
+                                                                          "required": [
+                                                                              "viewAngle",
+                                                                              "mutcdCode",
+                                                                              "position"
+                                                                          ],
+                                                                          "type": "object"
+                                                                      }
+                                                                  },
+                                                                  "required": [
+                                                                      "roadSignID"
+                                                                  ],
+                                                                  "type": "object"
+                                                              },
+                                                              "priority": {
+                                                                  "type": "string"
+                                                              },
+                                                              "regions": {
+                                                                  "properties": {
+                                                                      "GeographicalPath": {
+                                                                          "properties": {
+                                                                              "anchor": {
+                                                                                  "properties": {
+                                                                                      "lat": {
+                                                                                          "type": "string"
+                                                                                      },
+                                                                                      "long": {
+                                                                                          "type": "string"
+                                                                                      },
+                                                                                      "elevation": {
+                                                                                          "type": [
+                                                                                              "string",
+                                                                                              "null"
+                                                                                          ]
+                                                                                      }
+                                                                                  },
+                                                                                  "required": [
+                                                                                      "lat",
+                                                                                      "long"
+                                                                                  ],
+                                                                                  "type": [
+                                                                                      "object",
+                                                                                      "null"
+                                                                                  ]
+                                                                              },
+                                                                              "closedPath": {
+                                                                                  "properties": {
+                                                                                      "true": {
+                                                                                          "type": [
+                                                                                              "string",
+                                                                                              "null"
+                                                                                          ]
+                                                                                      },
+                                                                                      "false": {
+                                                                                          "type": [
+                                                                                              "string",
+                                                                                              "null"
+                                                                                          ]
+                                                                                      }
+                                                                                  },
+                                                                                  "type": [
+                                                                                      "object",
+                                                                                      "null"
+                                                                                  ]
+                                                                              },
+                                                                              "description": {
+                                                                                  "properties": {
+                                                                                      "path": {
+                                                                                          "properties": {
+                                                                                              "offset": {
+                                                                                                  "properties": {
+                                                                                                      "xy": {
+                                                                                                          "properties": {
+                                                                                                              "nodes": {
+                                                                                                                  "properties": {
+                                                                                                                      "NodeXY": {
+                                                                                                                          "items": [
+                                                                                                                              {
+                                                                                                                                  "properties": {
+                                                                                                                                      "delta": {
+                                                                                                                                          "properties": {
+                                                                                                                                              "node-LatLon": {
+                                                                                                                                                  "properties": {
+                                                                                                                                                      "lat": {
+                                                                                                                                                          "type": "string"
+                                                                                                                                                      },
+                                                                                                                                                      "lon": {
+                                                                                                                                                          "type": "string"
+                                                                                                                                                      },
+                                                                                                                                                      "elevation": {
+                                                                                                                                                          "type": [
+                                                                                                                                                              "string",
+                                                                                                                                                              "null"
+                                                                                                                                                          ]
+                                                                                                                                                      }
+                                                                                                                                                  },
+                                                                                                                                                  "required": [
+                                                                                                                                                      "lon",
+                                                                                                                                                      "lat"
+                                                                                                                                                  ],
+                                                                                                                                                  "type": "object"
+                                                                                                                                              }
+                                                                                                                                          },
+                                                                                                                                          "required": [
+                                                                                                                                              "node-LatLon"
+                                                                                                                                          ],
+                                                                                                                                          "type": "object"
+                                                                                                                                      }
+                                                                                                                                  },
+                                                                                                                                  "required": [
+                                                                                                                                      "delta"
+                                                                                                                                  ],
+                                                                                                                                  "type": "object"
+                                                                                                                              }
+                                                                                                                          ],
+                                                                                                                          "type": "array"
+                                                                                                                      }
+                                                                                                                  },
+                                                                                                                  "required": [
+                                                                                                                      "NodeXY"
+                                                                                                                  ],
+                                                                                                                  "type": "object"
+                                                                                                              }
+                                                                                                          },
+                                                                                                          "required": [
+                                                                                                              "nodes"
+                                                                                                          ],
+                                                                                                          "type": "object"
+                                                                                                      }
+                                                                                                  },
+                                                                                                  "required": [
+                                                                                                      "xy"
+                                                                                                  ],
+                                                                                                  "type": "object"
+                                                                                              }
+                                                                                          },
+                                                                                          "required": [
+                                                                                              "offset"
+                                                                                          ],
+                                                                                          "type": "object"
+                                                                                      }
+                                                                                  },
+                                                                                  "required": [
+                                                                                      "path"
+                                                                                  ],
+                                                                                  "type": [
+                                                                                      "object",
+                                                                                      "null"
+                                                                                  ]
+                                                                              },
+                                                                              "direction": {
+                                                                                  "type": "string"
+                                                                              },
+                                                                              "directionality": {
+                                                                                  "properties": {
+                                                                                      "unavailable": {
+                                                                                          "type": "string"
+                                                                                      },
+                                                                                      "forward": {
+                                                                                          "type": "string"
+                                                                                      },
+                                                                                      "reverse": {
+                                                                                          "type": "string"
+                                                                                      },
+                                                                                      "both": {
+                                                                                          "type": "string"
+                                                                                      }
+                                                                                  },
+                                                                                  "type": [
+                                                                                      "object",
+                                                                                      "null"
+                                                                                  ]
+                                                                              },
+                                                                              "laneWidth": {
+                                                                                  "type": [
+                                                                                      "string",
+                                                                                      "null"
+                                                                                  ]
+                                                                              }
+                                                                          },
+                                                                          "required": [
+                                                                              "direction"
+                                                                          ],
+                                                                          "type": "object"
+                                                                      }
+                                                                  },
+                                                                  "required": [
+                                                                      "GeographicalPath"
+                                                                  ],
+                                                                  "type": "object"
+                                                              },
+                                                              "sspLocationRights": {
+                                                                  "type": "string"
+                                                              },
+                                                              "sspMsgRights1": {
+                                                                  "type": "string"
+                                                              },
+                                                              "sspMsgRights2": {
+                                                                  "type": "string"
+                                                              },
+                                                              "sspTimRights": {
+                                                                  "type": "string"
+                                                              },
+                                                              "startTime": {
+                                                                  "type": "string"
+                                                              },
+                                                              "startYear": {
+                                                                  "type": "string"
+                                                              }
+                                                          },
+                                                          "required": [
+                                                              "regions",
+                                                              "duratonTime",
+                                                              "sspMsgRights1",
+                                                              "sspMsgRights2",
+                                                              "sspTimRights",
+                                                              "startYear",
+                                                              "sspLocationRights",
+                                                              "frameType",
+                                                              "msgId",
+                                                              "startTime",
+                                                              "priority",
+                                                              "content"
+                                                          ],
+                                                          "type": "object"
+                                                      }
+                                                  },
+                                                  "required": [
+                                                      "TravelerDataFrame"
+                                                  ],
+                                                  "type": "object"
+                                              },
+                                              "msgCnt": {
+                                                  "type": "string"
+                                              },
+                                              "packetID": {
+                                                  "type": "string"
+                                              }
+                                          },
+                                          "required": [
+                                              "packetID",
+                                              "dataFrames",
+                                              "msgCnt"
+                                          ],
+                                          "type": "object"
+                                      }
+                                  },
+                                  "required": [
+                                      "TravelerInformation"
+                                  ],
+                                  "type": "object"
+                              }
+                          },
+                          "required": [
+                              "messageId",
+                              "value"
+                          ],
+                          "type": "object"
+                      }
+                  },
+                  "required": [
+                      "MessageFrame"
+                  ],
+                  "type": "object"
+              },
+              "dataType": {
+                  "type": "string"
+              }
+          },
+          "required": [
+              "data",
+              "dataType"
+          ],
+          "type": "object"
+      }
   },
   "required": [
-    "metadata",
-    "payload"
+      "metadata",
+      "payload"
   ],
   "type": "object"
 }

--- a/docs/schemas/schema-tim.json
+++ b/docs/schemas/schema-tim.json
@@ -1,521 +1,525 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "properties": {
-      "metadata": {
-          "properties": {
-              "@class": {
-                  "type": "string"
-              },
-              "logFileName": {
-                  "type": "string"
-              },
-              "maxDurationTime": {
-                  "type": "string"
-              },
-              "odePacketID": {
-                  "type": "string"
-              },
-              "odeReceivedAt": {
-                  "type": "string"
-              },
-              "odeTimStartDateTime": {
-                  "type": "string"
-              },
-              "originIp": {
-                  "type": "string"
-              },
-              "payloadType": {
-                  "type": "string"
-              },
-              "receivedMessageDetails": {
-                  "type": "string"
-              },
-              "recordGeneratedAt": {
-                  "type": "string"
-              },
-              "recordGeneratedBy": {
-                  "type": "string"
-              },
-              "recordType": {
-                  "type": "string"
-              },
-              "sanitized": {
-                  "type": "string"
-              },
-              "schemaVersion": {
-                  "type": "string"
-              },
-              "securityResultCode": {
-                  "type": "string"
-              },
-              "serialId": {
-                  "properties": {
-                      "bundleId": {
-                          "type": "string"
-                      },
-                      "bundleSize": {
-                          "type": "string"
-                      },
-                      "recordId": {
-                          "type": "string"
-                      },
-                      "serialNumber": {
-                          "type": "string"
-                      },
-                      "streamId": {
-                          "type": "string"
-                      }
-                  },
-                  "required": [
-                      "recordId",
-                      "serialNumber",
-                      "streamId",
-                      "bundleSize",
-                      "bundleId"
-                  ],
-                  "type": "object"
-              }
-          },
-          "required": [
-              "@class",
-              "securityResultCode",
-              "recordGeneratedBy",
-              "schemaVersion",
-              "odePacketID",
-              "sanitized",
-              "recordGeneratedAt",
-              "recordType",
-              "maxDurationTime",
-              "odeTimStartDateTime",
-              "receivedMessageDetails",
-              "payloadType",
-              "serialId",
-              "logFileName",
-              "odeReceivedAt",
-              "originIp"
-          ],
-          "type": "object"
-      },
-      "payload": {
-          "properties": {
-              "data": {
-                  "properties": {
-                      "MessageFrame": {
-                          "properties": {
-                              "messageId": {
-                                  "type": "string"
-                              },
-                              "value": {
-                                  "properties": {
-                                      "TravelerInformation": {
-                                          "properties": {
-                                              "dataFrames": {
-                                                  "properties": {
-                                                      "TravelerDataFrame": {
-                                                          "properties": {
-                                                              "content": {
-                                                                  "properties": {
-                                                                      "advisory": {
-                                                                          "anyOf": [
-                                                                              {
-                                                                                  "properties": {
-                                                                                      "SEQUENCE": {
-                                                                                          "items": [
-                                                                                              {
-                                                                                                  "properties": {
-                                                                                                      "item": {
-                                                                                                          "properties": {
-                                                                                                              "itis": {
-                                                                                                                  "type": "string"
-                                                                                                              }
-                                                                                                          },
-                                                                                                          "required": [
-                                                                                                              "itis"
-                                                                                                          ],
-                                                                                                          "type": "object"
-                                                                                                      }
-                                                                                                  },
-                                                                                                  "required": [
-                                                                                                      "item"
-                                                                                                  ],
-                                                                                                  "type": "object"
-                                                                                              }
-                                                                                          ],
-                                                                                          "type": "array"
-                                                                                      }
-                                                                                  },
-                                                                                  "required": [
-                                                                                      "SEQUENCE"
-                                                                                  ],
-                                                                                  "type": "object"
-                                                                              },
-                                                                              {
-                                                                                  "properties": {
-                                                                                      "SEQUENCE": {
-                                                                                          "properties": {
-                                                                                              "item": {
-                                                                                                  "properties": {
-                                                                                                      "itis": {
-                                                                                                          "type": "string"
-                                                                                                      }
-                                                                                                  },
-                                                                                                  "required": [
-                                                                                                      "itis"
-                                                                                                  ],
-                                                                                                  "type": "object"
-                                                                                              }
-                                                                                          },
-                                                                                          "required": [
-                                                                                              "item"
-                                                                                          ],
-                                                                                          "type": "object"
-                                                                                      }
-                                                                                  },
-                                                                                  "required": [
-                                                                                      "SEQUENCE"
-                                                                                  ],
-                                                                                  "type": "object"
-                                                                              }
-                                                                          ]
-                                                                      }
-                                                                  },
-                                                                  "required": [
-                                                                      "advisory"
-                                                                  ],
-                                                                  "type": "object"
-                                                              },
-                                                              "duratonTime": {
-                                                                  "type": "string"
-                                                              },
-                                                              "frameType": {
-                                                                  "properties": {
-                                                                      "advisory": {
-                                                                          "type": "string"
-                                                                      }
-                                                                  },
-                                                                  "required": [
-                                                                      "advisory"
-                                                                  ],
-                                                                  "type": "object"
-                                                              },
-                                                              "msgId": {
-                                                                  "properties": {
-                                                                      "roadSignID": {
-                                                                          "properties": {
-                                                                              "mutcdCode": {
-                                                                                  "properties": {
-                                                                                      "warning": {
-                                                                                          "type": "string"
-                                                                                      }
-                                                                                  },
-                                                                                  "required": [
-                                                                                      "warning"
-                                                                                  ],
-                                                                                  "type": "object"
-                                                                              },
-                                                                              "position": {
-                                                                                  "properties": {
-                                                                                      "lat": {
-                                                                                          "type": "string"
-                                                                                      },
-                                                                                      "long": {
-                                                                                          "type": "string"
-                                                                                      },
-                                                                                      "elevation": {
-                                                                                          "type": [
-                                                                                              "string",
-                                                                                              "null"
-                                                                                          ]
-                                                                                      }
-                                                                                  },
-                                                                                  "required": [
-                                                                                      "lat",
-                                                                                      "long"
-                                                                                  ],
-                                                                                  "type": "object"
-                                                                              },
-                                                                              "viewAngle": {
-                                                                                  "type": "string"
-                                                                              }
-                                                                          },
-                                                                          "required": [
-                                                                              "viewAngle",
-                                                                              "mutcdCode",
-                                                                              "position"
-                                                                          ],
-                                                                          "type": "object"
-                                                                      }
-                                                                  },
-                                                                  "required": [
-                                                                      "roadSignID"
-                                                                  ],
-                                                                  "type": "object"
-                                                              },
-                                                              "priority": {
-                                                                  "type": "string"
-                                                              },
-                                                              "regions": {
-                                                                  "properties": {
-                                                                      "GeographicalPath": {
-                                                                          "properties": {
-                                                                              "anchor": {
-                                                                                  "properties": {
-                                                                                      "lat": {
-                                                                                          "type": "string"
-                                                                                      },
-                                                                                      "long": {
-                                                                                          "type": "string"
-                                                                                      },
-                                                                                      "elevation": {
-                                                                                          "type": [
-                                                                                              "string",
-                                                                                              "null"
-                                                                                          ]
-                                                                                      }
-                                                                                  },
-                                                                                  "required": [
-                                                                                      "lat",
-                                                                                      "long"
-                                                                                  ],
-                                                                                  "type": [
-                                                                                      "object",
-                                                                                      "null"
-                                                                                  ]
-                                                                              },
-                                                                              "closedPath": {
-                                                                                  "properties": {
-                                                                                      "true": {
-                                                                                          "type": [
-                                                                                              "string",
-                                                                                              "null"
-                                                                                          ]
-                                                                                      },
-                                                                                      "false": {
-                                                                                          "type": [
-                                                                                              "string",
-                                                                                              "null"
-                                                                                          ]
-                                                                                      }
-                                                                                  },
-                                                                                  "type": [
-                                                                                      "object",
-                                                                                      "null"
-                                                                                  ]
-                                                                              },
-                                                                              "description": {
-                                                                                  "properties": {
-                                                                                      "path": {
-                                                                                          "properties": {
-                                                                                              "offset": {
-                                                                                                  "properties": {
-                                                                                                      "xy": {
-                                                                                                          "properties": {
-                                                                                                              "nodes": {
-                                                                                                                  "properties": {
-                                                                                                                      "NodeXY": {
-                                                                                                                          "items": [
-                                                                                                                              {
-                                                                                                                                  "properties": {
-                                                                                                                                      "delta": {
-                                                                                                                                          "properties": {
-                                                                                                                                              "node-LatLon": {
-                                                                                                                                                  "properties": {
-                                                                                                                                                      "lat": {
-                                                                                                                                                          "type": "string"
-                                                                                                                                                      },
-                                                                                                                                                      "lon": {
-                                                                                                                                                          "type": "string"
-                                                                                                                                                      },
-                                                                                                                                                      "elevation": {
-                                                                                                                                                          "type": [
-                                                                                                                                                              "string",
-                                                                                                                                                              "null"
-                                                                                                                                                          ]
-                                                                                                                                                      }
-                                                                                                                                                  },
-                                                                                                                                                  "required": [
-                                                                                                                                                      "lon",
-                                                                                                                                                      "lat"
-                                                                                                                                                  ],
-                                                                                                                                                  "type": "object"
-                                                                                                                                              }
-                                                                                                                                          },
-                                                                                                                                          "required": [
-                                                                                                                                              "node-LatLon"
-                                                                                                                                          ],
-                                                                                                                                          "type": "object"
-                                                                                                                                      }
-                                                                                                                                  },
-                                                                                                                                  "required": [
-                                                                                                                                      "delta"
-                                                                                                                                  ],
-                                                                                                                                  "type": "object"
-                                                                                                                              }
-                                                                                                                          ],
-                                                                                                                          "type": "array"
-                                                                                                                      }
-                                                                                                                  },
-                                                                                                                  "required": [
-                                                                                                                      "NodeXY"
-                                                                                                                  ],
-                                                                                                                  "type": "object"
-                                                                                                              }
-                                                                                                          },
-                                                                                                          "required": [
-                                                                                                              "nodes"
-                                                                                                          ],
-                                                                                                          "type": "object"
-                                                                                                      }
-                                                                                                  },
-                                                                                                  "required": [
-                                                                                                      "xy"
-                                                                                                  ],
-                                                                                                  "type": "object"
-                                                                                              }
-                                                                                          },
-                                                                                          "required": [
-                                                                                              "offset"
-                                                                                          ],
-                                                                                          "type": "object"
-                                                                                      }
-                                                                                  },
-                                                                                  "required": [
-                                                                                      "path"
-                                                                                  ],
-                                                                                  "type": [
-                                                                                      "object",
-                                                                                      "null"
-                                                                                  ]
-                                                                              },
-                                                                              "direction": {
-                                                                                  "type": "string"
-                                                                              },
-                                                                              "directionality": {
-                                                                                  "properties": {
-                                                                                      "unavailable": {
-                                                                                          "type": "string"
-                                                                                      },
-                                                                                      "forward": {
-                                                                                          "type": "string"
-                                                                                      },
-                                                                                      "reverse": {
-                                                                                          "type": "string"
-                                                                                      },
-                                                                                      "both": {
-                                                                                          "type": "string"
-                                                                                      }
-                                                                                  },
-                                                                                  "type": [
-                                                                                      "object",
-                                                                                      "null"
-                                                                                  ]
-                                                                              },
-                                                                              "laneWidth": {
-                                                                                  "type": [
-                                                                                      "string",
-                                                                                      "null"
-                                                                                  ]
-                                                                              }
-                                                                          },
-                                                                          "required": [
-                                                                              "direction"
-                                                                          ],
-                                                                          "type": "object"
-                                                                      }
-                                                                  },
-                                                                  "required": [
-                                                                      "GeographicalPath"
-                                                                  ],
-                                                                  "type": "object"
-                                                              },
-                                                              "sspLocationRights": {
-                                                                  "type": "string"
-                                                              },
-                                                              "sspMsgRights1": {
-                                                                  "type": "string"
-                                                              },
-                                                              "sspMsgRights2": {
-                                                                  "type": "string"
-                                                              },
-                                                              "sspTimRights": {
-                                                                  "type": "string"
-                                                              },
-                                                              "startTime": {
-                                                                  "type": "string"
-                                                              },
-                                                              "startYear": {
-                                                                  "type": "string"
-                                                              }
-                                                          },
-                                                          "required": [
-                                                              "regions",
-                                                              "duratonTime",
-                                                              "sspMsgRights1",
-                                                              "sspMsgRights2",
-                                                              "sspTimRights",
-                                                              "startYear",
-                                                              "sspLocationRights",
-                                                              "frameType",
-                                                              "msgId",
-                                                              "startTime",
-                                                              "priority",
-                                                              "content"
-                                                          ],
-                                                          "type": "object"
-                                                      }
-                                                  },
-                                                  "required": [
-                                                      "TravelerDataFrame"
-                                                  ],
-                                                  "type": "object"
-                                              },
-                                              "msgCnt": {
-                                                  "type": "string"
-                                              },
-                                              "packetID": {
-                                                  "type": "string"
-                                              }
-                                          },
-                                          "required": [
-                                              "packetID",
-                                              "dataFrames",
-                                              "msgCnt"
-                                          ],
-                                          "type": "object"
-                                      }
-                                  },
-                                  "required": [
-                                      "TravelerInformation"
-                                  ],
-                                  "type": "object"
-                              }
-                          },
-                          "required": [
-                              "messageId",
-                              "value"
-                          ],
-                          "type": "object"
-                      }
-                  },
-                  "required": [
-                      "MessageFrame"
-                  ],
-                  "type": "object"
-              },
-              "dataType": {
-                  "type": "string"
-              }
-          },
-          "required": [
-              "data",
-              "dataType"
-          ],
-          "type": "object"
-      }
-  },
-  "required": [
-      "metadata",
-      "payload"
-  ],
-  "type": "object"
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "metadata": {
+            "properties": {
+                "@class": {
+                    "type": "string"
+                },
+                "logFileName": {
+                    "type": "string"
+                },
+                "maxDurationTime": {
+                    "type": "string"
+                },
+                "odePacketID": {
+                    "type": "string"
+                },
+                "odeReceivedAt": {
+                    "type": "string"
+                },
+                "odeTimStartDateTime": {
+                    "type": "string"
+                },
+                "originIp": {
+                    "type": "string"
+                },
+                "payloadType": {
+                    "type": "string"
+                },
+                "receivedMessageDetails": {
+                    "type": "string"
+                },
+                "recordGeneratedAt": {
+                    "type": "string"
+                },
+                "recordGeneratedBy": {
+                    "type": "string"
+                },
+                "recordType": {
+                    "type": "string"
+                },
+                "sanitized": {
+                    "type": "string"
+                },
+                "schemaVersion": {
+                    "type": "string"
+                },
+                "securityResultCode": {
+                    "type": "string"
+                },
+                "serialId": {
+                    "properties": {
+                        "bundleId": {
+                            "type": "string"
+                        },
+                        "bundleSize": {
+                            "type": "string"
+                        },
+                        "recordId": {
+                            "type": "string"
+                        },
+                        "serialNumber": {
+                            "type": "string"
+                        },
+                        "streamId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "recordId",
+                        "serialNumber",
+                        "streamId",
+                        "bundleSize",
+                        "bundleId"
+                    ],
+                    "type": "object"
+                }
+            },
+            "required": [
+                "@class",
+                "securityResultCode",
+                "recordGeneratedBy",
+                "schemaVersion",
+                "odePacketID",
+                "sanitized",
+                "recordGeneratedAt",
+                "recordType",
+                "maxDurationTime",
+                "odeTimStartDateTime",
+                "receivedMessageDetails",
+                "payloadType",
+                "serialId",
+                "logFileName",
+                "odeReceivedAt",
+                "originIp"
+            ],
+            "type": "object"
+        },
+        "payload": {
+            "properties": {
+                "@class": {
+                    "type": "string"
+                },
+                "data": {
+                    "properties": {
+                        "MessageFrame": {
+                            "properties": {
+                                "messageId": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "properties": {
+                                        "TravelerInformation": {
+                                            "properties": {
+                                                "dataFrames": {
+                                                    "properties": {
+                                                        "TravelerDataFrame": {
+                                                            "properties": {
+                                                                "content": {
+                                                                    "properties": {
+                                                                        "advisory": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "properties": {
+                                                                                        "SEQUENCE": {
+                                                                                            "items": [
+                                                                                                {
+                                                                                                    "properties": {
+                                                                                                        "item": {
+                                                                                                            "properties": {
+                                                                                                                "itis": {
+                                                                                                                    "type": "string"
+                                                                                                                }
+                                                                                                            },
+                                                                                                            "required": [
+                                                                                                                "itis"
+                                                                                                            ],
+                                                                                                            "type": "object"
+                                                                                                        }
+                                                                                                    },
+                                                                                                    "required": [
+                                                                                                        "item"
+                                                                                                    ],
+                                                                                                    "type": "object"
+                                                                                                }
+                                                                                            ],
+                                                                                            "type": "array"
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "SEQUENCE"
+                                                                                    ],
+                                                                                    "type": "object"
+                                                                                },
+                                                                                {
+                                                                                    "properties": {
+                                                                                        "SEQUENCE": {
+                                                                                            "properties": {
+                                                                                                "item": {
+                                                                                                    "properties": {
+                                                                                                        "itis": {
+                                                                                                            "type": "string"
+                                                                                                        }
+                                                                                                    },
+                                                                                                    "required": [
+                                                                                                        "itis"
+                                                                                                    ],
+                                                                                                    "type": "object"
+                                                                                                }
+                                                                                            },
+                                                                                            "required": [
+                                                                                                "item"
+                                                                                            ],
+                                                                                            "type": "object"
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "SEQUENCE"
+                                                                                    ],
+                                                                                    "type": "object"
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "advisory"
+                                                                    ],
+                                                                    "type": "object"
+                                                                },
+                                                                "duratonTime": {
+                                                                    "type": "string"
+                                                                },
+                                                                "frameType": {
+                                                                    "properties": {
+                                                                        "advisory": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "advisory"
+                                                                    ],
+                                                                    "type": "object"
+                                                                },
+                                                                "msgId": {
+                                                                    "properties": {
+                                                                        "roadSignID": {
+                                                                            "properties": {
+                                                                                "mutcdCode": {
+                                                                                    "properties": {
+                                                                                        "warning": {
+                                                                                            "type": "string"
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "warning"
+                                                                                    ],
+                                                                                    "type": "object"
+                                                                                },
+                                                                                "position": {
+                                                                                    "properties": {
+                                                                                        "lat": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "long": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "elevation": {
+                                                                                            "type": [
+                                                                                                "string",
+                                                                                                "null"
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "lat",
+                                                                                        "long"
+                                                                                    ],
+                                                                                    "type": "object"
+                                                                                },
+                                                                                "viewAngle": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "viewAngle",
+                                                                                "mutcdCode",
+                                                                                "position"
+                                                                            ],
+                                                                            "type": "object"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "roadSignID"
+                                                                    ],
+                                                                    "type": "object"
+                                                                },
+                                                                "priority": {
+                                                                    "type": "string"
+                                                                },
+                                                                "regions": {
+                                                                    "properties": {
+                                                                        "GeographicalPath": {
+                                                                            "properties": {
+                                                                                "anchor": {
+                                                                                    "properties": {
+                                                                                        "lat": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "long": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "elevation": {
+                                                                                            "type": [
+                                                                                                "string",
+                                                                                                "null"
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "lat",
+                                                                                        "long"
+                                                                                    ],
+                                                                                    "type": [
+                                                                                        "object",
+                                                                                        "null"
+                                                                                    ]
+                                                                                },
+                                                                                "closedPath": {
+                                                                                    "properties": {
+                                                                                        "true": {
+                                                                                            "type": [
+                                                                                                "string",
+                                                                                                "null"
+                                                                                            ]
+                                                                                        },
+                                                                                        "false": {
+                                                                                            "type": [
+                                                                                                "string",
+                                                                                                "null"
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "type": [
+                                                                                        "object",
+                                                                                        "null"
+                                                                                    ]
+                                                                                },
+                                                                                "description": {
+                                                                                    "properties": {
+                                                                                        "path": {
+                                                                                            "properties": {
+                                                                                                "offset": {
+                                                                                                    "properties": {
+                                                                                                        "xy": {
+                                                                                                            "properties": {
+                                                                                                                "nodes": {
+                                                                                                                    "properties": {
+                                                                                                                        "NodeXY": {
+                                                                                                                            "items": [
+                                                                                                                                {
+                                                                                                                                    "properties": {
+                                                                                                                                        "delta": {
+                                                                                                                                            "properties": {
+                                                                                                                                                "node-LatLon": {
+                                                                                                                                                    "properties": {
+                                                                                                                                                        "lat": {
+                                                                                                                                                            "type": "string"
+                                                                                                                                                        },
+                                                                                                                                                        "lon": {
+                                                                                                                                                            "type": "string"
+                                                                                                                                                        },
+                                                                                                                                                        "elevation": {
+                                                                                                                                                            "type": [
+                                                                                                                                                                "string",
+                                                                                                                                                                "null"
+                                                                                                                                                            ]
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    "required": [
+                                                                                                                                                        "lon",
+                                                                                                                                                        "lat"
+                                                                                                                                                    ],
+                                                                                                                                                    "type": "object"
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            "required": [
+                                                                                                                                                "node-LatLon"
+                                                                                                                                            ],
+                                                                                                                                            "type": "object"
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    "required": [
+                                                                                                                                        "delta"
+                                                                                                                                    ],
+                                                                                                                                    "type": "object"
+                                                                                                                                }
+                                                                                                                            ],
+                                                                                                                            "type": "array"
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    "required": [
+                                                                                                                        "NodeXY"
+                                                                                                                    ],
+                                                                                                                    "type": "object"
+                                                                                                                }
+                                                                                                            },
+                                                                                                            "required": [
+                                                                                                                "nodes"
+                                                                                                            ],
+                                                                                                            "type": "object"
+                                                                                                        }
+                                                                                                    },
+                                                                                                    "required": [
+                                                                                                        "xy"
+                                                                                                    ],
+                                                                                                    "type": "object"
+                                                                                                }
+                                                                                            },
+                                                                                            "required": [
+                                                                                                "offset"
+                                                                                            ],
+                                                                                            "type": "object"
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "path"
+                                                                                    ],
+                                                                                    "type": [
+                                                                                        "object",
+                                                                                        "null"
+                                                                                    ]
+                                                                                },
+                                                                                "direction": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "directionality": {
+                                                                                    "properties": {
+                                                                                        "unavailable": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "forward": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "reverse": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "both": {
+                                                                                            "type": "string"
+                                                                                        }
+                                                                                    },
+                                                                                    "type": [
+                                                                                        "object",
+                                                                                        "null"
+                                                                                    ]
+                                                                                },
+                                                                                "laneWidth": {
+                                                                                    "type": [
+                                                                                        "string",
+                                                                                        "null"
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "direction"
+                                                                            ],
+                                                                            "type": "object"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "GeographicalPath"
+                                                                    ],
+                                                                    "type": "object"
+                                                                },
+                                                                "sspLocationRights": {
+                                                                    "type": "string"
+                                                                },
+                                                                "sspMsgRights1": {
+                                                                    "type": "string"
+                                                                },
+                                                                "sspMsgRights2": {
+                                                                    "type": "string"
+                                                                },
+                                                                "sspTimRights": {
+                                                                    "type": "string"
+                                                                },
+                                                                "startTime": {
+                                                                    "type": "string"
+                                                                },
+                                                                "startYear": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "regions",
+                                                                "duratonTime",
+                                                                "sspMsgRights1",
+                                                                "sspMsgRights2",
+                                                                "sspTimRights",
+                                                                "startYear",
+                                                                "sspLocationRights",
+                                                                "frameType",
+                                                                "msgId",
+                                                                "startTime",
+                                                                "priority",
+                                                                "content"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "TravelerDataFrame"
+                                                    ],
+                                                    "type": "object"
+                                                },
+                                                "msgCnt": {
+                                                    "type": "string"
+                                                },
+                                                "packetID": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "packetID",
+                                                "dataFrames",
+                                                "msgCnt"
+                                            ],
+                                            "type": "object"
+                                        }
+                                    },
+                                    "required": [
+                                        "TravelerInformation"
+                                    ],
+                                    "type": "object"
+                                }
+                            },
+                            "required": [
+                                "messageId",
+                                "value"
+                            ],
+                            "type": "object"
+                        }
+                    },
+                    "required": [
+                        "MessageFrame"
+                    ],
+                    "type": "object"
+                },
+                "dataType": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "@class",
+                "data",
+                "dataType"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "metadata",
+        "payload"
+    ],
+    "type": "object"
 }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Updated the 6 message types ODE output schemas to be accurate to the current version of the ODE. This includes all pull requests that have been merged into the usdot-jpo-ode/jpo-ode dev branch as of 12/18/2022.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#474 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
It is important to have up to date schemas for anyone wanting to integrate schema checking or support the ODE message types without having test data to go off of.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually testing with CDOT live data and a schema validator. (https://www.jsonschemavalidator.net/)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
