### PR TITLE
Remove Conflicting Logging Dependencies and Use Spring Boot Logging Configuration

### DIFF
--- a/jpo-ode-plugins/pom.xml
+++ b/jpo-ode-plugins/pom.xml
@@ -36,16 +36,6 @@
       <version>1.0.0-SNAPSHOT</version>
     </dependency>
     -->
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-core</artifactId>
-        <version>1.5.13</version>
-    </dependency>
-
   </dependencies>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,12 +54,6 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.logging.log4j</groupId>
-          <artifactId>log4j-to-slf4j</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -115,11 +109,6 @@
         <version>Camden.SR1</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-core</artifactId>
-        <version>1.5.13</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
# PR Details
## Description
Conflicting logging dependencies have been removed, and the logging configuration provided by Spring Boot is now relied upon. For more information about Spring Boot logging, refer to [Spring Boot Logging](https://www.baeldung.com/spring-boot-logging).

## Related Issue
No related GitHub issue.

## Motivation and Context
Test failures were consistently observed in the CI pipeline after the fork was synced with the USDOT develop branch. Details of the test failures can be found [here](https://github.com/CDOT-CV/jpo-ode/actions/runs/12939914925/job/36093127242?pr=170).

## How Has This Been Tested?
All existing unit and integration tests were executed locally and confirmed to pass.

The services were started using Docker Compose, and the log output was verified to remain unchanged. Log excerpts have been attached for review.

```txt
00:07:04,204 |-INFO in ch.qos.logback.classic.LoggerContext[default] - This is logback-classic version 1.4.11
00:07:04,209 |-INFO in ch.qos.logback.classic.util.ContextInitializer@61386958 - Here is a list of configurators discovered as a service, by rank:
00:07:04,209 |-INFO in ch.qos.logback.classic.util.ContextInitializer@61386958 -   org.springframework.boot.logging.logback.RootLogLevelConfigurator
00:07:04,209 |-INFO in ch.qos.logback.classic.util.ContextInitializer@61386958 - They will be invoked in order until ExecutionStatus.DO_NOT_INVOKE_NEXT_IF_ANY is returned.
00:07:04,209 |-INFO in ch.qos.logback.classic.util.ContextInitializer@61386958 - Constructed configurator of type class org.springframework.boot.logging.logback.RootLogLevelConfigurator
00:07:04,220 |-INFO in ch.qos.logback.classic.util.ContextInitializer@61386958 - org.springframework.boot.logging.logback.RootLogLevelConfigurator.configure() call lasted 1 milliseconds. ExecutionStatus=INVOKE_NEXT_IF_ANY
00:07:04,220 |-INFO in ch.qos.logback.classic.util.ContextInitializer@61386958 - Trying to configure with ch.qos.logback.classic.joran.SerializedModelConfigurator
00:07:04,221 |-INFO in ch.qos.logback.classic.util.ContextInitializer@61386958 - Constructed configurator of type class ch.qos.logback.classic.joran.SerializedModelConfigurator
00:07:04,239 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback-test.scmo]
00:07:04,240 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback.scmo]
00:07:04,240 |-INFO in ch.qos.logback.classic.util.ContextInitializer@61386958 - ch.qos.logback.classic.joran.SerializedModelConfigurator.configure() call lasted 19 milliseconds. ExecutionStatus=INVOKE_NEXT_IF_ANY
00:07:04,240 |-INFO in ch.qos.logback.classic.util.ContextInitializer@61386958 - Trying to configure with ch.qos.logback.classic.util.DefaultJoranConfigurator
00:07:04,241 |-INFO in ch.qos.logback.classic.util.ContextInitializer@61386958 - Constructed configurator of type class ch.qos.logback.classic.util.DefaultJoranConfigurator
00:07:04,241 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback-test.xml]
00:07:04,242 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Found resource [logback.xml] at [file:/tmp/22d567a4-e689-4fc9-9bbd-1f1bef57ed06/logback.xml]
00:07:04,466 |-INFO in ch.qos.logback.classic.model.processor.ConfigurationModelHandlerFull - Registering a new ReconfigureOnChangeTask ReconfigureOnChangeTask(born:1737677224462)
00:07:04,467 |-INFO in ch.qos.logback.classic.model.processor.ConfigurationModelHandlerFull - No 'scanPeriod' specified. Defaulting to 1 minutes
00:07:04,467 |-INFO in ch.qos.logback.classic.model.processor.ConfigurationModelHandlerFull - Will scan for changes in [file:/tmp/22d567a4-e689-4fc9-9bbd-1f1bef57ed06/logback.xml]
00:07:04,468 |-INFO in ch.qos.logback.classic.model.processor.ConfigurationModelHandlerFull - Setting ReconfigureOnChangeTask scanning period to 1 minutes
00:07:04,482 |-WARN in ch.qos.logback.core.model.processor.ImplicitModelHandler - Ignoring unknown property [jmxConfigurator] in [ch.qos.logback.classic.LoggerContext]
00:07:04,485 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - Processing appender named [STDOUT]
00:07:04,486 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - About to instantiate appender of type [ch.qos.logback.core.ConsoleAppender]
00:07:04,492 |-INFO in ch.qos.logback.core.model.processor.ImplicitModelHandler - Assuming default type [ch.qos.logback.classic.encoder.PatternLayoutEncoder] for [encoder] property
00:07:04,521 |-INFO in ch.qos.logback.classic.pattern.DateConverter@2892d68 - Setting zoneId to "UTC"
00:07:04,524 |-INFO in ch.qos.logback.classic.model.processor.RootLoggerModelHandler - Setting level of ROOT logger to WARN
00:07:04,525 |-INFO in ch.qos.logback.core.model.processor.AppenderRefModelHandler - Attaching appender named [STDOUT] to Logger[ROOT]
00:07:04,526 |-INFO in ch.qos.logback.core.model.processor.DefaultProcessor@2a7f1f10 - End of configuration.
00:07:04,528 |-INFO in ch.qos.logback.classic.joran.JoranConfigurator@f78a47e - Registering current configuration as safe fallback point
00:07:04,528 |-INFO in ch.qos.logback.classic.util.ContextInitializer@61386958 - ch.qos.logback.classic.util.DefaultJoranConfigurator.configure() call lasted 287 milliseconds. ExecutionStatus=DO_NOT_INVOKE_NEXT_IF_ANY
00:07:05,396 |-INFO in ch.qos.logback.classic.model.processor.ConfigurationModelHandlerFull - Registering a new ReconfigureOnChangeTask ReconfigureOnChangeTask(born:1737677225396)
00:07:05,397 |-INFO in ch.qos.logback.classic.model.processor.ConfigurationModelHandlerFull - No 'scanPeriod' specified. Defaulting to 1 minutes
00:07:05,397 |-INFO in ch.qos.logback.classic.model.processor.ConfigurationModelHandlerFull - Will scan for changes in [file:/tmp/22d567a4-e689-4fc9-9bbd-1f1bef57ed06/logback.xml]
00:07:05,397 |-INFO in ch.qos.logback.classic.model.processor.ConfigurationModelHandlerFull - Setting ReconfigureOnChangeTask scanning period to 1 minutes
00:07:05,399 |-WARN in ch.qos.logback.core.model.processor.ImplicitModelHandler - Ignoring unknown property [jmxConfigurator] in [ch.qos.logback.classic.LoggerContext]
00:07:05,399 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - Processing appender named [STDOUT]
00:07:05,399 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - About to instantiate appender of type [ch.qos.logback.core.ConsoleAppender]
00:07:05,401 |-INFO in ch.qos.logback.core.model.processor.ImplicitModelHandler - Assuming default type [ch.qos.logback.classic.encoder.PatternLayoutEncoder] for [encoder] property
00:07:05,404 |-INFO in ch.qos.logback.classic.pattern.DateConverter@4639acda - Setting zoneId to "UTC"
00:07:05,405 |-INFO in ch.qos.logback.classic.model.processor.RootLoggerModelHandler - Setting level of ROOT logger to WARN
00:07:05,406 |-INFO in ch.qos.logback.classic.jul.LevelChangePropagator@552a8dcf - Propagating WARN level on Logger[ROOT] onto the JUL framework
00:07:05,407 |-INFO in ch.qos.logback.core.model.processor.AppenderRefModelHandler - Attaching appender named [STDOUT] to Logger[ROOT]
00:07:05,407 |-INFO in ch.qos.logback.core.model.processor.DefaultProcessor@1751b4b1 - End of configuration.
00:07:05,407 |-INFO in org.springframework.boot.logging.logback.SpringBootJoranConfigurator@22fecedb - Registering current configuration as safe fallback point

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/
 :: Spring Boot ::                (v3.1.3)

2025-01-24 00:07:25 [pool-4-thread-1] [,] WARN  TimIngestWatcher - ODE has not received TIM deposits in 15 seconds.
2025-01-24 00:07:38 [KeyedOdeTimJson-16d302f9-406a-482d-838d-0c7966bb6254-StreamThread-1] [,] WARN  KTableSource - Skipping record due to null key. topic=[topic.OdeTimJson] partition=[0] offset=[0]
2025-01-24 00:07:39 [KeyedOdeTimJson-16d302f9-406a-482d-838d-0c7966bb6254-StreamThread-1] [,] WARN  KTableSource - Skipping record due to null key. topic=[topic.OdeTimJson] partition=[0] offset=[1]
2025-01-24 00:07:40 [KeyedOdeTimJson-16d302f9-406a-482d-838d-0c7966bb6254-StreamThread-1] [,] WARN  KTableSource - Skipping record due to null key. topic=[topic.OdeTimJson] partition=[0] offset=[2]
2025-01-24 00:07:40 [pool-4-thread-1] [,] WARN  TimIngestWatcher - ODE has not received TIM deposits in 15 seconds.
2025-01-24 00:07:40 [KeyedOdeTimJson-16d302f9-406a-482d-838d-0c7966bb6254-StreamThread-1] [,] WARN  KTableSource - Skipping record due to null key. topic=[topic.OdeTimJson] partition=[0] offset=[3]
2025-01-24 00:07:41 [KeyedOdeTimJson-16d302f9-406a-482d-838d-0c7966bb6254-StreamThread-1] [,] WARN  KTableSource - Skipping record due to null key. topic=[topic.OdeTimJson] partition=[0] offset=[4]
2025-01-24 00:07:42 [KeyedOdeTimJson-16d302f9-406a-482d-838d-0c7966bb6254-StreamThread-1] [,] WARN  KTableSource - Skipping record due to null key. topic=[topic.OdeTimJson] partition=[0] offset=[5]
2025-01-24 00:07:43 [KeyedOdeTimJson-16d302f9-406a-482d-838d-0c7966bb6254-StreamThread-1] [,] WARN  KTableSource - Skipping record due to null key. topic=[topic.OdeTimJson] partition=[0] offset=[6]
2025-01-24 00:07:44 [KeyedOdeTimJson-16d302f9-406a-482d-838d-0c7966bb6254-StreamThread-1] [,] WARN  KTableSource - Skipping record due to null key. topic=[topic.OdeTimJson] partition=[0] offset=[7]
2025-01-24 00:07:45 [KeyedOdeTimJson-16d302f9-406a-482d-838d-0c7966bb6254-StreamThread-1] [,] WARN  KTableSource - Skipping record due to null key. topic=[topic.OdeTimJson] partition=[0] offset=[8]
2025-01-24 00:07:46 [KeyedOdeTimJson-16d302f9-406a-482d-838d-0c7966bb6254-StreamThread-1] [,] WARN  KTableSource - Skipping record due to null key. topic=[topic.OdeTimJson] partition=[0] offset=[9]
2025-01-24 00:07:47 [KeyedOdeTimJson-16d302f9-406a-482d-838d-0c7966bb6254-StreamThread-1] [,] WARN  KTableSource - Skipping record due to null key. topic=[topic.OdeTimJson] partition=[0] offset=[10]
2025-01-24 00:07:48 [KeyedOdeTimJson-16d302f9-406a-482d-838d-0c7966bb6254-StreamThread-1] [,] WARN  KTableSource - Skipping record due to null key. topic=[topic.OdeTimJson] partition=[0] offset=[11]
2025-01-24 00:07:49 [KeyedOdeTimJson-16d302f9-406a-482d-838d-0c7966bb6254-StreamThread-1] [,] WARN  KTableSource - Skipping record due to null key. topic=[topic.OdeTimJson] partition=[0] offset=[12]
2025-01-24 00:07:50 [KeyedOdeTimJson-16d302f9-406a-482d-838d-0c7966bb6254-StreamThread-1] [,] WARN  KTableSource - Skipping record due to null key. topic=[topic.OdeTimJson] partition=[0] offset=[13]
2025-01-24 00:07:51 [KeyedOdeTimJson-16d302f9-406a-482d-838d-0c7966bb6254-StreamThread-1] [,] WARN  KTableSource - Skipping record due to null key. topic=[topic.OdeTimJson] partition=[0] offset=[14]
2025-01-24 00:07:52 [KeyedOdeTimJson-16d302f9-406a-482d-838d-0c7966bb6254-StreamThread-1] [,] WARN  KTableSource - Skipping record due to null key. topic=[topic.OdeTimJson] partition=[0] offset=[15]
2025-01-24 00:07:53 [KeyedOdeTimJson-16d302f9-406a-482d-838d-0c7966bb6254-StreamThread-1] [,] WARN  KTableSource - Skipping record due to null key. topic=[topic.OdeTimJson] partition=[0] offset=[16]
2025-01-24 00:07:54 [KeyedOdeTimJson-16d302f9-406a-482d-838d-0c7966bb6254-StreamThread-1] [,] WARN  KTableSource - Skipping record due to null key. topic=[topic.OdeTimJson] partition=[0] offset=[17]
2025-01-24 00:07:54 [KeyedOdeTimJson-16d302f9-406a-482d-838d-0c7966bb6254-StreamThread-1] [,] WARN  KTableSource - Skipping record due to null key. topic=[topic.OdeTimJson] partition=[0] offset=[18]
2025-01-24 00:07:55 [pool-4-thread-1] [,] WARN  TimIngestWatcher - ODE has not received TIM deposits in 15 seconds.
2025-01-24 00:07:55 [KeyedOdeTimJson-16d302f9-406a-482d-838d-0c7966bb6254-StreamThread-1] [,] WARN  KTableSource - Skipping record due to null key. topic=[topic.OdeTimJson] partition=[0] offset=[19]
2025-01-24 00:07:56 [KeyedOdeTimJson-16d302f9-406a-482d-838d-0c7966bb6254-StreamThread-1] [,] WARN  KTableSource - Skipping record due to null key. topic=[topic.OdeTimJson] partition=[0] offset=[20]
2025-01-24 00:07:57 [KeyedOdeTimJson-16d302f9-406a-482d-838d-0c7966bb6254-StreamThread-1] [,] WARN  KTableSource - Skipping record due to null key. topic=[topic.OdeTimJson] partition=[0] offset=[21]
2025-01-24 00:07:58 [KeyedOdeTimJson-16d302f9-406a-482d-838d-0c7966bb6254-StreamThread-1] [,] WARN  KTableSource - Skipping record due to null key. topic=[topic.OdeTimJson] partition=[0] offset=[22]
2025-01-24 00:07:59 [KeyedOdeTimJson-16d302f9-406a-482d-838d-0c7966bb6254-StreamThread-1] [,] WARN  KTableSource - Skipping record due to null key. topic=[topic.OdeTimJson] partition=[0] offset=[23]
2025-01-24 00:08:00 [KeyedOdeTimJson-16d302f9-406a-482d-838d-0c7966bb6254-StreamThread-1] [,] WARN  KTableSource - Skipping record due to null key. topic=[topic.OdeTimJson] partition=[0] offset=[24]
2025-01-24 00:08:01 [KeyedOdeTimJson-16d302f9-406a-482d-838d-0c7966bb6254-StreamThread-1] [,] WARN  KTableSource - Skipping record due to null key. topic=[topic.OdeTimJson] partition=[0] offset=[25]
2025-01-24 00:08:02 [KeyedOdeTimJson-16d302f9-406a-482d-838d-0c7966bb6254-StreamThread-1] [,] WARN  KTableSource - Skipping record due to null key. topic=[topic.OdeTimJson] partition=[0] offset=[26]
2025-01-24 00:08:03 [KeyedOdeTimJson-16d302f9-406a-482d-838d-0c7966bb6254-StreamThread-1] [,] WARN  KTableSource - Skipping record due to null key. topic=[topic.OdeTimJson] partition=[0] offset=[27]
2025-01-24 00:08:04 [KeyedOdeTimJson-16d302f9-406a-482d-838d-0c7966bb6254-StreamThread-1] [,] WARN  KTableSource - Skipping record due to null key. topic=[topic.OdeTimJson] partition=[0] offset=[28]
2025-01-24 00:08:05 [KeyedOdeTimJson-16d302f9-406a-482d-838d-0c7966bb6254-StreamThread-1] [,] WARN  KTableSource - Skipping record due to null key. topic=[topic.OdeTimJson] partition=[0] offset=[29]

```

## Types of changes
- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:
- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
