### PR TITLE
Update BSM schema for partII list

### DIFF
--- a/jpo-ode-core/src/main/resources/schemas/schema-bsm.json
+++ b/jpo-ode-core/src/main/resources/schemas/schema-bsm.json
@@ -2171,7 +2171,6 @@
                                 ]
                             },
                             "maxItems": 8,
-                            "minItems": 1,
                             "type": [
                                 "array",
                                 "null"


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
The BSM schema requires at least 1 item in the partII list. This is not correct since partII data is optional in the J2735. The ODE will always include the field in the output of BSM messages but the list may be empty. This schema change makes it so this scenario does not incorrectly fail schema validation by not enforcing a minimum partII length requirement.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Schema failure for BSM messages with no partII data.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Schema has been validated amongst BSM data without partII data that has been provided by CDOT.

Example: 

`{"metadata":{"bsmSource":"RV","logFileName":"","recordType":"bsmTx","securityResultCode":"success","receivedMessageDetails":{"locationData":{"latitude":"","longitude":"","elevation":"","speed":"","heading":""},"rxSource":"RV"},"payloadType":"us.dot.its.jpo.ode.model.OdeBsmPayload","serialId":{"streamId":"9e436d9d-84f2-475e-a12c-944222faa259","bundleSize":1,"bundleId":0,"recordId":0,"serialNumber":0},"odeReceivedAt":"2023-11-06T22:04:50.810244Z","schemaVersion":6,"maxDurationTime":0,"recordGeneratedAt":"","sanitized":false,"odePacketID":"","odeTimStartDateTime":"","originIp":"172.16.28.105"},"payload":{"data":{"coreData":{"msgCnt":67,"id":"00000002","secMark":0,"position":{"latitude":39.6864296,"longitude":-104.9595063,"elevation":1611.7},"accelSet":{"accelLat":0.0,"accelLong":0.0,"accelVert":0.0,"accelYaw":0.0},"accuracy":{},"transmission":"NEUTRAL","speed":18.3,"heading":182.9,"angle":0.0,"brakes":{"wheelBrakes":{"leftFront":false,"rightFront":false,"unavailable":true,"leftRear":false,"rightRear":false},"traction":"off","abs":"off","scs":"off","brakeBoost":"off","auxBrakes":"off"},"size":{"width":1023,"length":4095}},"partII":[]},"dataType":"us.dot.its.jpo.ode.plugin.j2735.J2735Bsm"}}`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
