### PR TITLE
Duplicate Path Bug Fix

### DIFF
--- a/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/timstorage/NodeSetXY.java
+++ b/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/timstorage/NodeSetXY.java
@@ -7,9 +7,9 @@ import us.dot.its.jpo.ode.plugin.asn1.Asn1Object;
 public class NodeSetXY extends Asn1Object {
   private static final long serialVersionUID = 1L;
 
-  @JsonProperty("NodeXY")
   private NodeXY[] NodeXY;
-
+  
+  @JsonProperty("NodeXY")
   public NodeXY[] getNodeXY() {
     return NodeXY;
   }

--- a/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/timstorage/Nodes.java
+++ b/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/timstorage/Nodes.java
@@ -22,12 +22,12 @@ import us.dot.its.jpo.ode.plugin.asn1.Asn1Object;
 public class Nodes extends Asn1Object {
 
    private static final long serialVersionUID = 1L;
-   @JsonProperty("NodeLL")
    private NodeLL[] nodeLL;
    
    @JsonProperty("NodeXY")
    private NodeXY[] nodeXY;
-
+   
+   @JsonProperty("NodeLL")
    public NodeLL[] getNodeLL() {
       return nodeLL;
    }


### PR DESCRIPTION
Moving JsonProperty declaration to getters to avoid duplicate fetch in serialization/deserialization scenarios

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR moves the "@JsonProperty" declaration in the NodeSetXY and Nodes classes to their respective getters rather than the private property declaration. For some reason, having those on the private property exposed that private property when serializing/deserializing and as a result both the private property and the public getter method were called - causing paths to come out as duplicated.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Solves problem described in description

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Tested locally, and in WYDOT test environment
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
