### PR TITLE
Remove '@class' property from serialized JSON

### DIFF
--- a/docs/schemas/README.md
+++ b/docs/schemas/README.md
@@ -2,11 +2,11 @@
 
 The jpo-ode supports receiving and decoding ASN1 messages from RSUs. The supported message types are currently BSM, MAP, SPaT, SRM and SSM. These are decoded into XML, deserialized into POJOs and finally serialized into JSON. This JSON output can be access from any of the corresponding message's JSON output Kafka topics:
 
-- [topic.OdeBsmJson](schema-bsm.json)
-- [topic.OdeMapJson](schema-map.json)
-- [topic.OdeSpatJson](schema-spat.json)
-- [topic.OdeSrmJson](schema-srm.json)
-- [topic.OdeSsmJson](schema-ssm.json)
+- [topic.OdeBsmJson](../../jpo-ode-core/src/main/resources/schemas/schema-bsm.json)
+- [topic.OdeMapJson](../../jpo-ode-core/src/main/resources/schemas/schema-map.json)
+- [topic.OdeSpatJson](../../jpo-ode-core/src/main/resources/schemas/schema-spat.json)
+- [topic.OdeSrmJson](../../jpo-ode-core/src/main/resources/schemas/schema-srm.json)
+- [topic.OdeSsmJson](../../jpo-ode-core/src/main/resources/schemas/schema-ssm.json)
 
 The output JSON of the ODE is complex but it is similar to the official standard of J2735 with some minor differences due to the form of their deserialized POJOs. To help implement proper data validation for the JSON output of the ODE into any data pipeline infrastructure, you may use the provided validation schemas within this directory.
 

--- a/jpo-ode-core/pom.xml
+++ b/jpo-ode-core/pom.xml
@@ -90,6 +90,12 @@
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.networknt</groupId>
+      <artifactId>json-schema-validator</artifactId>
+      <version>1.0.76</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeBsmData.java
+++ b/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeBsmData.java
@@ -31,13 +31,13 @@ public class OdeBsmData extends OdeData {
    }
 
    @Override
-   @JsonTypeInfo(use = Id.CLASS, defaultImpl = OdeBsmMetadata.class)
+   @JsonTypeInfo(use = Id.CLASS, include = As.EXISTING_PROPERTY, defaultImpl = OdeBsmMetadata.class)
    public void setMetadata(OdeMsgMetadata metadata) {
       super.setMetadata(metadata);
    }
 
    @Override
-   @JsonTypeInfo(use = Id.CLASS, defaultImpl = OdeBsmPayload.class)
+   @JsonTypeInfo(use = Id.CLASS, include = As.EXISTING_PROPERTY, defaultImpl = OdeBsmPayload.class)
    public void setPayload(OdeMsgPayload payload) {
       super.setPayload(payload);
    }

--- a/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeMapData.java
+++ b/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeMapData.java
@@ -16,13 +16,13 @@ public class OdeMapData extends OdeData {
 	}
 
 	@Override
-	@JsonTypeInfo(use = Id.CLASS, defaultImpl = OdeMapMetadata.class)
+	@JsonTypeInfo(use = Id.CLASS, include = As.EXISTING_PROPERTY, defaultImpl = OdeMapMetadata.class)
 	public void setMetadata(OdeMsgMetadata metadata) {
 		super.setMetadata(metadata);
 	}
 
 	@Override
-	@JsonTypeInfo(use = Id.CLASS, defaultImpl = OdeMapPayload.class)
+	@JsonTypeInfo(use = Id.CLASS, include = As.EXISTING_PROPERTY, defaultImpl = OdeMapPayload.class)
 	public void setPayload(OdeMsgPayload payload) {
 		super.setPayload(payload);
 	}

--- a/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeSpatData.java
+++ b/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeSpatData.java
@@ -31,13 +31,13 @@ public class OdeSpatData extends OdeData {
    }
 
    @Override
-   @JsonTypeInfo(use = Id.CLASS, defaultImpl = OdeSpatMetadata.class)
+   @JsonTypeInfo(use = Id.CLASS, include = As.EXISTING_PROPERTY, defaultImpl = OdeSpatMetadata.class)
    public void setMetadata(OdeMsgMetadata metadata) {
       super.setMetadata(metadata);
    }
 
    @Override
-   @JsonTypeInfo(use = Id.CLASS, defaultImpl = OdeSpatPayload.class)
+   @JsonTypeInfo(use = Id.CLASS, include = As.EXISTING_PROPERTY, defaultImpl = OdeSpatPayload.class)
    public void setPayload(OdeMsgPayload payload) {
       super.setPayload(payload);
    }

--- a/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeSrmData.java
+++ b/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeSrmData.java
@@ -16,13 +16,13 @@ public class OdeSrmData extends OdeData {
     }
 
     @Override
-    @JsonTypeInfo(use = Id.CLASS, defaultImpl = OdeSrmMetadata.class)
+    @JsonTypeInfo(use = Id.CLASS, include = As.EXISTING_PROPERTY, defaultImpl = OdeSrmMetadata.class)
     public void setMetadata(OdeMsgMetadata metadata) {
         super.setMetadata(metadata);
     }
 
     @Override
-    @JsonTypeInfo(use = Id.CLASS, defaultImpl = OdeSrmPayload.class)
+    @JsonTypeInfo(use = Id.CLASS, include = As.EXISTING_PROPERTY, defaultImpl = OdeSrmPayload.class)
     public void setPayload(OdeMsgPayload payload) {
         super.setPayload(payload);
     }

--- a/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeSsmData.java
+++ b/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeSsmData.java
@@ -16,13 +16,13 @@ public class OdeSsmData extends OdeData {
     }
 
     @Override
-    @JsonTypeInfo(use = Id.CLASS, defaultImpl = OdeSsmMetadata.class)
+    @JsonTypeInfo(use = Id.CLASS, include = As.EXISTING_PROPERTY, defaultImpl = OdeSsmMetadata.class)
     public void setMetadata(OdeMsgMetadata metadata) {
         super.setMetadata(metadata);
     }
 
     @Override
-    @JsonTypeInfo(use = Id.CLASS, defaultImpl = OdeSsmPayload.class)
+    @JsonTypeInfo(use = Id.CLASS, include = As.EXISTING_PROPERTY, defaultImpl = OdeSsmPayload.class)
     public void setPayload(OdeMsgPayload payload) {
         super.setPayload(payload);
     }

--- a/jpo-ode-core/src/main/resources/schemas/schema-bsm.json
+++ b/jpo-ode-core/src/main/resources/schemas/schema-bsm.json
@@ -3,9 +3,6 @@
     "properties": {
         "metadata": {
             "properties": {
-                "@class": {
-                    "type": "string"
-                },
                 "bsmSource": {
                     "enum": [
                         "EV",
@@ -231,7 +228,6 @@
                 }
             },
             "required": [
-                "@class",
                 "bsmSource",
                 "logFileName",
                 "recordType",
@@ -248,9 +244,6 @@
         },
         "payload": {
             "properties": {
-                "@class": {
-                    "type": "string"
-                },
                 "data": {
                     "properties": {
                         "coreData": {
@@ -2196,7 +2189,6 @@
                 }
             },
             "required": [
-                "@class",
                 "dataType",
                 "data"
             ],

--- a/jpo-ode-core/src/main/resources/schemas/schema-map.json
+++ b/jpo-ode-core/src/main/resources/schemas/schema-map.json
@@ -3,9 +3,6 @@
     "properties": {
         "metadata": {
             "properties": {
-                "@class": {
-                    "type": "string"
-                },
                 "encodings": {
                     "type": "null"
                 },
@@ -100,7 +97,6 @@
                 }
             },
             "required": [
-                "@class",
                 "mapSource",
                 "originIp",
                 "logFileName",
@@ -121,9 +117,6 @@
         },
         "payload": {
             "properties": {
-                "@class": {
-                    "type": "string"
-                },
                 "data": {
                     "properties": {
                         "dataParameters": {
@@ -2101,7 +2094,6 @@
                 }
             },
             "required": [
-                "@class",
                 "dataType",
                 "data"
             ],

--- a/jpo-ode-core/src/main/resources/schemas/schema-spat.json
+++ b/jpo-ode-core/src/main/resources/schemas/schema-spat.json
@@ -9,7 +9,6 @@
         "metadata": {
             "type": "object",
             "required": [
-                "@class",
                 "spatSource",
                 "logFileName",
                 "recordType",
@@ -23,9 +22,6 @@
                 "sanitized"
             ],
             "properties": {
-                "@class": {
-                    "type": "string"
-                },
                 "spatSource": {
                     "type": "string",
                     "enum": [
@@ -266,14 +262,10 @@
         "payload": {
             "type": "object",
             "required": [
-                "@class",
                 "dataType",
                 "data"
             ],
             "properties": {
-                "@class": {
-                    "type": "string"
-                },
                 "dataType": {
                     "type": "string"
                 },

--- a/jpo-ode-core/src/main/resources/schemas/schema-srm.json
+++ b/jpo-ode-core/src/main/resources/schemas/schema-srm.json
@@ -5,9 +5,6 @@
         "metadata": {
             "type": "object",
             "properties": {
-                "@class": {
-                    "type": "string"
-                },
                 "originIp": {
                     "type": "string"
                 },
@@ -96,7 +93,6 @@
                 }
             },
             "required": [
-                "@class",
                 "originIp",
                 "srmSource",
                 "logFileName",
@@ -116,9 +112,6 @@
         "payload": {
             "type": "object",
             "properties": {
-                "@class": {
-                    "type": "string"
-                },
                 "dataType": {
                     "type": "string"
                 },
@@ -442,7 +435,6 @@
                 }
             },
             "required": [
-                "@class",
                 "dataType",
                 "data"
             ]

--- a/jpo-ode-core/src/main/resources/schemas/schema-ssm.json
+++ b/jpo-ode-core/src/main/resources/schemas/schema-ssm.json
@@ -5,9 +5,6 @@
         "metadata": {
             "type": "object",
             "properties": {
-                "@class": {
-                    "type": "string"
-                },
                 "originIp": {
                     "type": "string"
                 },
@@ -105,7 +102,6 @@
                 }
             },
             "required": [
-                "@class",
                 "originIp",
                 "ssmSource",
                 "logFileName",
@@ -125,9 +121,6 @@
         "payload": {
             "type": "object",
             "properties": {
-                "@class": {
-                    "type": "string"
-                },
                 "dataType": {
                     "type": "string"
                 },
@@ -372,7 +365,6 @@
                 }
             },
             "required": [
-                "@class",
                 "dataType",
                 "data"
             ]

--- a/jpo-ode-core/src/main/resources/schemas/schema-tim.json
+++ b/jpo-ode-core/src/main/resources/schemas/schema-tim.json
@@ -3,9 +3,6 @@
     "properties": {
         "metadata": {
             "properties": {
-                "@class": {
-                    "type": "string"
-                },
                 "logFileName": {
                     "type": "string"
                 },
@@ -77,7 +74,6 @@
                 }
             },
             "required": [
-                "@class",
                 "securityResultCode",
                 "recordGeneratedBy",
                 "schemaVersion",
@@ -98,9 +94,6 @@
         },
         "payload": {
             "properties": {
-                "@class": {
-                    "type": "string"
-                },
                 "data": {
                     "properties": {
                         "MessageFrame": {
@@ -510,7 +503,6 @@
                 }
             },
             "required": [
-                "@class",
                 "data",
                 "dataType"
             ],

--- a/jpo-ode-core/src/test/java/us/dot/its/jpo/ode/model/OdeBsmDataTest.java
+++ b/jpo-ode-core/src/test/java/us/dot/its/jpo/ode/model/OdeBsmDataTest.java
@@ -1,7 +1,17 @@
 package us.dot.its.jpo.ode.model;
 
 import org.junit.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+import java.util.Set;
+
 import static org.junit.Assert.*;
+
+
 
 import us.dot.its.jpo.ode.plugin.j2735.J2735Bsm;
 import us.dot.its.jpo.ode.plugin.j2735.J2735SupplementalVehicleExtensions;
@@ -9,13 +19,14 @@ import us.dot.its.jpo.ode.plugin.j2735.J2735VehicleSafetyExtensions;
 import us.dot.its.jpo.ode.util.JsonUtils;
 
 public class OdeBsmDataTest {
+
+    final String bsmTxJson = "{\"metadata\":{\"bsmSource\":\"RV\",\"logFileName\":\"\",\"recordType\":\"bsmTx\",\"securityResultCode\":\"success\",\"receivedMessageDetails\":{\"locationData\":{\"latitude\":\"\",\"longitude\":\"\",\"elevation\":\"\",\"speed\":\"\",\"heading\":\"\"},\"rxSource\":\"RV\"},\"payloadType\":\"us.dot.its.jpo.ode.model.OdeBsmPayload\",\"serialId\":{\"streamId\":\"504becf3-8e20-49cb-a2d7-25b646c34d0f\",\"bundleSize\":1,\"bundleId\":0,\"recordId\":0,\"serialNumber\":0},\"odeReceivedAt\":\"2022-06-17T19:14:21.223956Z\",\"schemaVersion\":6,\"maxDurationTime\":0,\"recordGeneratedAt\":\"\",\"sanitized\":false,\"odePacketID\":\"\",\"odeTimStartDateTime\":\"\",\"originIp\":\"10.11.81.12\"},\"payload\":{\"data\":{\"coreData\":{\"msgCnt\":46,\"id\":\"E6A99808\",\"secMark\":21061,\"position\":{\"latitude\":39.5881304,\"longitude\":-105.0910403,\"elevation\":1692.0},\"accelSet\":{\"accelLong\":-0.07,\"accelYaw\":-0.09},\"accuracy\":{\"semiMajor\":2.0,\"semiMinor\":2.0,\"orientation\":44.49530799},\"transmission\":\"UNAVAILABLE\",\"speed\":22.62,\"heading\":169.3,\"brakes\":{\"wheelBrakes\":{\"leftFront\":false,\"rightFront\":false,\"unavailable\":true,\"leftRear\":false,\"rightRear\":false},\"traction\":\"unavailable\",\"abs\":\"off\",\"scs\":\"unavailable\",\"brakeBoost\":\"unavailable\",\"auxBrakes\":\"unavailable\"},\"size\":{\"width\":180,\"length\":480}},\"partII\":[{\"id\":\"VehicleSafetyExtensions\",\"value\":{\"pathHistory\":{\"crumbData\":[{\"elevationOffset\":0.8,\"latOffset\":-0.0001802,\"lonOffset\":0.0000434,\"timeOffset\":0.89},{\"elevationOffset\":4.5,\"latOffset\":-0.0011801,\"lonOffset\":0.0002357,\"timeOffset\":5.7},{\"elevationOffset\":9.3,\"latOffset\":-0.0023623,\"lonOffset\":0.0003881,\"timeOffset\":11.1}]},\"pathPrediction\":{\"confidence\":70.0,\"radiusOfCurve\":0.0}}}]},\"dataType\":\"us.dot.its.jpo.ode.plugin.j2735.J2735Bsm\"}}";
+    final String bsmLogJson = "{\"metadata\":{\"bsmSource\":\"RV\",\"logFileName\":\"bsmLogDuringEvent.gz\",\"recordType\":\"bsmLogDuringEvent\",\"securityResultCode\":\"success\",\"receivedMessageDetails\":{\"locationData\":{\"latitude\":\"40.565771\",\"longitude\":\"-105.0318108\",\"elevation\":\"1487\",\"speed\":\"0.14\",\"heading\":\"205.975\"},\"rxSource\":\"NA\"},\"payloadType\":\"us.dot.its.jpo.ode.model.OdeBsmPayload\",\"serialId\":{\"streamId\":\"801780cb-d91d-444b-8f4d-9c44fe27f5ea\",\"bundleSize\":222,\"bundleId\":71,\"recordId\":221,\"serialNumber\":14725},\"odeReceivedAt\":\"2019-04-09T18:07:12.352Z\",\"schemaVersion\":6,\"recordGeneratedAt\":\"2018-05-01T16:04:23.694Z\",\"recordGeneratedBy\":\"OBU\",\"sanitized\":false},\"payload\":{\"dataType\":\"us.dot.its.jpo.ode.plugin.j2735.J2735Bsm\",\"data\":{\"coreData\":{\"msgCnt\":95,\"id\":\"31325431\",\"secMark\":23794,\"position\":{\"latitude\":40.5657318,\"longitude\":-105.0318485,\"elevation\":1472.8},\"accelSet\":{\"accelLat\":0.00,\"accelLong\":0.52,\"accelVert\":0.00,\"accelYaw\":0.00},\"accuracy\":{\"semiMajor\":12.70,\"semiMinor\":12.40},\"transmission\":\"NEUTRAL\",\"speed\":0.10,\"heading\":250.9125,\"brakes\":{\"wheelBrakes\":{\"leftFront\":false,\"rightFront\":false,\"unavailable\":true,\"leftRear\":false,\"rightRear\":false},\"traction\":\"unavailable\",\"abs\":\"unavailable\",\"scs\":\"unavailable\",\"brakeBoost\":\"unavailable\",\"auxBrakes\":\"unavailable\"},\"size\":{\"width\":190,\"length\":570}},\"partII\":[{\"id\":\"VehicleSafetyExtensions\",\"value\":{\"pathHistory\":{\"crumbData\":[{\"elevationOffset\":0.3,\"latOffset\":-0.0000044,\"lonOffset\":-0.0000106,\"timeOffset\":0.59},{\"elevationOffset\":1.5,\"latOffset\":0.0000141,\"lonOffset\":0.0000047,\"timeOffset\":6.99},{\"elevationOffset\":2.8,\"latOffset\":0.0000385,\"lonOffset\":0.0000206,\"timeOffset\":15.09},{\"elevationOffset\":4.2,\"latOffset\":0.0000394,\"lonOffset\":0.0000051,\"timeOffset\":23.19},{\"elevationOffset\":8.6,\"latOffset\":0.0000586,\"lonOffset\":0.0000595,\"timeOffset\":37.89},{\"elevationOffset\":10.2,\"latOffset\":0.0000866,\"lonOffset\":0.0001174,\"timeOffset\":43.80},{\"elevationOffset\":8.5,\"latOffset\":0.0001026,\"lonOffset\":0.0001127,\"timeOffset\":49.20},{\"elevationOffset\":-0.1,\"latOffset\":0.0001183,\"lonOffset\":0.0000434,\"timeOffset\":55.60},{\"elevationOffset\":-8.1,\"latOffset\":0.0001101,\"lonOffset\":-0.0000274,\"timeOffset\":59.09},{\"elevationOffset\":-14.2,\"latOffset\":0.0001019,\"lonOffset\":-0.0000492,\"timeOffset\":61.19},{\"elevationOffset\":-19.0,\"latOffset\":0.0000944,\"lonOffset\":-0.0000738,\"timeOffset\":63.49},{\"elevationOffset\":-31.4,\"latOffset\":0.0000826,\"lonOffset\":-0.0001389,\"timeOffset\":69.19},{\"elevationOffset\":-39.8,\"latOffset\":0.0000788,\"lonOffset\":-0.0001748,\"timeOffset\":73.09},{\"elevationOffset\":-46.7,\"latOffset\":0.0000753,\"lonOffset\":-0.0002035,\"timeOffset\":78.89},{\"elevationOffset\":-48.9,\"latOffset\":0.0000831,\"lonOffset\":-0.0002563,\"timeOffset\":82.09}]},\"pathPrediction\":{\"confidence\":0.0,\"radiusOfCurve\":0.0}}},{\"id\":\"SupplementalVehicleExtensions\",\"value\":{}}]}}}";
+
     
     @Test
     public void shouldDeserializeJson_bsmTx() {
-
-        final String bsmJson = "{\"metadata\":{\"bsmSource\":\"RV\",\"logFileName\":\"\",\"recordType\":\"bsmTx\",\"securityResultCode\":\"success\",\"receivedMessageDetails\":{\"locationData\":{\"latitude\":\"\",\"longitude\":\"\",\"elevation\":\"\",\"speed\":\"\",\"heading\":\"\"},\"rxSource\":\"RV\"},\"payloadType\":\"us.dot.its.jpo.ode.model.OdeBsmPayload\",\"serialId\":{\"streamId\":\"504becf3-8e20-49cb-a2d7-25b646c34d0f\",\"bundleSize\":1,\"bundleId\":0,\"recordId\":0,\"serialNumber\":0},\"odeReceivedAt\":\"2022-06-17T19:14:21.223956Z\",\"schemaVersion\":6,\"maxDurationTime\":0,\"recordGeneratedAt\":\"\",\"sanitized\":false,\"odePacketID\":\"\",\"odeTimStartDateTime\":\"\",\"originIp\":\"10.11.81.12\"},\"payload\":{\"data\":{\"coreData\":{\"msgCnt\":46,\"id\":\"E6A99808\",\"secMark\":21061,\"position\":{\"latitude\":39.5881304,\"longitude\":-105.0910403,\"elevation\":1692.0},\"accelSet\":{\"accelLong\":-0.07,\"accelYaw\":-0.09},\"accuracy\":{\"semiMajor\":2.0,\"semiMinor\":2.0,\"orientation\":44.49530799},\"transmission\":\"UNAVAILABLE\",\"speed\":22.62,\"heading\":169.3,\"brakes\":{\"wheelBrakes\":{\"leftFront\":false,\"rightFront\":false,\"unavailable\":true,\"leftRear\":false,\"rightRear\":false},\"traction\":\"unavailable\",\"abs\":\"off\",\"scs\":\"unavailable\",\"brakeBoost\":\"unavailable\",\"auxBrakes\":\"unavailable\"},\"size\":{\"width\":180,\"length\":480}},\"partII\":[{\"id\":\"VehicleSafetyExtensions\",\"value\":{\"pathHistory\":{\"crumbData\":[{\"elevationOffset\":0.8,\"latOffset\":-0.0001802,\"lonOffset\":0.0000434,\"timeOffset\":0.89},{\"elevationOffset\":4.5,\"latOffset\":-0.0011801,\"lonOffset\":0.0002357,\"timeOffset\":5.7},{\"elevationOffset\":9.3,\"latOffset\":-0.0023623,\"lonOffset\":0.0003881,\"timeOffset\":11.1}]},\"pathPrediction\":{\"confidence\":70.0,\"radiusOfCurve\":0.0}}}]},\"dataType\":\"us.dot.its.jpo.ode.plugin.j2735.J2735Bsm\"}}";
-
-        var deserialized = (OdeBsmData)JsonUtils.fromJson(bsmJson, OdeBsmData.class);
+        final var deserialized = (OdeBsmData)JsonUtils.fromJson(bsmTxJson, OdeBsmData.class);
         assertNotNull(deserialized);
         assertTrue(deserialized.getMetadata() instanceof OdeBsmMetadata);     
         assertTrue(deserialized.getPayload() instanceof OdeBsmPayload);
@@ -29,10 +40,7 @@ public class OdeBsmDataTest {
 
     @Test
     public void shouldDeserializeJson_bsmLogDuringEvent() {
-
-        final String bsmJson = "{\"metadata\":{\"bsmSource\":\"RV\",\"logFileName\":\"bsmLogDuringEvent.gz\",\"recordType\":\"bsmLogDuringEvent\",\"securityResultCode\":\"success\",\"receivedMessageDetails\":{\"locationData\":{\"latitude\":\"40.565771\",\"longitude\":\"-105.0318108\",\"elevation\":\"1487\",\"speed\":\"0.14\",\"heading\":\"205.975\"},\"rxSource\":\"NA\"},\"payloadType\":\"us.dot.its.jpo.ode.model.OdeBsmPayload\",\"serialId\":{\"streamId\":\"801780cb-d91d-444b-8f4d-9c44fe27f5ea\",\"bundleSize\":222,\"bundleId\":71,\"recordId\":221,\"serialNumber\":14725},\"odeReceivedAt\":\"2019-04-09T18:07:12.352Z\",\"schemaVersion\":6,\"recordGeneratedAt\":\"2018-05-01T16:04:23.694Z\",\"recordGeneratedBy\":\"OBU\",\"sanitized\":false},\"payload\":{\"dataType\":\"us.dot.its.jpo.ode.plugin.j2735.J2735Bsm\",\"data\":{\"coreData\":{\"msgCnt\":95,\"id\":\"31325431\",\"secMark\":23794,\"position\":{\"latitude\":40.5657318,\"longitude\":-105.0318485,\"elevation\":1472.8},\"accelSet\":{\"accelLat\":0.00,\"accelLong\":0.52,\"accelVert\":0.00,\"accelYaw\":0.00},\"accuracy\":{\"semiMajor\":12.70,\"semiMinor\":12.40},\"transmission\":\"NEUTRAL\",\"speed\":0.10,\"heading\":250.9125,\"brakes\":{\"wheelBrakes\":{\"leftFront\":false,\"rightFront\":false,\"unavailable\":true,\"leftRear\":false,\"rightRear\":false},\"traction\":\"unavailable\",\"abs\":\"unavailable\",\"scs\":\"unavailable\",\"brakeBoost\":\"unavailable\",\"auxBrakes\":\"unavailable\"},\"size\":{\"width\":190,\"length\":570}},\"partII\":[{\"id\":\"VehicleSafetyExtensions\",\"value\":{\"pathHistory\":{\"crumbData\":[{\"elevationOffset\":0.3,\"latOffset\":-0.0000044,\"lonOffset\":-0.0000106,\"timeOffset\":0.59},{\"elevationOffset\":1.5,\"latOffset\":0.0000141,\"lonOffset\":0.0000047,\"timeOffset\":6.99},{\"elevationOffset\":2.8,\"latOffset\":0.0000385,\"lonOffset\":0.0000206,\"timeOffset\":15.09},{\"elevationOffset\":4.2,\"latOffset\":0.0000394,\"lonOffset\":0.0000051,\"timeOffset\":23.19},{\"elevationOffset\":8.6,\"latOffset\":0.0000586,\"lonOffset\":0.0000595,\"timeOffset\":37.89},{\"elevationOffset\":10.2,\"latOffset\":0.0000866,\"lonOffset\":0.0001174,\"timeOffset\":43.80},{\"elevationOffset\":8.5,\"latOffset\":0.0001026,\"lonOffset\":0.0001127,\"timeOffset\":49.20},{\"elevationOffset\":-0.1,\"latOffset\":0.0001183,\"lonOffset\":0.0000434,\"timeOffset\":55.60},{\"elevationOffset\":-8.1,\"latOffset\":0.0001101,\"lonOffset\":-0.0000274,\"timeOffset\":59.09},{\"elevationOffset\":-14.2,\"latOffset\":0.0001019,\"lonOffset\":-0.0000492,\"timeOffset\":61.19},{\"elevationOffset\":-19.0,\"latOffset\":0.0000944,\"lonOffset\":-0.0000738,\"timeOffset\":63.49},{\"elevationOffset\":-31.4,\"latOffset\":0.0000826,\"lonOffset\":-0.0001389,\"timeOffset\":69.19},{\"elevationOffset\":-39.8,\"latOffset\":0.0000788,\"lonOffset\":-0.0001748,\"timeOffset\":73.09},{\"elevationOffset\":-46.7,\"latOffset\":0.0000753,\"lonOffset\":-0.0002035,\"timeOffset\":78.89},{\"elevationOffset\":-48.9,\"latOffset\":0.0000831,\"lonOffset\":-0.0002563,\"timeOffset\":82.09}]},\"pathPrediction\":{\"confidence\":0.0,\"radiusOfCurve\":0.0}}},{\"id\":\"SupplementalVehicleExtensions\",\"value\":{}}]}}}";
-
-        var deserialized = (OdeBsmData)JsonUtils.fromJson(bsmJson, OdeBsmData.class);
+        final var deserialized = (OdeBsmData)JsonUtils.fromJson(bsmLogJson, OdeBsmData.class);
         assertNotNull(deserialized);
         assertTrue(deserialized.getMetadata() instanceof OdeBsmMetadata);
         assertTrue(deserialized.getPayload() instanceof OdeBsmPayload);
@@ -43,5 +51,44 @@ public class OdeBsmDataTest {
         assertTrue(data.getPartII().size() == 2);
         assertTrue(data.getPartII().get(0).getValue() instanceof J2735VehicleSafetyExtensions);
         assertTrue(data.getPartII().get(1).getValue() instanceof J2735SupplementalVehicleExtensions);
+    }
+
+    
+
+    @Test
+    public void serializationShouldNotAddClassProperty_bsmTx() {
+        final var deserialized = (OdeBsmData)JsonUtils.fromJson(bsmTxJson, OdeBsmData.class);
+        final String serialized = deserialized.toJson(false);
+        assertFalse(serialized.contains("@class"));
+    }
+
+    @Test
+    public void serializationShouldNotAddClassProperty_bsmLogDuringEvent() {
+        final var deserialized = (OdeBsmData)JsonUtils.fromJson(bsmLogJson, OdeBsmData.class);
+        final String serialized = deserialized.toJson(false);
+        assertFalse(serialized.contains("@class"));
+    }
+
+    @Test
+    public void shouldValidateJson_bsmTx() throws Exception {
+        final var deserialized = (OdeBsmData)JsonUtils.fromJson(bsmTxJson, OdeBsmData.class);
+        final String serialized = deserialized.toJson(false);
+        validateJson(serialized);
+    }
+
+    @Test
+    public void shouldValidateJson_bsmLogDuringEvent() throws Exception {
+        final var deserialized = (OdeBsmData)JsonUtils.fromJson(bsmLogJson, OdeBsmData.class);
+        final String serialized = deserialized.toJson(false);
+        validateJson(serialized);
+    }
+
+    private void validateJson(final String serialized) throws Exception {
+        // Load json schema from resource
+        JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7);
+        final JsonSchema schema = factory.getSchema(getClass().getClassLoader().getResource("schemas/schema-bsm.json").toURI());
+        final JsonNode node = (JsonNode)JsonUtils.fromJson(serialized, JsonNode.class);
+        Set<ValidationMessage> validationMessages = schema.validate(node);
+        assertEquals(String.format("Json validation errors: %s", validationMessages), 0, validationMessages.size());
     }
 }

--- a/jpo-ode-core/src/test/java/us/dot/its/jpo/ode/model/OdeMapDataTest.java
+++ b/jpo-ode-core/src/test/java/us/dot/its/jpo/ode/model/OdeMapDataTest.java
@@ -1,20 +1,48 @@
 package us.dot.its.jpo.ode.model;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+import java.util.Set;
+
 import org.junit.Test;
 import static org.junit.Assert.*;
 
 import us.dot.its.jpo.ode.util.JsonUtils;
 
 public class OdeMapDataTest {
+
+    final String json = "{\"metadata\":{\"logFileName\":\"\",\"recordType\":\"mapTx\",\"securityResultCode\":\"success\",\"receivedMessageDetails\":{\"locationData\":null,\"rxSource\":\"NA\"},\"encodings\":null,\"payloadType\":\"us.dot.its.jpo.ode.model.OdeMapPayload\",\"serialId\":{\"streamId\":\"18d7c2e0-9158-4456-916d-5cd4b080d290\",\"bundleSize\":1,\"bundleId\":0,\"recordId\":0,\"serialNumber\":0},\"odeReceivedAt\":\"2022-06-17T19:02:13.083984Z\",\"schemaVersion\":6,\"maxDurationTime\":0,\"recordGeneratedAt\":\"\",\"recordGeneratedBy\":null,\"sanitized\":false,\"odePacketID\":\"\",\"odeTimStartDateTime\":\"\",\"mapSource\":\"RSU\",\"originIp\":\"10.11.81.25\"},\"payload\":{\"data\":{\"timeStamp\":null,\"msgIssueRevision\":2,\"layerType\":\"intersectionData\",\"layerID\":0,\"intersections\":null,\"roadSegments\":null,\"dataParameters\":null,\"restrictionList\":null},\"dataType\":\"us.dot.its.jpo.ode.plugin.j2735.J2735MAP\"}}";
+
     @Test
     public void shouldDeserializeJson() {
-
-        final String bsmJson = "{\"metadata\":{\"logFileName\":\"\",\"recordType\":\"mapTx\",\"securityResultCode\":\"success\",\"receivedMessageDetails\":{\"locationData\":null,\"rxSource\":\"NA\"},\"encodings\":null,\"payloadType\":\"us.dot.its.jpo.ode.model.OdeMapPayload\",\"serialId\":{\"streamId\":\"18d7c2e0-9158-4456-916d-5cd4b080d290\",\"bundleSize\":1,\"bundleId\":0,\"recordId\":0,\"serialNumber\":0},\"odeReceivedAt\":\"2022-06-17T19:02:13.083984Z\",\"schemaVersion\":6,\"maxDurationTime\":0,\"recordGeneratedAt\":\"\",\"recordGeneratedBy\":null,\"sanitized\":false,\"odePacketID\":\"\",\"odeTimStartDateTime\":\"\",\"mapSource\":\"RSU\",\"originIp\":\"10.11.81.25\"},\"payload\":{\"data\":{\"timeStamp\":null,\"msgIssueRevision\":2,\"layerType\":\"intersectionData\",\"layerID\":0,\"intersections\":null,\"roadSegments\":null,\"dataParameters\":null,\"restrictionList\":null},\"dataType\":\"us.dot.its.jpo.ode.plugin.j2735.J2735MAP\"}}";
-
-        var deserialized = (OdeMapData)JsonUtils.fromJson(bsmJson, OdeMapData.class);
+        final var deserialized = (OdeMapData)JsonUtils.fromJson(json, OdeMapData.class);
         assertNotNull(deserialized);
         assertTrue(deserialized.getMetadata() instanceof OdeMapMetadata);
         assertTrue(deserialized.getPayload() instanceof OdeMapPayload);
         
     }
+
+    @Test
+    public void serializationShouldNotAddClassProperty() {
+        final var deserialized = (OdeMapData)JsonUtils.fromJson(json, OdeMapData.class);
+        final String serialized = deserialized.toJson(false);
+        assertFalse(serialized.contains("@class"));
+    }
+
+    @Test
+    public void shouldValidateJson() throws Exception {
+        final var deserialized = (OdeMapData)JsonUtils.fromJson(json, OdeMapData.class);
+        final String serialized = deserialized.toJson(false);
+
+        // Load json schema from resource
+        JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V4);
+        final JsonSchema schema = factory.getSchema(getClass().getClassLoader().getResource("schemas/schema-map.json").toURI());
+        final JsonNode node = (JsonNode)JsonUtils.fromJson(serialized, JsonNode.class);
+        Set<ValidationMessage> validationMessages = schema.validate(node);
+        assertEquals(String.format("Json validation errors: %s", validationMessages), 0, validationMessages.size());
+    }
 }
+

--- a/jpo-ode-core/src/test/java/us/dot/its/jpo/ode/model/OdeSpatDataTest.java
+++ b/jpo-ode-core/src/test/java/us/dot/its/jpo/ode/model/OdeSpatDataTest.java
@@ -1,20 +1,47 @@
 package us.dot.its.jpo.ode.model;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+import java.util.Set;
+
 import org.junit.Test;
 import static org.junit.Assert.*;
 
 import us.dot.its.jpo.ode.util.JsonUtils;
 
 public class OdeSpatDataTest {
+    
+    final String json = "{\"metadata\":{\"logFileName\":\"\",\"recordType\":\"spatTx\",\"securityResultCode\":\"success\",\"receivedMessageDetails\":{\"rxSource\":\"NA\"},\"payloadType\":\"us.dot.its.jpo.ode.model.OdeSpatPayload\",\"serialId\":{\"streamId\":\"ed008249-0a8d-47f2-a526-ffd8c30b9810\",\"bundleSize\":1,\"bundleId\":0,\"recordId\":0,\"serialNumber\":0},\"odeReceivedAt\":\"2022-12-24T01:49:54.160478Z\",\"schemaVersion\":6,\"maxDurationTime\":0,\"recordGeneratedAt\":\"\",\"sanitized\":false,\"odePacketID\":\"\",\"odeTimStartDateTime\":\"\",\"spatSource\":\"V2X\",\"originIp\":\"172.18.0.1\",\"isCertPresent\":false},\"payload\":{\"data\":{\"intersectionStateList\":{\"intersectionStatelist\":[{\"id\":{\"id\":12111},\"revision\":0,\"status\":{\"failureFlash\":false,\"noValidSPATisAvailableAtThisTime\":false,\"fixedTimeOperation\":false,\"standbyOperation\":false,\"trafficDependentOperation\":false,\"manualControlIsEnabled\":false,\"off\":false,\"stopTimeIsActivated\":false,\"recentChangeInMAPassignedLanesIDsUsed\":false,\"recentMAPmessageUpdate\":false,\"failureMode\":false,\"noValidMAPisAvailableAtThisTime\":false,\"signalPriorityIsActive\":false,\"preemptIsActive\":false},\"timeStamp\":35176,\"states\":{\"movementList\":[{\"signalGroup\":2,\"state_time_speed\":{\"movementEventList\":[{\"eventState\":\"PROTECTED_MOVEMENT_ALLOWED\",\"timing\":{\"minEndTime\":22120,\"maxEndTime\":22121}}]}},{\"signalGroup\":4,\"state_time_speed\":{\"movementEventList\":[{\"eventState\":\"STOP_AND_REMAIN\",\"timing\":{\"minEndTime\":22181,\"maxEndTime\":22181}}]}},{\"signalGroup\":6,\"state_time_speed\":{\"movementEventList\":[{\"eventState\":\"PROTECTED_MOVEMENT_ALLOWED\",\"timing\":{\"minEndTime\":22120,\"maxEndTime\":22121}}]}},{\"signalGroup\":8,\"state_time_speed\":{\"movementEventList\":[{\"eventState\":\"STOP_AND_REMAIN\",\"timing\":{\"minEndTime\":21852,\"maxEndTime\":21852}}]}},{\"signalGroup\":1,\"state_time_speed\":{\"movementEventList\":[{\"eventState\":\"STOP_AND_REMAIN\",\"timing\":{\"minEndTime\":21852,\"maxEndTime\":21852}}]}},{\"signalGroup\":5,\"state_time_speed\":{\"movementEventList\":[{\"eventState\":\"STOP_AND_REMAIN\",\"timing\":{\"minEndTime\":21852,\"maxEndTime\":21852}}]}}]}}]}},\"dataType\":\"us.dot.its.jpo.ode.plugin.j2735.J2735SPAT\"}}";
+
     @Test
     public void shouldDeserializeJson() {
-
-        final String bsmJson = "{\"metadata\":{\"logFileName\":\"\",\"recordType\":\"spatTx\",\"securityResultCode\":\"success\",\"receivedMessageDetails\":{\"locationData\":null,\"rxSource\":\"NA\"},\"encodings\":null,\"payloadType\":\"us.dot.its.jpo.ode.model.OdeSpatPayload\",\"serialId\":{\"streamId\":\"24d9dfcb-1ca0-41b8-8576-f4a00a51218e\",\"bundleSize\":1,\"bundleId\":0,\"recordId\":0,\"serialNumber\":0},\"odeReceivedAt\":\"2022-06-17T19:02:05.366148Z\",\"schemaVersion\":6,\"maxDurationTime\":0,\"recordGeneratedAt\":\"\",\"recordGeneratedBy\":null,\"sanitized\":false,\"odePacketID\":\"\",\"odeTimStartDateTime\":\"\",\"spatSource\":\"V2X\",\"originIp\":\"10.11.81.12\",\"isCertPresent\":false},\"payload\":{\"data\":{\"timeStamp\":null,\"name\":null,\"intersectionStateList\":null},\"dataType\":\"us.dot.its.jpo.ode.plugin.j2735.J2735SPAT\"}}";
-
-        var deserialized = (OdeSpatData)JsonUtils.fromJson(bsmJson, OdeSpatData.class);
+        final var deserialized = (OdeSpatData)JsonUtils.fromJson(json, OdeSpatData.class);
         assertNotNull(deserialized);
         assertTrue(deserialized.getMetadata() instanceof OdeSpatMetadata);
         assertTrue(deserialized.getPayload() instanceof OdeSpatPayload);
         
+    }
+
+    @Test
+    public void serializationShouldNotAddClassProperty() {
+        final var deserialized = (OdeSpatData)JsonUtils.fromJson(json, OdeSpatData.class);
+        final String serialized = deserialized.toJson(false);
+        assertFalse(serialized.contains("@class"));
+    }
+
+    @Test
+    public void shouldValidateJson() throws Exception {
+        final var deserialized = (OdeSpatData)JsonUtils.fromJson(json, OdeSpatData.class);
+        final String serialized = deserialized.toJson(false);
+
+        // Load json schema from resource
+        JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7);
+        final JsonSchema schema = factory.getSchema(getClass().getClassLoader().getResource("schemas/schema-spat.json").toURI());
+        final JsonNode node = (JsonNode)JsonUtils.fromJson(serialized, JsonNode.class);
+        Set<ValidationMessage> validationMessages = schema.validate(node);
+        assertEquals(String.format("Json validation errors: %s", validationMessages), 0, validationMessages.size());
     }
 }

--- a/jpo-ode-core/src/test/java/us/dot/its/jpo/ode/model/OdeSrmDataTest.java
+++ b/jpo-ode-core/src/test/java/us/dot/its/jpo/ode/model/OdeSrmDataTest.java
@@ -1,20 +1,47 @@
 package us.dot.its.jpo.ode.model;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+import java.util.Set;
+
 import org.junit.Test;
 import static org.junit.Assert.*;
 
 import us.dot.its.jpo.ode.util.JsonUtils;
 
 public class OdeSrmDataTest {
+
+    final String json = "{\"metadata\":{\"logFileName\":\"\",\"recordType\":\"srmTx\",\"securityResultCode\":null,\"receivedMessageDetails\":{\"locationData\":null,\"rxSource\":\"NA\"},\"encodings\":null,\"payloadType\":\"us.dot.its.jpo.ode.model.OdeSrmPayload\",\"serialId\":{\"streamId\":\"c3ff825f-ed1f-4411-a12e-1ba889f56483\",\"bundleSize\":1,\"bundleId\":0,\"recordId\":0,\"serialNumber\":0},\"odeReceivedAt\":\"2022-12-13T18:58:53.541816Z\",\"schemaVersion\":6,\"maxDurationTime\":0,\"recordGeneratedAt\":\"\",\"recordGeneratedBy\":null,\"sanitized\":false,\"odePacketID\":\"\",\"odeTimStartDateTime\":\"\",\"originIp\":\"172.21.0.1\",\"srmSource\":\"RSU\"},\"payload\":{\"data\":{\"timeStamp\":null,\"second\":0,\"sequenceNumber\":1,\"requests\":{\"signalRequestPackage\":[{\"request\":{\"id\":{\"region\":null,\"id\":12109},\"requestID\":4,\"requestType\":\"priorityRequest\",\"inBoundLane\":{\"lane\":13,\"approach\":null,\"connection\":null},\"outBoundLane\":{\"lane\":4,\"approach\":null,\"connection\":null}},\"minute\":null,\"second\":null,\"duration\":10979}]},\"requestor\":{\"id\":{\"entityID\":null,\"stationID\":2366845094},\"type\":{\"role\":\"publicTransport\",\"subrole\":null,\"request\":null,\"iso3883\":null,\"hpmsType\":null},\"position\":{\"position\":{\"latitude\":39.5904915,\"longitude\":-105.0913829,\"elevation\":1685.4},\"heading\":175.9000,\"speed\":null},\"name\":null,\"routeName\":null,\"transitStatus\":null,\"transitOccupancy\":null,\"transitSchedule\":null}},\"dataType\":\"us.dot.its.jpo.ode.plugin.j2735.J2735SRM\"}}";
+
     @Test
     public void shouldDeserializeJson() {
-
-        final String bsmJson = "{\"metadata\":{\"logFileName\":\"\",\"recordType\":\"srmTx\",\"securityResultCode\":null,\"receivedMessageDetails\":{\"locationData\":null,\"rxSource\":\"NA\"},\"encodings\":null,\"payloadType\":\"us.dot.its.jpo.ode.model.OdeSrmPayload\",\"serialId\":{\"streamId\":\"c3ff825f-ed1f-4411-a12e-1ba889f56483\",\"bundleSize\":1,\"bundleId\":0,\"recordId\":0,\"serialNumber\":0},\"odeReceivedAt\":\"2022-12-13T18:58:53.541816Z\",\"schemaVersion\":6,\"maxDurationTime\":0,\"recordGeneratedAt\":\"\",\"recordGeneratedBy\":null,\"sanitized\":false,\"odePacketID\":\"\",\"odeTimStartDateTime\":\"\",\"originIp\":\"172.21.0.1\",\"srmSource\":\"RSU\"},\"payload\":{\"data\":{\"timeStamp\":null,\"second\":0,\"sequenceNumber\":1,\"requests\":{\"signalRequestPackage\":[{\"request\":{\"id\":{\"region\":null,\"id\":12109},\"requestID\":4,\"requestType\":\"priorityRequest\",\"inBoundLane\":{\"lane\":13,\"approach\":null,\"connection\":null},\"outBoundLane\":{\"lane\":4,\"approach\":null,\"connection\":null}},\"minute\":null,\"second\":null,\"duration\":10979}]},\"requestor\":{\"id\":{\"entityID\":null,\"stationID\":2366845094},\"type\":{\"role\":\"publicTransport\",\"subrole\":null,\"request\":null,\"iso3883\":null,\"hpmsType\":null},\"position\":{\"position\":{\"latitude\":39.5904915,\"longitude\":-105.0913829,\"elevation\":1685.4},\"heading\":175.9000,\"speed\":null},\"name\":null,\"routeName\":null,\"transitStatus\":null,\"transitOccupancy\":null,\"transitSchedule\":null}},\"dataType\":\"us.dot.its.jpo.ode.plugin.j2735.J2735SRM\"}}";
-
-        var deserialized = (OdeSrmData)JsonUtils.fromJson(bsmJson, OdeSrmData.class);
+        final var deserialized = (OdeSrmData)JsonUtils.fromJson(json, OdeSrmData.class);
         assertNotNull(deserialized);
         assertTrue(deserialized.getMetadata() instanceof OdeSrmMetadata);
         assertTrue(deserialized.getPayload() instanceof OdeSrmPayload);
         
+    }
+
+    @Test
+    public void serializationShouldNotAddClassProperty() {
+        final var deserialized = (OdeSrmData)JsonUtils.fromJson(json, OdeSrmData.class);
+        final String serialized = deserialized.toJson(false);
+        assertFalse(serialized.contains("@class"));
+    }
+
+    @Test
+    public void shouldValidateJson() throws Exception {
+        final var deserialized = (OdeSrmData)JsonUtils.fromJson(json, OdeSrmData.class);
+        final String serialized = deserialized.toJson(false);
+
+        // Load json schema from resource
+        JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V4);
+        final JsonSchema schema = factory.getSchema(getClass().getClassLoader().getResource("schemas/schema-srm.json").toURI());
+        final JsonNode node = (JsonNode)JsonUtils.fromJson(serialized, JsonNode.class);
+        Set<ValidationMessage> validationMessages = schema.validate(node);
+        assertEquals(String.format("Json validation errors: %s", validationMessages), 0, validationMessages.size());
     }
 }

--- a/jpo-ode-core/src/test/java/us/dot/its/jpo/ode/model/OdeSsmDataTest.java
+++ b/jpo-ode-core/src/test/java/us/dot/its/jpo/ode/model/OdeSsmDataTest.java
@@ -1,20 +1,48 @@
 package us.dot.its.jpo.ode.model;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+import java.util.Set;
+
 import org.junit.Test;
 import static org.junit.Assert.*;
 
 import us.dot.its.jpo.ode.util.JsonUtils;
 
 public class OdeSsmDataTest {
+
+    final String json = "{\"metadata\":{\"logFileName\":\"\",\"recordType\":\"ssmTx\",\"securityResultCode\":null,\"receivedMessageDetails\":{\"locationData\":null,\"rxSource\":\"NA\"},\"encodings\":null,\"payloadType\":\"us.dot.its.jpo.ode.model.OdeSsmPayload\",\"serialId\":{\"streamId\":\"b9801eb3-66fb-4d36-ae08-3e8f2bcb2026\",\"bundleSize\":1,\"bundleId\":0,\"recordId\":0,\"serialNumber\":0},\"odeReceivedAt\":\"2022-12-13T19:00:42.326229Z\",\"schemaVersion\":6,\"maxDurationTime\":0,\"recordGeneratedAt\":\"\",\"recordGeneratedBy\":null,\"sanitized\":false,\"odePacketID\":\"\",\"odeTimStartDateTime\":\"\",\"originIp\":\"172.21.0.1\",\"ssmSource\":\"RSU\"},\"payload\":{\"data\":{\"timeStamp\":null,\"second\":0,\"sequenceNumber\":null,\"status\":{\"signalStatus\":[{\"sequenceNumber\":0,\"id\":{\"region\":null,\"id\":12110},\"sigStatus\":{\"signalStatusPackage\":[{\"requester\":{\"id\":{\"entityID\":null,\"stationID\":2366845094},\"request\":3,\"sequenceNumber\":0,\"role\":null,\"typeData\":{\"role\":\"publicTransport\",\"subrole\":null,\"request\":null,\"iso3883\":null,\"hpmsType\":null}},\"inboundOn\":{\"lane\":23,\"approach\":null,\"connection\":null},\"outboundOn\":null,\"minute\":null,\"second\":null,\"duration\":null,\"status\":\"granted\"}]}}]}},\"dataType\":\"us.dot.its.jpo.ode.plugin.j2735.J2735SSM\"}}";
+
     @Test
     public void shouldDeserializeJson() {
 
-        final String bsmJson = "{\"metadata\":{\"logFileName\":\"\",\"recordType\":\"ssmTx\",\"securityResultCode\":null,\"receivedMessageDetails\":{\"locationData\":null,\"rxSource\":\"NA\"},\"encodings\":null,\"payloadType\":\"us.dot.its.jpo.ode.model.OdeSsmPayload\",\"serialId\":{\"streamId\":\"b9801eb3-66fb-4d36-ae08-3e8f2bcb2026\",\"bundleSize\":1,\"bundleId\":0,\"recordId\":0,\"serialNumber\":0},\"odeReceivedAt\":\"2022-12-13T19:00:42.326229Z\",\"schemaVersion\":6,\"maxDurationTime\":0,\"recordGeneratedAt\":\"\",\"recordGeneratedBy\":null,\"sanitized\":false,\"odePacketID\":\"\",\"odeTimStartDateTime\":\"\",\"originIp\":\"172.21.0.1\",\"ssmSource\":\"RSU\"},\"payload\":{\"data\":{\"timeStamp\":null,\"second\":0,\"sequenceNumber\":null,\"status\":{\"signalStatus\":[{\"sequenceNumber\":0,\"id\":{\"region\":null,\"id\":12110},\"sigStatus\":{\"signalStatusPackage\":[{\"requester\":{\"id\":{\"entityID\":null,\"stationID\":2366845094},\"request\":3,\"sequenceNumber\":0,\"role\":null,\"typeData\":{\"role\":\"publicTransport\",\"subrole\":null,\"request\":null,\"iso3883\":null,\"hpmsType\":null}},\"inboundOn\":{\"lane\":23,\"approach\":null,\"connection\":null},\"outboundOn\":null,\"minute\":null,\"second\":null,\"duration\":null,\"status\":\"granted\"}]}}]}},\"dataType\":\"us.dot.its.jpo.ode.plugin.j2735.J2735SSM\"}}";
-
-        var deserialized = (OdeSsmData)JsonUtils.fromJson(bsmJson, OdeSsmData.class);
+        final var deserialized = (OdeSsmData)JsonUtils.fromJson(json, OdeSsmData.class);
         assertNotNull(deserialized);
         assertTrue(deserialized.getMetadata() instanceof OdeSsmMetadata);
         assertTrue(deserialized.getPayload() instanceof OdeSsmPayload);
         
+    }
+
+    @Test
+    public void serializationShouldNotAddClassProperty() {
+        final var deserialized = (OdeSsmData)JsonUtils.fromJson(json, OdeSsmData.class);
+        final String serialized = deserialized.toJson(false);
+        assertFalse(serialized.contains("@class"));
+    }
+
+    @Test
+    public void shouldValidateJson() throws Exception {
+        final var deserialized = (OdeSsmData)JsonUtils.fromJson(json, OdeSsmData.class);
+        final String serialized = deserialized.toJson(false);
+
+        // Load json schema from resource
+        JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V4);
+        final JsonSchema schema = factory.getSchema(getClass().getClassLoader().getResource("schemas/schema-ssm.json").toURI());
+        final JsonNode node = (JsonNode)JsonUtils.fromJson(serialized, JsonNode.class);
+        Set<ValidationMessage> validationMessages = schema.validate(node);
+        assertEquals(String.format("Json validation errors: %s", validationMessages), 0, validationMessages.size());
     }
 }

--- a/jpo-ode-core/src/test/java/us/dot/its/jpo/ode/model/OdeTimDataTest.java
+++ b/jpo-ode-core/src/test/java/us/dot/its/jpo/ode/model/OdeTimDataTest.java
@@ -1,0 +1,33 @@
+package us.dot.its.jpo.ode.model;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+
+import us.dot.its.jpo.ode.util.JsonUtils;
+
+import java.util.Set;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class OdeTimDataTest {
+    final String json = "{\"metadata\":{\"securityResultCode\":\"\",\"recordGeneratedBy\":\"RSU\",\"schemaVersion\":\"6\",\"odePacketID\":\"\",\"sanitized\":\"false\",\"recordType\":\"timMsg\",\"recordGeneratedAt\":\"\",\"maxDurationTime\":\"0\",\"odeTimStartDateTime\":\"\",\"receivedMessageDetails\":\"\",\"payloadType\":\"us.dot.its.jpo.ode.model.OdeTimPayload\",\"serialId\":{\"recordId\":\"0\",\"serialNumber\":\"0\",\"streamId\":\"11ad5323-ec81-4694-8cd0-eb88ca08728e\",\"bundleSize\":\"1\",\"bundleId\":\"0\"},\"logFileName\":\"\",\"odeReceivedAt\":\"2022-12-24T02:24:38.248417Z\",\"originIp\":\"172.18.0.1\"},\"payload\":{\"data\":{\"MessageFrame\":{\"messageId\":\"31\",\"value\":{\"TravelerInformation\":{\"timeStamp\":\"449089\",\"packetID\":\"0000000000000BBC2B\",\"urlB\":\"null\",\"dataFrames\":{\"TravelerDataFrame\":{\"regions\":{\"GeographicalPath\":{\"closedPath\":{\"false\":\"\"},\"anchor\":{\"lat\":\"411269876\",\"long\":\"-1047269563\"},\"name\":\"westbound_I-80_366.0_365.0_RSU-10.145.1.100_RW_4456\",\"laneWidth\":\"32700\",\"directionality\":{\"both\":\"\"},\"description\":{\"path\":{\"offset\":{\"xy\":{\"nodes\":{\"NodeXY\":[{\"delta\":{\"node-LatLon\":{\"lon\":\"-1047287423\",\"lat\":\"411264686\"}}},{\"delta\":{\"node-LatLon\":{\"lon\":\"-1047305390\",\"lat\":\"411260104\"}}},{\"delta\":{\"node-LatLon\":{\"lon\":\"-1047323629\",\"lat\":\"411256185\"}}},{\"delta\":{\"node-LatLon\":{\"lon\":\"-1047342080\",\"lat\":\"411252886\"}}},{\"delta\":{\"node-LatLon\":{\"lon\":\"-1047360706\",\"lat\":\"411250207\"}}},{\"delta\":{\"node-LatLon\":{\"lon\":\"-1047379480\",\"lat\":\"411248201\"}}},{\"delta\":{\"node-LatLon\":{\"lon\":\"-1047398354\",\"lat\":\"411246839\"}}},{\"delta\":{\"node-LatLon\":{\"lon\":\"-1047417290\",\"lat\":\"411246133\"}}},{\"delta\":{\"node-LatLon\":{\"lon\":\"-1047436246\",\"lat\":\"411245796\"}}},{\"delta\":{\"node-LatLon\":{\"lon\":\"-1047455202\",\"lat\":\"411245470\"}}},{\"delta\":{\"node-LatLon\":{\"lon\":\"-1047474159\",\"lat\":\"411245173\"}}}]}}},\"scale\":\"0\"}},\"id\":{\"id\":\"0\",\"region\":\"0\"},\"direction\":\"0000000000010000\"}},\"duratonTime\":\"1440\",\"sspMsgRights1\":\"1\",\"sspMsgRights2\":\"1\",\"startYear\":\"2018\",\"msgId\":{\"roadSignID\":{\"viewAngle\":\"1111111111111111\",\"mutcdCode\":{\"warning\":\"\"},\"position\":{\"lat\":\"411269876\",\"long\":\"-1047269563\"}}},\"priority\":\"5\",\"content\":{\"advisory\":{\"SEQUENCE\":[{\"item\":{\"itis\":\"777\"}},{\"item\":{\"itis\":\"13579\"}}]}},\"url\":\"null\",\"sspTimRights\":\"1\",\"sspLocationRights\":\"1\",\"frameType\":{\"advisory\":\"\"},\"startTime\":\"448260\"}},\"msgCnt\":\"1\"}}}},\"dataType\":\"TravelerInformation\"}}";
+
+    //
+    // Note that OdeTimData does not have annotations to support deserialization, so serialization/deserialization is not tested here.
+    //
+
+    @Test
+    public void shouldValidateJson() throws Exception {
+        // Load json schema from resource
+        JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V4);
+        final JsonSchema schema = factory.getSchema(getClass().getClassLoader().getResource("schemas/schema-tim.json").toURI());
+        final JsonNode node = (JsonNode)JsonUtils.fromJson(json, JsonNode.class);
+        Set<ValidationMessage> validationMessages = schema.validate(node);
+        assertEquals(String.format("Json validation errors: %s", validationMessages), 0, validationMessages.size());
+    }
+}

--- a/scripts/tests/udpsender_map.py
+++ b/scripts/tests/udpsender_map.py
@@ -15,5 +15,5 @@ sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM) # UDP
 
 while True:
   time.sleep(5)
-  print("sending SRM every 5 second")
+  print(f"sending MAP every 5 seconds")
   sock.sendto(bytes.fromhex(MESSAGE), (UDP_IP, UDP_PORT))

--- a/scripts/tests/udpsender_tim.py
+++ b/scripts/tests/udpsender_tim.py
@@ -1,0 +1,19 @@
+import socket
+import time
+import os
+
+# Currently set to oim-dev environment's ODE
+UDP_IP = os.getenv('DOCKER_HOST_IP')
+UDP_PORT = 47900
+MESSAGE = "005f498718cca69ec1a04600000100105d9b46ec5be401003a0103810040038081d4001f80d07016da410000000000000bbc2b0f775d9b0309c271431fa166ee0a27fff93f136b8205a0a107fb2ef979f4c5bfaeec97e4ad70c2fb36cd9730becdb355cc2fd2a7556b160b98b46ab98ae62c185fa55efb468d5b4000000004e2863f42cddc144ff7980040401262cdd7b809c509f5c62cdd35519c507b9062cdcee129c505cf262cdca5ff9c50432c62cdc5d3d9c502e3e62cdc13e79c501e9262cdbca2d9c5013ee62cdb80359c500e6a62cdb36299c500bc862cdaec1d9c50093c62cdaa2109c5006ea1080203091a859eeebb36006001830001aad27f4ff7580001aad355e39b5880a30029d6585009ef808332d8d9f80c3855151b38c772f765007967ec1170bcb7937f5cb880a25a52863493bcb87570dbcb5abc6bfb2faec606cfa34eb95a24790b2017366d3aabe7729e"
+
+print("UDP target IP:", UDP_IP)
+print("UDP target port:", UDP_PORT)
+#print("message:", MESSAGE)
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM) # UDP
+
+while True:
+  time.sleep(5)
+  print("sending TIM every 5 second")
+  sock.sendto(bytes.fromhex(MESSAGE), (UDP_IP, UDP_PORT))


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
* Fixes the JsonTypeInfo annotations added to the OdeBsmData, OdeMapData, OdeSpatData, OdeSsmData, and OdeSrmData messages in [PR #487](https://github.com/usdot-jpo-ode/jpo-ode/pull/487) to prevent unnecessary '`@class`' fields from being added to the JSON when serializing the POJOs.

* Removes the `@class` fields from the json schemas that had been added in [PR #490](https://github.com/usdot-jpo-ode/jpo-ode/pull/490)

* Adds unit tests that check whether JSON serialized from the data POJOs can be validated with the JSON schemas.

* Moves the JSON schemas from the `docs/schemas` directory to the `jpo-ode-core/src/main/resources/schemas` directory to enable testing them.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Deserializing JSON to ODE Data Objects #486](https://github.com/usdot-jpo-ode/jpo-ode/issues/486)


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
It was brought to our attention that the '`@class`' fields in the schemas cause issues with importing the JSON into BigQuery, and they are not needed for the deserialization functionality implemented in PR #487 to work.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Existing unit tests were run.
* New unit tests were added to validate the serialized JSON against the schemas and verify that the `@class` fields are not added.
* Re-ran the integration test scripts in the `scripts/tests` directory with the ODE running in Docker while monitoring the OdeX__Json topics, to verify that these changes did not break the ODE's UPER -> XML -> JSON decoding functionality.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
