### PR TITLE
SRM requests list builder fix

### DIFF
--- a/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/builders/SRMBuilder.java
+++ b/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/builders/SRMBuilder.java
@@ -1,10 +1,6 @@
 package us.dot.its.jpo.ode.plugin.j2735.builders;
 
-import javax.xml.transform.Source;
-
 import com.fasterxml.jackson.databind.JsonNode;
-
-import org.codehaus.groovy.runtime.powerassert.SourceText;
 
 import us.dot.its.jpo.ode.plugin.j2735.J2735SRM;
 import us.dot.its.jpo.ode.plugin.j2735.J2735SignalRequestList;

--- a/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/builders/SignalRequestListBuilder.java
+++ b/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/builders/SignalRequestListBuilder.java
@@ -14,19 +14,15 @@ public class SignalRequestListBuilder {
 	public static J2735SignalRequestList genericSignalRequestList(JsonNode requests) {
 		J2735SignalRequestList signalRequestList = new J2735SignalRequestList();
 
-		if (requests.isArray()) {
-			Iterator<JsonNode> elements = requests.elements();
-
-			while (elements.hasNext()) {
-				signalRequestList.getRequests()
-                    .add(SignalRequestPackageBuilder.genericSignalRequestPackage(elements.next()));
-			}
-		} else {
-			JsonNode signalRequest = requests.get("SignalRequestPackage");
-			if(signalRequest != null)
-			{
-				signalRequestList.getRequests()
-					.add(SignalRequestPackageBuilder.genericSignalRequestPackage(signalRequest));
+		JsonNode signalRequest = requests.get("SignalRequestPackage");
+		if(signalRequest != null) {
+			if (signalRequest.isArray()) {
+				Iterator<JsonNode> elements = signalRequest.elements();
+				while (elements.hasNext()) {
+					signalRequestList.getRequests().add(SignalRequestPackageBuilder.genericSignalRequestPackage(elements.next()));
+				}
+			} else {
+				signalRequestList.getRequests().add(SignalRequestPackageBuilder.genericSignalRequestPackage(signalRequest));
 			}
 		}
 		

--- a/jpo-ode-plugins/src/test/java/us/dot/its/jpo/ode/plugin/j2735/builders/SRMBuilderTest.java
+++ b/jpo-ode-plugins/src/test/java/us/dot/its/jpo/ode/plugin/j2735/builders/SRMBuilderTest.java
@@ -13,7 +13,7 @@ import us.dot.its.jpo.ode.util.XmlUtils.XmlUtilsException;
 
 public class SRMBuilderTest {
     @Test
-	public void shouldTranslateSrm() {
+	public void shouldTranslateSrmSingle() {
 
 		JsonNode jsonMap = null;
 		try {
@@ -24,6 +24,22 @@ public class SRMBuilderTest {
 		}
 		J2735SRM actualSrm = SRMBuilder.genericSRM(jsonMap.findValue("SignalRequestMessage"));	
 		String expected ="{\"second\":0,\"sequenceNumber\":1,\"requests\":{\"signalRequestPackage\":[{\"request\":{\"id\":{\"id\":12109},\"requestID\":4,\"requestType\":\"priorityRequest\",\"inBoundLane\":{\"lane\":13},\"outBoundLane\":{\"lane\":4}},\"duration\":10979}]},\"requestor\":{\"id\":{\"stationID\":2366845094},\"type\":{\"role\":\"publicTransport\"},\"position\":{\"position\":{\"latitude\":39.5904915,\"longitude\":-105.0913829,\"elevation\":1685.4},\"heading\":175.9000}}}";
+		assertEquals(expected, actualSrm.toString()); 
+		
+	}
+
+    @Test
+	public void shouldTranslateSrmList() {
+
+		JsonNode jsonMap = null;
+		try {
+			jsonMap = XmlUtils.toObjectNode(
+					"<OdeAsn1Data><metadata><logFileName/><recordType>srmTx</recordType><securityResultCode/><receivedMessageDetails/><encodings><encodings><elementName>unsecuredData</elementName><elementType>MessageFrame</elementType><encodingRule>UPER</encodingRule></encodings></encodings><payloadType>us.dot.its.jpo.ode.model.OdeAsn1Payload</payloadType><serialId><streamId>bb49cf33-9403-4746-ac11-0c3e86f39043</streamId><bundleSize>1</bundleSize><bundleId>0</bundleId><recordId>0</recordId><serialNumber>0</serialNumber></serialId><odeReceivedAt>2023-01-11T21:43:39.558284Z</odeReceivedAt><schemaVersion>6</schemaVersion><maxDurationTime>0</maxDurationTime><recordGeneratedAt/><recordGeneratedBy/><sanitized>false</sanitized><odePacketID/><odeTimStartDateTime/><originIp>172.19.0.1</originIp><srmSource>RSU</srmSource></metadata><payload><dataType>MessageFrame</dataType><data><MessageFrame><messageId>29</messageId><value><SignalRequestMessage><timeStamp>6759</timeStamp><second>0</second><sequenceNumber>7</sequenceNumber><requests><SignalRequestPackage><request><id><id>12114</id></id><requestID>2</requestID><requestType><priorityRequest/></requestType><inBoundLane><lane>11</lane></inBoundLane><outBoundLane><lane>8</lane></outBoundLane></request><duration>25172</duration></SignalRequestPackage><SignalRequestPackage><request><id><id>12114</id></id><requestID>1</requestID><requestType><priorityCancellation/></requestType><inBoundLane><lane>12</lane></inBoundLane><outBoundLane><lane>7</lane></outBoundLane></request><duration>31032</duration></SignalRequestPackage></requests><requestor><id><stationID>2031825062</stationID></id><type><role><publicTransport/></role></type><position><position><lat>395572888</lat><long>-1050834514</long><elevation>16779</elevation></position><heading>16592</heading><speed><transmisson><unavailable/></transmisson><speed>727</speed></speed></position></requestor></SignalRequestMessage></value></MessageFrame></data></payload></OdeAsn1Data>");
+		} catch (XmlUtilsException e) {
+			fail("XML parsing error:" + e);
+		}
+		J2735SRM actualSrm = SRMBuilder.genericSRM(jsonMap.findValue("SignalRequestMessage"));	
+		String expected ="{\"timeStamp\":6759,\"second\":0,\"sequenceNumber\":7,\"requests\":{\"signalRequestPackage\":[{\"request\":{\"id\":{\"id\":12114},\"requestID\":2,\"requestType\":\"priorityRequest\",\"inBoundLane\":{\"lane\":11},\"outBoundLane\":{\"lane\":8}},\"duration\":25172},{\"request\":{\"id\":{\"id\":12114},\"requestID\":1,\"requestType\":\"priorityCancellation\",\"inBoundLane\":{\"lane\":12},\"outBoundLane\":{\"lane\":7}},\"duration\":31032}]},\"requestor\":{\"id\":{\"stationID\":2031825062},\"type\":{\"role\":\"publicTransport\"},\"position\":{\"position\":{\"latitude\":39.5572888,\"longitude\":-105.0834514,\"elevation\":1677.9},\"heading\":207.4000,\"speed\":{\"speed\":14.54,\"transmisson\":\"UNAVAILABLE\"}}}}";
 		assertEquals(expected, actualSrm.toString()); 
 		
 	}


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Fix SRM requests list builder deserialization of the decoder XML output.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#492 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Data is lost otherwise. Currently, the builder leaves the list as an empty list if the XML requests object has more than one request in it.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New unit test with real SRM CDOT data has been used.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
