### PR TITLE
Dev

### DIFF
--- a/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/builders/TravelerMessageFromHumanToAsnConverter.java
+++ b/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/builders/TravelerMessageFromHumanToAsnConverter.java
@@ -126,8 +126,7 @@ public class TravelerMessageFromHumanToAsnConverter {
   public static final String BOOLEAN_OBJECT_TRUE = "BOOLEAN_OBJECT_TRUE";
   public static final String BOOLEAN_OBJECT_FALSE = "BOOLEAN_OBJECT_FALSE";
 
-  private static final Logger logger =
-      LoggerFactory.getLogger(TravelerMessageFromHumanToAsnConverter.class);
+  private static final Logger logger = LoggerFactory.getLogger(TravelerMessageFromHumanToAsnConverter.class);
 
   private TravelerMessageFromHumanToAsnConverter() {
     super();
@@ -142,7 +141,7 @@ public class TravelerMessageFromHumanToAsnConverter {
    * @throws IllegalArgumentException if the JsonNode contains old fields that are no longer used
    */
   public static void convertTravelerInputDataToEncodableTim(JsonNode tid)
-      throws JsonUtilsException, NoncompliantFieldsException {
+      throws JsonUtilsException, NoncompliantFieldsException, InvalidNodeLatLonOffsetException {
     // msgCnt MsgCount,
     // timeStamp MinuteOfTheYear OPTIONAL
     // packetID UniqueMSGID OPTIONAL
@@ -154,15 +153,13 @@ public class TravelerMessageFromHumanToAsnConverter {
 
     // timeStamp is optional
     if (timDataObjectNode.get(TIME_STAMP) != null) {
-      timDataObjectNode.put(TIME_STAMP,
-          translateISOTimeStampToMinuteOfYear(timDataObjectNode.get(TIME_STAMP).asText()));
+      timDataObjectNode.put(TIME_STAMP, translateISOTimeStampToMinuteOfYear(timDataObjectNode.get(TIME_STAMP).asText()));
     }
 
     // urlB is optional but does not need replacement
 
     // dataFrames are required
-    timDataObjectNode.set(DATA_FRAMES_STRING,
-        transformDataFrames(timDataObjectNode.get(DATAFRAMES)));
+    timDataObjectNode.set(DATA_FRAMES_STRING, transformDataFrames(timDataObjectNode.get(DATAFRAMES)));
     timDataObjectNode.remove(DATAFRAMES);
   }
 
@@ -175,7 +172,7 @@ public class TravelerMessageFromHumanToAsnConverter {
    * @throws NoncompliantFieldsException if the JsonNode contains old fields that are no longer used
    */
   public static ObjectNode transformDataFrames(JsonNode dataFrames)
-      throws JsonUtilsException, NoncompliantFieldsException {
+      throws JsonUtilsException, NoncompliantFieldsException, InvalidNodeLatLonOffsetException {
 
     if (dataFrames == null) {
       return JsonUtils.newNode();
@@ -203,8 +200,7 @@ public class TravelerMessageFromHumanToAsnConverter {
    * @throws JsonUtilsException          if there is an issue converting the JsonNode
    * @throws NoncompliantFieldsException if the JsonNode contains old fields that are no longer used
    */
-  public static void replaceDataFrame(ObjectNode dataFrame)
-      throws JsonUtilsException, NoncompliantFieldsException {
+  public static void replaceDataFrame(ObjectNode dataFrame) throws JsonUtilsException, NoncompliantFieldsException, InvalidNodeLatLonOffsetException {
 
     // INPUT
     //////
@@ -244,8 +240,7 @@ public class TravelerMessageFromHumanToAsnConverter {
     // </dataFrames>
 
     // set frameType value
-    dataFrame.set("frameType",
-        JsonUtils.newNode().put(dataFrame.get("frameType").asText(), EMPTY_FIELD_FLAG));
+    dataFrame.set("frameType", JsonUtils.newNode().put(dataFrame.get("frameType").asText(), EMPTY_FIELD_FLAG));
 
     ensureComplianceWithJ2735Revision2024(dataFrame);
 
@@ -276,13 +271,9 @@ public class TravelerMessageFromHumanToAsnConverter {
     try {
       ZonedDateTime zonedDateTime = DateTimeUtils.isoDateTime(isoTime);
       startYear = zonedDateTime.getYear();
-      startMinute =
-          (int) Duration.between(DateTimeUtils.isoDateTime(startYear, 1, 1, 0,
-                  0, 0, 0), zonedDateTime)
-              .toMinutes();
+      startMinute = (int) Duration.between(DateTimeUtils.isoDateTime(startYear, 1, 1, 0, 0, 0, 0), zonedDateTime).toMinutes();
     } catch (Exception e) { // NOSONAR
-      logger.error("Failed to parse datetime {}, defaulting to unknown value {}", isoTime,
-          startMinute);
+      logger.error("Failed to parse datetime {}, defaulting to unknown value {}", isoTime, startMinute);
     }
 
     return startMinute;
@@ -310,12 +301,9 @@ public class TravelerMessageFromHumanToAsnConverter {
     try {
       ZonedDateTime zonedDateTime = DateTimeUtils.isoDateTime(startDateTime);
       startYear = zonedDateTime.getYear();
-      startMinute =
-          (int) ChronoUnit.MINUTES.between(DateTimeUtils.isoDateTime(startYear, 1, 1, 0, 0, 0, 0),
-              zonedDateTime);
+      startMinute = (int) ChronoUnit.MINUTES.between(DateTimeUtils.isoDateTime(startYear, 1, 1, 0, 0, 0, 0), zonedDateTime);
     } catch (Exception e) {
-      logger.error("Failed to startDateTime {}, defaulting to unknown value {}.", startDateTime,
-          startMinute);
+      logger.error("Failed to startDateTime {}, defaulting to unknown value {}.", startDateTime, startMinute);
     }
 
     dataFrame.put("startYear", startYear);
@@ -430,16 +418,14 @@ public class TravelerMessageFromHumanToAsnConverter {
       ObjectNode roadSignID = (ObjectNode) msgId.get("roadSignID");
       if (roadSignID != null) {
 
-        DsrcPosition3D position = Position3DBuilder
-            .dsrcPosition3D(Position3DBuilder.odePosition3D(roadSignID.get(POSITION)));
+        DsrcPosition3D position = Position3DBuilder.dsrcPosition3D(Position3DBuilder.odePosition3D(roadSignID.get(POSITION)));
 
         roadSignID.putPOJO(POSITION, position);
 
         // mutcdCode is optional
         JsonNode mutcdNode = roadSignID.get("mutcdCode");
         if (mutcdNode != null) {
-          roadSignID.set("mutcdCode",
-              JsonUtils.newNode().put(mutcdNode.asText(), EMPTY_FIELD_FLAG));
+          roadSignID.set("mutcdCode", JsonUtils.newNode().put(mutcdNode.asText(), EMPTY_FIELD_FLAG));
         }
       }
     }
@@ -452,7 +438,7 @@ public class TravelerMessageFromHumanToAsnConverter {
    * @return ObjectNode representing the transformed regions
    * @throws JsonUtilsException if there is an issue converting the JsonNode
    */
-  public static ObjectNode transformRegions(JsonNode regions) throws JsonUtilsException {
+  public static ObjectNode transformRegions(JsonNode regions) throws JsonUtilsException, InvalidNodeLatLonOffsetException {
     ArrayNode replacedRegions = JsonUtils.newNode().arrayNode();
 
     if (regions.isArray()) {
@@ -474,7 +460,7 @@ public class TravelerMessageFromHumanToAsnConverter {
    * @param region ObjectNode representing the region
    * @throws JsonUtilsException if there is an issue converting the JsonNode
    */
-  public static void replaceRegion(ObjectNode region) throws JsonUtilsException {
+  public static void replaceRegion(ObjectNode region) throws JsonUtilsException, InvalidNodeLatLonOffsetException {
 
     //// EXPECTED INPUT:
     // "name": "Testing TIM",
@@ -530,8 +516,7 @@ public class TravelerMessageFromHumanToAsnConverter {
       region.set(ID, id);
     }
     // replace regulatorID and segmentID with id
-    ObjectNode id = JsonUtils.newNode().put(REGION, region.get(REGULATOR_ID).asInt()).put(ID,
-        region.get(SEGMENT_ID).asInt());
+    ObjectNode id = JsonUtils.newNode().put(REGION, region.get(REGULATOR_ID).asInt()).put(ID, region.get(SEGMENT_ID).asInt());
 
     region.set(ID, id);
     region.remove(REGULATOR_ID);
@@ -540,8 +525,8 @@ public class TravelerMessageFromHumanToAsnConverter {
     // anchorPosition --> anchor (optional)
     JsonNode anchorPos = region.get(ANCHOR_POSITION);
     if (anchorPos != null) {
-      region.set(ANCHOR, JsonUtils.toObjectNode(Position3DBuilder
-          .dsrcPosition3D(Position3DBuilder.odePosition3D(region.get(ANCHOR_POSITION))).toJson()));
+      region.set(ANCHOR,
+          JsonUtils.toObjectNode(Position3DBuilder.dsrcPosition3D(Position3DBuilder.odePosition3D(region.get(ANCHOR_POSITION))).toJson()));
       region.remove(ANCHOR_POSITION);
     }
 
@@ -554,8 +539,7 @@ public class TravelerMessageFromHumanToAsnConverter {
     // directionality (optional)
     if (region.has(DIRECTIONALITY)) {
       JsonNode directionality = region.get(DIRECTIONALITY);
-      String enumString =
-          CommonUtils.enumToString(DirectionOfUseEnum.class, directionality.asText());
+      String enumString = CommonUtils.enumToString(DirectionOfUseEnum.class, directionality.asText());
       if (enumString != null) {
         region.set(DIRECTIONALITY, JsonUtils.newNode().put(enumString, EMPTY_FIELD_FLAG));
       }
@@ -564,8 +548,7 @@ public class TravelerMessageFromHumanToAsnConverter {
     // closed path (optional)
     JsonNode closedPath = region.get(CLOSED_PATH);
     if (closedPath != null) {
-      region.put(CLOSED_PATH,
-          (closedPath.asBoolean() ? BOOLEAN_OBJECT_TRUE : BOOLEAN_OBJECT_FALSE));
+      region.put(CLOSED_PATH, (closedPath.asBoolean() ? BOOLEAN_OBJECT_TRUE : BOOLEAN_OBJECT_FALSE));
     }
 
     // description (optional)
@@ -589,7 +572,7 @@ public class TravelerMessageFromHumanToAsnConverter {
     }
   }
 
-  private static void replacePath(ObjectNode pathNode) {
+  private static void replacePath(ObjectNode pathNode) throws InvalidNodeLatLonOffsetException {
 
     //// EXPECTED INPUT:
     // "path":
@@ -624,7 +607,7 @@ public class TravelerMessageFromHumanToAsnConverter {
 
   }
 
-  private static ArrayNode transformNodeSetLL(JsonNode nodes) {
+  private static ArrayNode transformNodeSetLL(JsonNode nodes) throws InvalidNodeLatLonOffsetException {
 
     //// EXPECTED INPUT:
     // "nodes": []
@@ -651,7 +634,7 @@ public class TravelerMessageFromHumanToAsnConverter {
     return outputNodeList;
   }
 
-  private static ObjectNode transformNodeLL(JsonNode oldNode) {
+  protected static ObjectNode transformNodeLL(JsonNode oldNode) throws InvalidNodeLatLonOffsetException {
 
     //// EXPECTED INPUT:
 
@@ -682,7 +665,7 @@ public class TravelerMessageFromHumanToAsnConverter {
       transformedLat = OffsetLLBuilder.offsetLL(latOffset);
       transformedLong = OffsetLLBuilder.offsetLL(longOffset);
       if (deltaText.equals("node-LL")) {
-        deltaText = nodeOffsetPointLL(transformedLat, transformedLong);
+        deltaText = getNodeOffsetPointLLType(transformedLat, transformedLong);
       }
     } else if (NODE_LAT_LON.equals(deltaText)) {
       transformedLat = LatitudeBuilder.j2735Latitude(latOffset);
@@ -691,63 +674,58 @@ public class TravelerMessageFromHumanToAsnConverter {
 
     innerNode.set(deltaText, latLong);
     latLong.put(LAT, transformedLat).put(LON, transformedLong);
-    ObjectNode deltaNode = JsonUtils.newNode().set(DELTA, innerNode);
-    return deltaNode;
+    return JsonUtils.newNode().set(DELTA, innerNode);
   }
 
   // -- Nodes with LL content Span at the equator when using a zoom of one:
-  // node-LL1 Node-LL-24B, -- within +- 22.634554 meters of last node
-  // node-LL2 Node-LL-28B, -- within +- 90.571389 meters of last node
-  // node-LL3 Node-LL-32B, -- within +- 362.31873 meters of last node
-  // node-LL4 Node-LL-36B, -- within +- 01.449308 Kmeters of last node
-  // node-LL5 Node-LL-44B, -- within +- 23.189096 Kmeters of last node
-  // node-LL6 Node-LL-48B, -- within +- 92.756481 Kmeters of last node
-  // node-LatLon Node-LLmD-64b, -- node is a full 32b Lat/Lon range
-  private static String nodeOffsetPointLL(long transformedLat, long transformedLon) {
-    long transformedLatabs = Math.abs(transformedLat);
-    long transformedLonabs = Math.abs(transformedLon);
-    if (((transformedLatabs & (-1 << 11)) == 0
-        || (transformedLat < 0 && (transformedLatabs ^ (1 << 11)) == 0))
-        && (transformedLonabs & (-1 << 11)) == 0
-        || (transformedLon < 0 && ((transformedLonabs ^ (1 << 11)) == 0))) {
-      // 11 bit value
-      return "node-LL1";
-    } else if (((transformedLatabs & (-1 << 13)) == 0
-        || (transformedLat < 0 && (transformedLatabs ^ (1 << 13)) == 0))
-        && (transformedLonabs & (-1 << 13)) == 0
-        || (transformedLon < 0 && ((transformedLonabs ^ (1 << 13)) == 0))) {
-      // 13 bit value
-      return "node-LL2";
-    } else if (((transformedLatabs & (-1 << 15)) == 0
-        || (transformedLat < 0 && (transformedLatabs ^ (1 << 15)) == 0))
-        && (transformedLonabs & (-1 << 15)) == 0
-        || (transformedLon < 0 && ((transformedLonabs ^ (1 << 15)) == 0))) {
-      // 15 bit value
-      return "node-LL3";
-    } else if (((transformedLatabs & (-1 << 17)) == 0
-        || (transformedLat < 0 && (transformedLatabs ^ (1 << 17)) == 0))
-        && (transformedLonabs & (-1 << 17)) == 0
-        || (transformedLon < 0 && ((transformedLonabs ^ (1 << 17)) == 0))) {
-      // 17 bit value
-      return "node-LL4";
-    } else if (((transformedLatabs & (-1 << 21)) == 0
-        || (transformedLat < 0 && (transformedLatabs ^ (1 << 21)) == 0))
-        && (transformedLonabs & (-1 << 21)) == 0
-        || (transformedLon < 0 && ((transformedLonabs ^ (1 << 21)) == 0))) {
-      // 21 bit value
-      return "node-LL5";
-    } else if (((transformedLatabs & (-1 << 23)) == 0
-        || (transformedLat < 0 && (transformedLatabs ^ (1 << 23)) == 0))
-        && (transformedLonabs & (-1 << 23)) == 0
-        || (transformedLon < 0 && ((transformedLonabs ^ (1 << 23)) == 0))) {
-      // 23 bit value
-      return "node-LL6";
-    } else {
-      throw new IllegalArgumentException(
-          "Invalid node lat/long offset: " + transformedLat + "/" + transformedLon
-              + ". Values must be between a range of -0.8388608/+0.8388607 degrees.");
-    }
+  protected static final String NODE_LL1 = "node-LL1"; // Node-LL-24B, within ±22.634554 meters of last node
+  protected static final String NODE_LL2 = "node-LL2"; // Node-LL-28B, within ±90.571389 meters of last node
+  protected static final String NODE_LL3 = "node-LL3"; // Node-LL-32B, within ±362.31873 meters of last node
+  protected static final String NODE_LL4 = "node-LL4"; // Node-LL-36B, within ±1.449308 kilometers of last node
+  protected static final String NODE_LL5 = "node-LL5"; // Node-LL-44B, within ±23.189096 kilometers of last node
+  protected static final String NODE_LL6 = "node-LL6"; // Node-LL-48B, within ±92.756481 kilometers of last node
 
+  // -- Limits for each node type
+  protected final static long NODE_LL1_LIMIT = 2047;
+  protected final static long NODE_LL2_LIMIT = 8191;
+  protected final static long NODE_LL3_LIMIT = 32767;
+  protected final static long NODE_LL4_LIMIT = 131071;
+  protected final static long NODE_LL5_LIMIT = 2097151;
+  protected final static long NODE_LL6_LIMIT = 8388607;
+  // In J2735, the value -8388608 indicates an unknown value and is considered invalid because it falls outside the acceptable ± range.
+
+  /**
+   * Determines the node offset point LL type based on the latitude and longitude deltas.
+   * The method evaluates the absolute values of the deltas against predefined limits to determine
+   * the appropriate node type. If the deltas do not fit within any allowed ranges, an exception
+   * is thrown.
+   *
+   * @param latDelta The latitude delta as a long value.
+   * @param lonDelta The longitude delta as a long value.
+   * @return A string representing the node offset point LL type (e.g., NODE_LL1, NODE_LL2, etc.).
+   * @throws InvalidNodeLatLonOffsetException if latDelta or lonDelta are outside the permissible range
+   *                                          of -0.8388608 to +0.8388607 degrees.
+   */
+  protected static String getNodeOffsetPointLLType(long latDelta, long lonDelta) throws InvalidNodeLatLonOffsetException {
+    long absLatDelta = Math.abs(latDelta);
+    long absLonDelta = Math.abs(lonDelta);
+
+    if (absLatDelta <= NODE_LL1_LIMIT && absLonDelta <= NODE_LL1_LIMIT) {
+      return NODE_LL1;
+    } else if (absLatDelta <= NODE_LL2_LIMIT && absLonDelta <= NODE_LL2_LIMIT) {
+      return NODE_LL2;
+    } else if (absLatDelta <= NODE_LL3_LIMIT && absLonDelta <= NODE_LL3_LIMIT) {
+      return NODE_LL3;
+    } else if (absLatDelta <= NODE_LL4_LIMIT && absLonDelta <= NODE_LL4_LIMIT) {
+      return NODE_LL4;
+    } else if (absLatDelta <= NODE_LL5_LIMIT && absLonDelta <= NODE_LL5_LIMIT) {
+      return NODE_LL5;
+    } else if (absLatDelta <= NODE_LL6_LIMIT && absLonDelta <= NODE_LL6_LIMIT) {
+      return NODE_LL6;
+    } else {
+      throw new InvalidNodeLatLonOffsetException(
+          "Invalid node lat/long offset: " + latDelta + "/" + lonDelta + ". Values must be within a range of -0.8388607/+0.8388607 degrees.");
+    }
   }
 
   /**
@@ -830,9 +808,7 @@ public class TravelerMessageFromHumanToAsnConverter {
 
     // replace anchor (optional)
     if (updatedNode.get(ANCHOR_POSITION) != null) {
-      JsonUtils.addNode(updatedNode, ANCHOR,
-          Position3DBuilder.dsrcPosition3D(
-              Position3DBuilder.odePosition3D(updatedNode.get(ANCHOR_POSITION))));
+      JsonUtils.addNode(updatedNode, ANCHOR, Position3DBuilder.dsrcPosition3D(Position3DBuilder.odePosition3D(updatedNode.get(ANCHOR_POSITION))));
       updatedNode.remove(ANCHOR_POSITION);
     }
 
@@ -855,7 +831,7 @@ public class TravelerMessageFromHumanToAsnConverter {
 
     ObjectNode updatedNode = (ObjectNode) circle;
 
-    JsonNode centerPosition = null;
+    JsonNode centerPosition;
     if (updatedNode.has(POSITION)) {
       centerPosition = updatedNode.get(POSITION);
       updatedNode.remove(POSITION);
@@ -864,8 +840,7 @@ public class TravelerMessageFromHumanToAsnConverter {
     }
 
     // replace center
-    JsonUtils.addNode(updatedNode, CENTER,
-        Position3DBuilder.dsrcPosition3D(Position3DBuilder.odePosition3D(centerPosition)));
+    JsonUtils.addNode(updatedNode, CENTER, Position3DBuilder.dsrcPosition3D(Position3DBuilder.odePosition3D(centerPosition)));
 
     // radius does not need replacement
 
@@ -895,22 +870,18 @@ public class TravelerMessageFromHumanToAsnConverter {
 
     // replace anchor
     if (updatedNode.has(ANCHOR)) {
-      JsonUtils.addNode(updatedNode, ANCHOR,
-          Position3DBuilder.dsrcPosition3D(
-              Position3DBuilder.odePosition3D(updatedNode.get(ANCHOR))));
+      JsonUtils.addNode(updatedNode, ANCHOR, Position3DBuilder.dsrcPosition3D(Position3DBuilder.odePosition3D(updatedNode.get(ANCHOR))));
     }
 
     // replace lane width
     if (updatedNode.has(LANE_WIDTH)) {
-      updatedNode.put(LANE_WIDTH,
-          LaneWidthBuilder.laneWidth(JsonUtils.decimalValue(updatedNode.get(LANE_WIDTH))));
+      updatedNode.put(LANE_WIDTH, LaneWidthBuilder.laneWidth(JsonUtils.decimalValue(updatedNode.get(LANE_WIDTH))));
     }
 
     // replace directionality
     if (updatedNode.has(DIRECTIONALITY)) {
       JsonNode directionality = updatedNode.get(DIRECTIONALITY);
-      String enumString =
-          CommonUtils.enumToString(DirectionOfUseEnum.class, directionality.asText());
+      String enumString = CommonUtils.enumToString(DirectionOfUseEnum.class, directionality.asText());
       if (enumString != null) {
         updatedNode.set(DIRECTIONALITY, JsonUtils.newNode().put(enumString, EMPTY_FIELD_FLAG));
       }
@@ -953,20 +924,17 @@ public class TravelerMessageFromHumanToAsnConverter {
 
     // rotateXY Angle OPTIONAL
     if (updatedNode.has(ROTATE_XY)) {
-      updatedNode.put(ROTATE_XY,
-          AngleBuilder.angle(JsonUtils.decimalValue(updatedNode.get(ROTATE_XY))));
+      updatedNode.put(ROTATE_XY, AngleBuilder.angle(JsonUtils.decimalValue(updatedNode.get(ROTATE_XY))));
     }
 
     // scaleXaxis Scale-B12 OPTIONAL
     if (updatedNode.has(SCALE_X_AXIS)) {
-      updatedNode.put(SCALE_X_AXIS,
-          ScaleB12Builder.scaleB12(JsonUtils.decimalValue(updatedNode.get(SCALE_X_AXIS))));
+      updatedNode.put(SCALE_X_AXIS, ScaleB12Builder.scaleB12(JsonUtils.decimalValue(updatedNode.get(SCALE_X_AXIS))));
     }
 
     // scaleYaxis Scale-B12 OPTIONAL
     if (updatedNode.has(SCALE_Y_AXIS)) {
-      updatedNode.put(SCALE_Y_AXIS,
-          ScaleB12Builder.scaleB12(JsonUtils.decimalValue(updatedNode.get(SCALE_Y_AXIS))));
+      updatedNode.put(SCALE_Y_AXIS, ScaleB12Builder.scaleB12(JsonUtils.decimalValue(updatedNode.get(SCALE_Y_AXIS))));
     }
   }
 
@@ -1062,13 +1030,11 @@ public class TravelerMessageFromHumanToAsnConverter {
       updatedNode.set(DATA, transformLaneDataAttributeList(jsonNode.get(DATA)));
     }
     if (jsonNode.has(D_WIDTH)) {
-      updatedNode.put(D_WIDTH,
-          OffsetXyBuilder.offsetXy(JsonUtils.decimalValue(jsonNode.get(D_WIDTH))));
+      updatedNode.put(D_WIDTH, OffsetXyBuilder.offsetXy(JsonUtils.decimalValue(jsonNode.get(D_WIDTH))));
     }
 
     if (jsonNode.has(D_ELEVATION)) {
-      updatedNode.put(D_ELEVATION,
-          OffsetXyBuilder.offsetXy(JsonUtils.decimalValue(jsonNode.get(D_ELEVATION))));
+      updatedNode.put(D_ELEVATION, OffsetXyBuilder.offsetXy(JsonUtils.decimalValue(jsonNode.get(D_ELEVATION))));
     }
     return updatedNode;
   }
@@ -1109,18 +1075,16 @@ public class TravelerMessageFromHumanToAsnConverter {
     if (oldNode.has("pathEndPointAngle")) {
       // do nothing
     } else if (oldNode.has(LANE_CROWN_POINT_CENTER)) {
-      updatedNode.put(LANE_CROWN_POINT_CENTER, RoadwayCrownAngleBuilder
-          .roadwayCrownAngle(JsonUtils.decimalValue(updatedNode.get(LANE_CROWN_POINT_CENTER))));
+      updatedNode.put(LANE_CROWN_POINT_CENTER,
+          RoadwayCrownAngleBuilder.roadwayCrownAngle(JsonUtils.decimalValue(updatedNode.get(LANE_CROWN_POINT_CENTER))));
     } else if (oldNode.has(LANE_CROWN_POINT_LEFT)) {
-      updatedNode.put(LANE_CROWN_POINT_LEFT, RoadwayCrownAngleBuilder
-          .roadwayCrownAngle(JsonUtils.decimalValue(updatedNode.get(LANE_CROWN_POINT_LEFT))));
+      updatedNode.put(LANE_CROWN_POINT_LEFT,
+          RoadwayCrownAngleBuilder.roadwayCrownAngle(JsonUtils.decimalValue(updatedNode.get(LANE_CROWN_POINT_LEFT))));
     } else if (oldNode.has(LANE_CROWN_POINT_RIGHT)) {
-      updatedNode.put(LANE_CROWN_POINT_RIGHT, RoadwayCrownAngleBuilder
-          .roadwayCrownAngle(JsonUtils.decimalValue(updatedNode.get(LANE_CROWN_POINT_RIGHT))));
+      updatedNode.put(LANE_CROWN_POINT_RIGHT,
+          RoadwayCrownAngleBuilder.roadwayCrownAngle(JsonUtils.decimalValue(updatedNode.get(LANE_CROWN_POINT_RIGHT))));
     } else if (oldNode.has(LANE_ANGLE)) {
-      updatedNode.put(LANE_ANGLE,
-          MergeDivergeNodeAngleBuilder.mergeDivergeNodeAngle(
-              JsonUtils.decimalValue(updatedNode.get(LANE_ANGLE))));
+      updatedNode.put(LANE_ANGLE, MergeDivergeNodeAngleBuilder.mergeDivergeNodeAngle(JsonUtils.decimalValue(updatedNode.get(LANE_ANGLE))));
     } else if (oldNode.has(SPEED_LIMITS)) {
       replaceSpeedLimitList(updatedNode.get(SPEED_LIMITS));
     }
@@ -1153,8 +1117,7 @@ public class TravelerMessageFromHumanToAsnConverter {
     }
 
     // replace velocity
-    updatedNode.put(SPEED,
-        VelocityBuilder.velocity(JsonUtils.decimalValue(updatedNode.get(SPEED))));
+    updatedNode.put(SPEED, VelocityBuilder.velocity(JsonUtils.decimalValue(updatedNode.get(SPEED))));
 
   }
 
@@ -1203,11 +1166,7 @@ public class TravelerMessageFromHumanToAsnConverter {
       Long transformedLon = LatitudeBuilder.j2735Latitude(lonOffset);
       Long transformedLat = LongitudeBuilder.j2735Longitude(latOffset);
       ObjectNode latLong = JsonUtils.newNode().put(LON, transformedLon).put(LAT, transformedLat);
-      if (deltaText.equals(NODE_XY)) {
-        innerNode.set(nodeOffsetPointLL(transformedLat, transformedLon), latLong);
-      } else {
-        innerNode.set(deltaText, latLong);
-      }
+      innerNode.set(deltaText, latLong);
     }
 
     deltaNode.set(DELTA, innerNode);
@@ -1240,10 +1199,23 @@ public class TravelerMessageFromHumanToAsnConverter {
       return "node-XY6";
     } else {
       throw new IllegalArgumentException(
-          "Invalid node X/Y offset: " + transformedX + "/" + transformedY
-              + ". Values must be between a range of -327.68/+327.67 meters.");
+          "Invalid node X/Y offset: " + transformedX + "/" + transformedY + ". Values must be between a range of -327.68/+327.67 meters.");
     }
   }
+
+  private static final Set<String> nonCompliantFields = Set.of(
+      SSP_MSG_CONTENT,
+      SSP_MSG_TYPES,
+      SSP_LOCATION_RIGHTS,
+      SSP_TIM_RIGHTS,
+      SSP_MSG_RIGHTS_1,
+      SSP_MSG_RIGHTS_2,
+      NOT_USED,
+      NOT_USED_1,
+      NOT_USED_2,
+      NOT_USED_3,
+      DURATON_TIME_MISSPELLED
+  );
 
   /**
    * Ensures compliance with the J2735 2024 standard by checking
@@ -1252,22 +1224,8 @@ public class TravelerMessageFromHumanToAsnConverter {
    * @param dataFrame the JSON object representing the data frame to be checked
    * @throws NoncompliantFieldsException if any old fields are found
    */
-  public static void ensureComplianceWithJ2735Revision2024(ObjectNode dataFrame)
-      throws NoncompliantFieldsException {
+  public static void ensureComplianceWithJ2735Revision2024(ObjectNode dataFrame) throws NoncompliantFieldsException {
     // Check and throw exception if old fields are found
-    Set<String> nonCompliantFields = Set.of(
-        SSP_MSG_CONTENT,
-        SSP_MSG_TYPES,
-        SSP_LOCATION_RIGHTS,
-        SSP_TIM_RIGHTS,
-        SSP_MSG_RIGHTS_1,
-        SSP_MSG_RIGHTS_2,
-        NOT_USED,
-        NOT_USED_1,
-        NOT_USED_2,
-        NOT_USED_3,
-        DURATON_TIME_MISSPELLED
-    );
     ArrayList<String> violations = new ArrayList<>();
     for (String violationName : nonCompliantFields) {
       if (dataFrame.has(violationName)) {
@@ -1275,11 +1233,9 @@ public class TravelerMessageFromHumanToAsnConverter {
       }
     }
     if (!violations.isEmpty()) {
-      throw new NoncompliantFieldsException(
-          String.format(
-              "Data frame contains the following old fields that are not compliant with "
-                  + "J2735 2024: [%s]. Deserialization should prevent this.",
-              violations));
+      throw new NoncompliantFieldsException(String.format(
+          "Data frame contains the following old fields that are not compliant with " + "J2735 2024: [%s]. Deserialization should prevent this.",
+          violations));
     }
   }
 
@@ -1288,6 +1244,15 @@ public class TravelerMessageFromHumanToAsnConverter {
    */
   public static class NoncompliantFieldsException extends Exception {
     public NoncompliantFieldsException(String message) {
+      super(message);
+    }
+  }
+
+  /**
+   * Exception thrown when an invalid node latitude or longitude offset is encountered.
+   */
+  public static class InvalidNodeLatLonOffsetException extends Exception {
+    public InvalidNodeLatLonOffsetException(String message) {
       super(message);
     }
   }

--- a/jpo-ode-plugins/src/test/java/us/dot/its/jpo/ode/plugin/j2735/builders/TravelerMessageFromHumanToAsnConverterTest.java
+++ b/jpo-ode-plugins/src/test/java/us/dot/its/jpo/ode/plugin/j2735/builders/TravelerMessageFromHumanToAsnConverterTest.java
@@ -16,10 +16,10 @@
 
 package us.dot.its.jpo.ode.plugin.j2735.builders;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import java.io.IOException;
 
 import org.json.JSONObject;
 import org.json.XML;
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -54,25 +53,24 @@ class TravelerMessageFromHumanToAsnConverterTest {
   }
 
   @Test
-  void testAdvisoryNodeLL() throws JsonProcessingException, IOException, JsonUtilsException,
-      TravelerMessageFromHumanToAsnConverter.NoncompliantFieldsException {
+  void testAdvisoryNodeLL() throws JsonUtilsException, TravelerMessageFromHumanToAsnConverter.NoncompliantFieldsException,
+      TravelerMessageFromHumanToAsnConverter.InvalidNodeLatLonOffsetException {
 
     ObjectNode inputTID = JsonUtils.toObjectNode(
-        "{\"request\":{\"rsus\":[{\"rsuIndex\":\"10\",\"rsuTarget\":\"127.0.0.2\",\"rsuUsername\":\"v3user\",\"rsuPassword\":\"password\",\"rsuRetries\":\"1\",\"rsuTimeout\":\"1000\"}],\"snmp\":{\"rsuid\":\"00000083\",\"msgid\":\"31\",\"mode\":\"1\",\"channel\":\"178\",\"interval\":\"2\",\"deliverystart\":\"2017-06-01T17:47:11-05:00\",\"deliverystop\":\"2018-01-01T17:47:11-05:15\",\"enable\":\"1\",\"status\":\"4\"}},\"tim\":{\"msgCnt\":\"1\",\"timeStamp\":\"2017-08-03T22:25:36.297Z\",\"urlB\":\"null\",\"packetID\":\"EC9C236B0000000000\",\"dataframes\":[{\"startDateTime\":\"2017-08-02T22:25:00.000Z\",\"durationTime\":1,\"doNotUse1\":0,\"frameType\":\"advisory\",\"msgId\":{\"roadSignID\":{\"position\":{\"latitude\":\"41.678473\",\"longitude\":\"-108.782775\",\"elevation\":\"917.1432\"},\"viewAngle\":\"1010101010101010\",\"mutcdCode\":\"warning\",\"crc\":\"0000\"}},\"priority\":\"0\",\"doNotUse2\":0,\"regions\":[{\"name\":\"Testing TIM\",\"regulatorID\":\"0\",\"segmentID\":\"33\",\"anchorPosition\":{\"latitude\":\"41.2500807\",\"longitude\":\"-111.0093847\",\"elevation\":\"2020.6969900289998\"},\"laneWidth\":\"7\",\"directionality\":\"3\",\"closedPath\":\"false\",\"description\":\"path\",\"path\":{\"scale\":\"0\",\"type\":\"ll\",\"nodes\":[{\"nodeLong\":\"0.0002047\",\"nodeLat\":\"-0.0002048\",\"delta\":\"node-LL\"},{\"nodeLong\":\"0.0008191\",\"nodeLat\":\"-0.0008192\",\"delta\":\"node-LL\"},{\"nodeLong\":\"0.0032767\",\"nodeLat\":\"-0.0032768\",\"delta\":\"node-LL\"},{\"nodeLong\":\"0.0131071\",\"nodeLat\":\"-0.0131072\",\"delta\":\"node-LL\"},{\"nodeLong\":\"0.2097151\",\"nodeLat\":\"-0.2097152\",\"delta\":\"node-LL\"},{\"nodeLong\":\"0.8388607\",\"nodeLat\":\"-0.8388608\",\"delta\":\"node-LL\"},{\"nodeLong\":\"0.0002047\",\"nodeLat\":\"-0.0002048\",\"delta\":\"node-LL1\"},{\"nodeLong\":\"0.0008191\",\"nodeLat\":\"-0.0008192\",\"delta\":\"node-LL2\"},{\"nodeLong\":\"0.0032767\",\"nodeLat\":\"-0.0032768\",\"delta\":\"node-LL3\"},{\"nodeLong\":\"0.0131071\",\"nodeLat\":\"-0.0131072\",\"delta\":\"node-LL4\"},{\"nodeLong\":\"0.2097151\",\"nodeLat\":\"-0.2097152\",\"delta\":\"node-LL5\"},{\"nodeLong\":\"0.8388607\",\"nodeLat\":\"-0.8388608\",\"delta\":\"node-LL6\"},{\"nodeLong\":\"-111.0093847\",\"nodeLat\":\"41.2500807\",\"delta\":\"node-LatLon\"}]},\"direction\":\"0000000000001010\"}],\"doNotUse4\":0,\"doNotUse3\":0,\"content\":\"advisory\",\"items\":[\"125\",\"some text\",\"250\",\"'98765\"],\"url\":\"null\"}]}}");
+        "{\"request\":{\"rsus\":[{\"rsuIndex\":\"10\",\"rsuTarget\":\"127.0.0.2\",\"rsuUsername\":\"v3user\",\"rsuPassword\":\"password\",\"rsuRetries\":\"1\",\"rsuTimeout\":\"1000\"}],\"snmp\":{\"rsuid\":\"00000083\",\"msgid\":\"31\",\"mode\":\"1\",\"channel\":\"178\",\"interval\":\"2\",\"deliverystart\":\"2017-06-01T17:47:11-05:00\",\"deliverystop\":\"2018-01-01T17:47:11-05:15\",\"enable\":\"1\",\"status\":\"4\"}},\"tim\":{\"msgCnt\":\"1\",\"timeStamp\":\"2017-08-03T22:25:36.297Z\",\"urlB\":\"null\",\"packetID\":\"EC9C236B0000000000\",\"dataframes\":[{\"startDateTime\":\"2017-08-02T22:25:00.000Z\",\"durationTime\":1,\"doNotUse1\":0,\"frameType\":\"advisory\",\"msgId\":{\"roadSignID\":{\"position\":{\"latitude\":\"41.678473\",\"longitude\":\"-108.782775\",\"elevation\":\"917.1432\"},\"viewAngle\":\"1010101010101010\",\"mutcdCode\":\"warning\",\"crc\":\"0000\"}},\"priority\":\"0\",\"doNotUse2\":0,\"regions\":[{\"name\":\"Testing TIM\",\"regulatorID\":\"0\",\"segmentID\":\"33\",\"anchorPosition\":{\"latitude\":\"41.2500807\",\"longitude\":\"-111.0093847\",\"elevation\":\"2020.6969900289998\"},\"laneWidth\":\"7\",\"directionality\":\"3\",\"closedPath\":\"false\",\"description\":\"path\",\"path\":{\"scale\":\"0\",\"type\":\"ll\",\"nodes\":[{\"nodeLong\":\"0.0002047\",\"nodeLat\":\"-0.0002047\",\"delta\":\"node-LL\"},{\"nodeLong\":\"0.0008191\",\"nodeLat\":\"-0.0008191\",\"delta\":\"node-LL\"},{\"nodeLong\":\"0.0032767\",\"nodeLat\":\"-0.0032767\",\"delta\":\"node-LL\"},{\"nodeLong\":\"0.0131071\",\"nodeLat\":\"-0.0131071\",\"delta\":\"node-LL\"},{\"nodeLong\":\"0.2097151\",\"nodeLat\":\"-0.2097151\",\"delta\":\"node-LL\"},{\"nodeLong\":\"0.8388607\",\"nodeLat\":\"-0.8388607\",\"delta\":\"node-LL\"},{\"nodeLong\":\"0.0002047\",\"nodeLat\":\"-0.0002047\",\"delta\":\"node-LL1\"},{\"nodeLong\":\"0.0008191\",\"nodeLat\":\"-0.0008191\",\"delta\":\"node-LL2\"},{\"nodeLong\":\"0.0032767\",\"nodeLat\":\"-0.0032767\",\"delta\":\"node-LL3\"},{\"nodeLong\":\"0.0131071\",\"nodeLat\":\"-0.0131071\",\"delta\":\"node-LL4\"},{\"nodeLong\":\"0.2097151\",\"nodeLat\":\"-0.2097151\",\"delta\":\"node-LL5\"},{\"nodeLong\":\"0.8388607\",\"nodeLat\":\"-0.8388607\",\"delta\":\"node-LL6\"},{\"nodeLong\":\"-111.0093847\",\"nodeLat\":\"41.2500807\",\"delta\":\"node-LatLon\"}]},\"direction\":\"0000000000001010\"}],\"doNotUse4\":0,\"doNotUse3\":0,\"content\":\"advisory\",\"items\":[\"125\",\"some text\",\"250\",\"'98765\"],\"url\":\"null\"}]}}");
     TravelerMessageFromHumanToAsnConverter.convertTravelerInputDataToEncodableTim(inputTID);
 
     ObjectNode expectedTID = JsonUtils.toObjectNode(
-        "{\"request\":{\"rsus\":[{\"rsuIndex\":\"10\",\"rsuTarget\":\"127.0.0.2\",\"rsuUsername\":\"v3user\",\"rsuPassword\":\"password\",\"rsuRetries\":\"1\",\"rsuTimeout\":\"1000\"}],\"snmp\":{\"rsuid\":\"00000083\",\"msgid\":\"31\",\"mode\":\"1\",\"channel\":\"178\",\"interval\":\"2\",\"deliverystart\":\"2017-06-01T17:47:11-05:00\",\"deliverystop\":\"2018-01-01T17:47:11-05:15\",\"enable\":\"1\",\"status\":\"4\"}},\"tim\":{\"msgCnt\":\"1\",\"timeStamp\":309505,\"urlB\":\"null\",\"packetID\":\"EC9C236B0000000000\",\"dataFrames\":{\"TravelerDataFrame\":[{\"durationTime\":1,\"doNotUse1\":0,\"frameType\":{\"advisory\":\"EMPTY_TAG\"},\"msgId\":{\"roadSignID\":{\"position\":{\"lat\":416784730,\"long\":-1087827750,\"elevation\":9171},\"viewAngle\":\"1010101010101010\",\"mutcdCode\":{\"warning\":\"EMPTY_TAG\"},\"crc\":\"0000\"}},\"priority\":\"0\",\"doNotUse2\":0,\"regions\":{\"GeographicalPath\":[{\"name\":\"Testing TIM\",\"laneWidth\":700,\"directionality\":{\"both\":\"EMPTY_TAG\"},\"closedPath\":\"BOOLEAN_OBJECT_FALSE\",\"description\":{\"path\":{\"scale\":\"0\",\"offset\":{\"ll\":{\"nodes\":{\"NodeLL\":[{\"delta\":{\"node-LL1\":{\"lat\":-2048,\"lon\":2047}}},{\"delta\":{\"node-LL2\":{\"lat\":-8192,\"lon\":8191}}},{\"delta\":{\"node-LL3\":{\"lat\":-32768,\"lon\":32767}}},{\"delta\":{\"node-LL4\":{\"lat\":-131072,\"lon\":131071}}},{\"delta\":{\"node-LL5\":{\"lat\":-2097152,\"lon\":2097151}}},{\"delta\":{\"node-LL6\":{\"lat\":-8388608,\"lon\":8388607}}},{\"delta\":{\"node-LL1\":{\"lat\":-2048,\"lon\":2047}}},{\"delta\":{\"node-LL2\":{\"lat\":-8192,\"lon\":8191}}},{\"delta\":{\"node-LL3\":{\"lat\":-32768,\"lon\":32767}}},{\"delta\":{\"node-LL4\":{\"lat\":-131072,\"lon\":131071}}},{\"delta\":{\"node-LL5\":{\"lat\":-2097152,\"lon\":2097151}}},{\"delta\":{\"node-LL6\":{\"lat\":-8388608,\"lon\":8388607}}},{\"delta\":{\"node-LatLon\":{\"lat\":412500807,\"lon\":-1110093847}}}]}}}}},\"direction\":\"0000000000001010\",\"id\":{\"region\":0,\"id\":33},\"anchor\":{\"lat\":412500807,\"long\":-1110093847,\"elevation\":20207}}]},\"doNotUse4\":0,\"doNotUse3\":0,\"url\":\"null\",\"startYear\":2017,\"startTime\":308065,\"tcontent\":{\"advisory\":{\"SEQUENCE\":[{\"item\":{\"itis\":125}},{\"item\":{\"text\":\"some text\"}},{\"item\":{\"itis\":250}},{\"item\":{\"text\":\"98765\"}}]}}}]}}}");
+        "{\"request\":{\"rsus\":[{\"rsuIndex\":\"10\",\"rsuTarget\":\"127.0.0.2\",\"rsuUsername\":\"v3user\",\"rsuPassword\":\"password\",\"rsuRetries\":\"1\",\"rsuTimeout\":\"1000\"}],\"snmp\":{\"rsuid\":\"00000083\",\"msgid\":\"31\",\"mode\":\"1\",\"channel\":\"178\",\"interval\":\"2\",\"deliverystart\":\"2017-06-01T17:47:11-05:00\",\"deliverystop\":\"2018-01-01T17:47:11-05:15\",\"enable\":\"1\",\"status\":\"4\"}},\"tim\":{\"msgCnt\":\"1\",\"timeStamp\":309505,\"urlB\":\"null\",\"packetID\":\"EC9C236B0000000000\",\"dataFrames\":{\"TravelerDataFrame\":[{\"durationTime\":1,\"doNotUse1\":0,\"frameType\":{\"advisory\":\"EMPTY_TAG\"},\"msgId\":{\"roadSignID\":{\"position\":{\"lat\":416784730,\"long\":-1087827750,\"elevation\":9171},\"viewAngle\":\"1010101010101010\",\"mutcdCode\":{\"warning\":\"EMPTY_TAG\"},\"crc\":\"0000\"}},\"priority\":\"0\",\"doNotUse2\":0,\"regions\":{\"GeographicalPath\":[{\"name\":\"Testing TIM\",\"laneWidth\":700,\"directionality\":{\"both\":\"EMPTY_TAG\"},\"closedPath\":\"BOOLEAN_OBJECT_FALSE\",\"description\":{\"path\":{\"scale\":\"0\",\"offset\":{\"ll\":{\"nodes\":{\"NodeLL\":[{\"delta\":{\"node-LL1\":{\"lat\":-2047,\"lon\":2047}}},{\"delta\":{\"node-LL2\":{\"lat\":-8191,\"lon\":8191}}},{\"delta\":{\"node-LL3\":{\"lat\":-32767,\"lon\":32767}}},{\"delta\":{\"node-LL4\":{\"lat\":-131071,\"lon\":131071}}},{\"delta\":{\"node-LL5\":{\"lat\":-2097151,\"lon\":2097151}}},{\"delta\":{\"node-LL6\":{\"lat\":-8388607,\"lon\":8388607}}},{\"delta\":{\"node-LL1\":{\"lat\":-2047,\"lon\":2047}}},{\"delta\":{\"node-LL2\":{\"lat\":-8191,\"lon\":8191}}},{\"delta\":{\"node-LL3\":{\"lat\":-32767,\"lon\":32767}}},{\"delta\":{\"node-LL4\":{\"lat\":-131071,\"lon\":131071}}},{\"delta\":{\"node-LL5\":{\"lat\":-2097151,\"lon\":2097151}}},{\"delta\":{\"node-LL6\":{\"lat\":-8388607,\"lon\":8388607}}},{\"delta\":{\"node-LatLon\":{\"lat\":412500807,\"lon\":-1110093847}}}]}}}}},\"direction\":\"0000000000001010\",\"id\":{\"region\":0,\"id\":33},\"anchor\":{\"lat\":412500807,\"long\":-1110093847,\"elevation\":20207}}]},\"doNotUse4\":0,\"doNotUse3\":0,\"url\":\"null\",\"startYear\":2017,\"startTime\":308065,\"tcontent\":{\"advisory\":{\"SEQUENCE\":[{\"item\":{\"itis\":125}},{\"item\":{\"text\":\"some text\"}},{\"item\":{\"itis\":250}},{\"item\":{\"text\":\"98765\"}}]}}}]}}}");
     Assertions.assertEquals(expectedTID.toString(), inputTID.toString());
     JSONObject timObject = new JSONObject();
-    timObject.put(TravelerMessageFromHumanToAsnConverter.TRAVELER_INFORMATION,
-        JsonUtils.toJSONObject(inputTID.toString()));
-    Assertions.assertNotNull(XML.toString(timObject));
+    timObject.put(TravelerMessageFromHumanToAsnConverter.TRAVELER_INFORMATION, JsonUtils.toJSONObject(inputTID.toString()));
+    assertNotNull(XML.toString(timObject));
   }
 
   @Test
-  void testWorkzoneNodeXYWithStringLatLon() throws JsonUtilsException,
-      TravelerMessageFromHumanToAsnConverter.NoncompliantFieldsException {
+  void testWorkzoneNodeXYWithStringLatLon() throws JsonUtilsException, TravelerMessageFromHumanToAsnConverter.NoncompliantFieldsException,
+      TravelerMessageFromHumanToAsnConverter.InvalidNodeLatLonOffsetException {
 
     ObjectNode inputTID = JsonUtils.toObjectNode(
         "{\"request\":{\"rsus\":[{\"rsuIndex\":\"10\",\"rsuTarget\":\"127.0.0.3\",\"rsuUsername\":\"v3user\",\"rsuPassword\":\"password\",\"rsuRetries\":\"1\",\"rsuTimeout\":\"1000\"}],\"snmp\":{\"rsuid\":\"00000083\",\"msgid\":\"31\",\"mode\":\"1\",\"channel\":\"178\",\"interval\":\"2\",\"deliverystart\":\"2017-06-01T17:47:11-05:00\",\"deliverystop\":\"2018-01-01T17:47:11-05:15\",\"enable\":\"1\",\"status\":\"4\"},\"sdw\":{\"ttl\":\"oneweek\",\"serviceRegion\":{\"nwCorner\":{\"latitude\":\"44.998459\",\"longitude\":\"-111.040817\"},\"seCorner\":{\"latitude\":\"41.104674\",\"longitude\":\"-104.111312\"}}}},\"tim\":{\"msgCnt\":\"1\",\"timeStamp\":\"2017-10-27T18:04:43.045Z\",\"packetID\":\"3\",\"urlB\":\"null\",\"dataframes\":[{\"startDateTime\":\"2017-10-20T05:22:33.985Z\",\"durationTime\":100,\"frameType\":\"1\",\"doNotUse1\":0,\"msgId\":\"roadSignID\",\"position\":{\"latitude\":\"40.573068\",\"longitude\":\"-105.049016\",\"elevation\":\"1500.8999999999999\"},\"viewAngle\":\"1111111111111111\",\"mutcd\":\"2\",\"crc\":\"0000\",\"priority\":\"5\",\"doNotUse2\":0,\"regions\":[{\"name\":\"Testing TIM\",\"regulatorID\":\"0\",\"segmentID\":\"33\",\"anchorPosition\":{\"latitude\":\"40.573068\",\"longitude\":\"-105.049016\",\"elevation\":\"1500.8999999999999\"},\"laneWidth\":\"327\",\"directionality\":\"3\",\"closedPath\":\"false\",\"description\":\"path\",\"path\":{\"scale\":\"0\",\"type\":\"xy\",\"nodes\":[{\"nodeLong\":\"-105.047355\",\"nodeLat\":\"40.572429\",\"delta\":\"node-LatLon\",\"attributes\":{\"localNode\":[\"stopLine\",\"roundedCapStyleA\",\"roundedCapStyleB\",\"mergePoint\",\"divergePoint\",\"downstreamStopLine\",\"downstreamStartNode\",\"closedToTraffic\",\"safeIsland\",\"curbPresentAtStepOff\",\"hydrantPresent\",\"reserved\"],\"disabled\":[\"reserved\",\"doNotBlock\",\"whiteLine\",\"mergingLaneLeft\",\"mergingLaneRight\",\"curbOnLeft\",\"curbOnRight\",\"loadingzoneOnLeft\",\"loadingzoneOnRight\",\"turnOutPointOnLeft\",\"turnOutPointOnRight\"],\"enabled\":[\"adjacentParkingOnLeft\",\"adjacentParkingOnRight\",\"adjacentBikeLaneOnLeft\"],\"data\":[{\"pathEndPointAngle\":123},{\"laneCrownPointCenter\":12.3},{\"laneCrownPointLeft\":\"23.4\"},{\"laneCrownPointRight\":34.5},{\"laneAngle\":\"1.23\"},{\"speedLimits\":[{\"type\":\"2\",\"speed\":\"12.3\"},{\"type\":\"maxSpeedInSchoolZone\",\"speed\":\"23.4\"},{\"type\":3,\"speed\":12.3},{\"type\":\"vehicleMinSpeed\",\"speed\":23.4}]}],\"dWidth\":\"1.23\",\"dElevation\":\"2.34\"}},{\"nodeLong\":\"-105.046844\",\"nodeLat\":\"40.572228\",\"delta\":\"node-LatLon\"},{\"nodeLong\":\"-105.04659\",\"nodeLat\":\"40.572113\",\"delta\":\"node-LatLon\"},{\"nodeLong\":\"-105.046243\",\"nodeLat\":\"40.57191\",\"delta\":\"node-LatLon\"},{\"nodeLong\":\"-105.045936\",\"nodeLat\":\"40.571675\",\"delta\":\"node-LatLon\"},{\"nodeLong\":\"-105.045674\",\"nodeLat\":\"40.571422\",\"delta\":\"node-LatLon\"},{\"nodeLong\":\"-105.04545\",\"nodeLat\":\"40.571131\",\"delta\":\"node-LatLon\"},{\"nodeLong\":\"-105.045235\",\"nodeLat\":\"40.570724\",\"delta\":\"node-LatLon\"},{\"nodeLong\":\"-105.045113\",\"nodeLat\":\"40.570293\",\"delta\":\"node-LatLon\"},{\"nodeLong\":\"-105.045087\",\"nodeLat\":\"40.569848\",\"delta\":\"node-LatLon\"}]},\"direction\":\"1111111111111111\"}],\"doNotUse4\":0,\"doNotUse3\":0,\"content\":\"workZone\",\"items\":[\"7425\"],\"url\":\"null\"}]}}");
@@ -82,14 +80,13 @@ class TravelerMessageFromHumanToAsnConverterTest {
         "{\"request\":{\"rsus\":[{\"rsuIndex\":\"10\",\"rsuTarget\":\"127.0.0.3\",\"rsuUsername\":\"v3user\",\"rsuPassword\":\"password\",\"rsuRetries\":\"1\",\"rsuTimeout\":\"1000\"}],\"snmp\":{\"rsuid\":\"00000083\",\"msgid\":\"31\",\"mode\":\"1\",\"channel\":\"178\",\"interval\":\"2\",\"deliverystart\":\"2017-06-01T17:47:11-05:00\",\"deliverystop\":\"2018-01-01T17:47:11-05:15\",\"enable\":\"1\",\"status\":\"4\"},\"sdw\":{\"ttl\":\"oneweek\",\"serviceRegion\":{\"nwCorner\":{\"latitude\":\"44.998459\",\"longitude\":\"-111.040817\"},\"seCorner\":{\"latitude\":\"41.104674\",\"longitude\":\"-104.111312\"}}}},\"tim\":{\"msgCnt\":\"1\",\"timeStamp\":431644,\"packetID\":\"3\",\"urlB\":\"null\",\"dataFrames\":{\"TravelerDataFrame\":[{\"durationTime\":100,\"frameType\":{\"1\":\"EMPTY_TAG\"},\"doNotUse1\":0,\"msgId\":\"roadSignID\",\"position\":{\"latitude\":\"40.573068\",\"longitude\":\"-105.049016\",\"elevation\":\"1500.8999999999999\"},\"viewAngle\":\"1111111111111111\",\"mutcd\":\"2\",\"crc\":\"0000\",\"priority\":\"5\",\"doNotUse2\":0,\"regions\":{\"GeographicalPath\":[{\"name\":\"Testing TIM\",\"laneWidth\":32700,\"directionality\":{\"both\":\"EMPTY_TAG\"},\"closedPath\":\"BOOLEAN_OBJECT_FALSE\",\"description\":{\"path\":{\"scale\":\"0\",\"offset\":{\"xy\":{\"nodes\":{\"NodeXY\":[{\"delta\":{\"node-LatLon\":{\"lon\":-1050473550,\"lat\":405724290}},\"attributes\":{\"data\":[{\"pathEndPointAngle\":123},{\"laneCrownPointCenter\":41},{\"laneCrownPointLeft\":78},{\"laneCrownPointRight\":115},{\"laneAngle\":1},{\"speedLimits\":[{\"type\":{\"maxSpeedInSchoolZoneWhenChildrenArePresent\":\"EMPTY_TAG\"},\"speed\":615},{\"type\":{\"maxSpeedInSchoolZone\":\"EMPTY_TAG\"},\"speed\":1170},{\"type\":{\"maxSpeedInConstructionZone\":\"EMPTY_TAG\"},\"speed\":615},{\"type\":{\"vehicleMinSpeed\":\"EMPTY_TAG\"},\"speed\":1170}]}],\"dWidth\":123,\"dElevation\":234}},{\"delta\":{\"node-LatLon\":{\"lon\":-1050468440,\"lat\":405722280}}},{\"delta\":{\"node-LatLon\":{\"lon\":-1050465900,\"lat\":405721130}}},{\"delta\":{\"node-LatLon\":{\"lon\":-1050462430,\"lat\":405719100}}},{\"delta\":{\"node-LatLon\":{\"lon\":-1050459360,\"lat\":405716750}}},{\"delta\":{\"node-LatLon\":{\"lon\":-1050456740,\"lat\":405714220}}},{\"delta\":{\"node-LatLon\":{\"lon\":-1050454500,\"lat\":405711310}}},{\"delta\":{\"node-LatLon\":{\"lon\":-1050452350,\"lat\":405707240}}},{\"delta\":{\"node-LatLon\":{\"lon\":-1050451130,\"lat\":405702930}}},{\"delta\":{\"node-LatLon\":{\"lon\":-1050450870,\"lat\":405698480}}}]}}}}},\"direction\":\"1111111111111111\",\"id\":{\"region\":0,\"id\":33},\"anchor\":{\"lat\":405730680,\"long\":-1050490160,\"elevation\":15009}}]},\"doNotUse4\":0,\"doNotUse3\":0,\"url\":\"null\",\"startYear\":2017,\"startTime\":420802,\"tcontent\":{\"workZone\":{\"SEQUENCE\":[{\"item\":{\"itis\":7425}}]}}}]}}}");
     Assertions.assertEquals(expectedTID.toString(), inputTID.toString());
     JSONObject timObject = new JSONObject();
-    timObject.put(TravelerMessageFromHumanToAsnConverter.TRAVELER_INFORMATION,
-        JsonUtils.toJSONObject(inputTID.toString()));
-    Assertions.assertNotNull(XML.toString(timObject));
+    timObject.put(TravelerMessageFromHumanToAsnConverter.TRAVELER_INFORMATION, JsonUtils.toJSONObject(inputTID.toString()));
+    assertNotNull(XML.toString(timObject));
   }
 
   @Test
-  void testGenericSignNodeXYWithNumericLatLon() throws JsonUtilsException,
-      TravelerMessageFromHumanToAsnConverter.NoncompliantFieldsException {
+  void testGenericSignNodeXYWithNumericLatLon() throws JsonUtilsException, TravelerMessageFromHumanToAsnConverter.NoncompliantFieldsException,
+      TravelerMessageFromHumanToAsnConverter.InvalidNodeLatLonOffsetException {
 
     ObjectNode inputTID = JsonUtils.toObjectNode(
         "{\"request\":{\"rsus\":[{\"rsuIndex\":\"10\",\"rsuTarget\":\"127.0.0.3\",\"rsuUsername\":\"v3user\",\"rsuPassword\":\"password\",\"rsuRetries\":\"1\",\"rsuTimeout\":\"1000\"}],\"snmp\":{\"rsuid\":\"00000083\",\"msgid\":\"31\",\"mode\":\"1\",\"channel\":\"178\",\"interval\":\"2\",\"deliverystart\":\"2017-06-01T17:47:11-05:00\",\"deliverystop\":\"2018-01-01T17:47:11-05:15\",\"enable\":\"1\",\"status\":\"4\"},\"sdw\":{\"ttl\":\"oneweek\",\"serviceRegion\":{\"nwCorner\":{\"latitude\":44.998459,\"longitude\":-111.040817},\"seCorner\":{\"latitude\":41.104674,\"longitude\":-104.111312}}}},\"tim\":{\"msgCnt\":\"1\",\"timeStamp\":\"2017-10-27T18:04:43.045Z\",\"packetID\":\"3\",\"urlB\":\"null\",\"dataframes\":[{\"startDateTime\":\"2017-10-20T05:22:33.985Z\",\"durationTime\":100,\"frameType\":\"advisory\",\"doNotUse1\":0,\"msgId\":\"roadSignID\",\"position\":{\"latitude\":40.573068,\"longitude\":-105.049016,\"elevation\":1500.8999999999999},\"viewAngle\":\"1111111111111111\",\"mutcd\":\"2\",\"crc\":\"0000\",\"priority\":\"5\",\"doNotUse2\":0,\"regions\":[{\"name\":\"Testing TIM\",\"regulatorID\":\"0\",\"segmentID\":\"33\",\"anchorPosition\":{\"latitude\":40.573068,\"longitude\":-105.049016,\"elevation\":1500.8999999999999},\"laneWidth\":\"327\",\"directionality\":\"3\",\"closedPath\":\"false\",\"description\":\"path\",\"path\":{\"scale\":\"0\",\"type\":\"xy\",\"nodes\":[{\"nodeLong\":-105.047355,\"nodeLat\":40.572429,\"delta\":\"node-LatLon\",\"attributes\":{\"localNode\":[\"stopLine\",\"roundedCapStyleA\",\"roundedCapStyleB\",\"mergePoint\",\"divergePoint\",\"downstreamStopLine\",\"downstreamStartNode\",\"closedToTraffic\",\"safeIsland\",\"curbPresentAtStepOff\",\"hydrantPresent\",\"reserved\"],\"disabled\":[\"reserved\",\"doNotBlock\",\"whiteLine\",\"mergingLaneLeft\",\"mergingLaneRight\",\"curbOnLeft\",\"curbOnRight\",\"loadingzoneOnLeft\",\"loadingzoneOnRight\",\"turnOutPointOnLeft\",\"turnOutPointOnRight\"],\"enabled\":[\"adjacentParkingOnLeft\",\"adjacentParkingOnRight\",\"adjacentBikeLaneOnLeft\"],\"data\":[{\"pathEndPointAngle\":123},{\"laneCrownPointCenter\":12.3},{\"laneCrownPointLeft\":\"23.4\"},{\"laneCrownPointRight\":34.5},{\"laneAngle\":\"1.23\"},{\"speedLimits\":[{\"type\":\"2\",\"speed\":\"12.3\"},{\"type\":\"maxSpeedInSchoolZone\",\"speed\":\"23.4\"},{\"type\":3,\"speed\":12.3},{\"type\":\"vehicleMinSpeed\",\"speed\":23.4}]}],\"dWidth\":\"1.23\",\"dElevation\":\"2.34\"}},{\"nodeLong\":\"-105.046844\",\"nodeLat\":\"40.572228\",\"delta\":\"node-LatLon\"},{\"nodeLong\":\"-105.04659\",\"nodeLat\":\"40.572113\",\"delta\":\"node-LatLon\"},{\"nodeLong\":\"-105.046243\",\"nodeLat\":\"40.57191\",\"delta\":\"node-LatLon\"},{\"nodeLong\":\"-105.045936\",\"nodeLat\":\"40.571675\",\"delta\":\"node-LatLon\"},{\"nodeLong\":\"-105.045674\",\"nodeLat\":\"40.571422\",\"delta\":\"node-LatLon\"},{\"nodeLong\":\"-105.04545\",\"nodeLat\":\"40.571131\",\"delta\":\"node-LatLon\"},{\"nodeLong\":\"-105.045235\",\"nodeLat\":\"40.570724\",\"delta\":\"node-LatLon\"},{\"nodeLong\":\"-105.045113\",\"nodeLat\":\"40.570293\",\"delta\":\"node-LatLon\"},{\"nodeLong\":\"-105.045087\",\"nodeLat\":\"40.569848\",\"delta\":\"node-LatLon\"}]},\"direction\":\"1111111111111111\"}],\"doNotUse4\":0,\"doNotUse3\":0,\"content\":\"genericSign\",\"items\":[\"7425\"],\"url\":\"null\"}]}}");
@@ -99,14 +96,13 @@ class TravelerMessageFromHumanToAsnConverterTest {
         "{\"request\":{\"rsus\":[{\"rsuIndex\":\"10\",\"rsuTarget\":\"127.0.0.3\",\"rsuUsername\":\"v3user\",\"rsuPassword\":\"password\",\"rsuRetries\":\"1\",\"rsuTimeout\":\"1000\"}],\"snmp\":{\"rsuid\":\"00000083\",\"msgid\":\"31\",\"mode\":\"1\",\"channel\":\"178\",\"interval\":\"2\",\"deliverystart\":\"2017-06-01T17:47:11-05:00\",\"deliverystop\":\"2018-01-01T17:47:11-05:15\",\"enable\":\"1\",\"status\":\"4\"},\"sdw\":{\"ttl\":\"oneweek\",\"serviceRegion\":{\"nwCorner\":{\"latitude\":44.998459,\"longitude\":-111.040817},\"seCorner\":{\"latitude\":41.104674,\"longitude\":-104.111312}}}},\"tim\":{\"msgCnt\":\"1\",\"timeStamp\":431644,\"packetID\":\"3\",\"urlB\":\"null\",\"dataFrames\":{\"TravelerDataFrame\":[{\"durationTime\":100,\"frameType\":{\"advisory\":\"EMPTY_TAG\"},\"doNotUse1\":0,\"msgId\":\"roadSignID\",\"position\":{\"latitude\":40.573068,\"longitude\":-105.049016,\"elevation\":1500.8999999999999},\"viewAngle\":\"1111111111111111\",\"mutcd\":\"2\",\"crc\":\"0000\",\"priority\":\"5\",\"doNotUse2\":0,\"regions\":{\"GeographicalPath\":[{\"name\":\"Testing TIM\",\"laneWidth\":32700,\"directionality\":{\"both\":\"EMPTY_TAG\"},\"closedPath\":\"BOOLEAN_OBJECT_FALSE\",\"description\":{\"path\":{\"scale\":\"0\",\"offset\":{\"xy\":{\"nodes\":{\"NodeXY\":[{\"delta\":{\"node-LatLon\":{\"lon\":-1050473550,\"lat\":405724290}},\"attributes\":{\"data\":[{\"pathEndPointAngle\":123},{\"laneCrownPointCenter\":41},{\"laneCrownPointLeft\":78},{\"laneCrownPointRight\":115},{\"laneAngle\":1},{\"speedLimits\":[{\"type\":{\"maxSpeedInSchoolZoneWhenChildrenArePresent\":\"EMPTY_TAG\"},\"speed\":615},{\"type\":{\"maxSpeedInSchoolZone\":\"EMPTY_TAG\"},\"speed\":1170},{\"type\":{\"maxSpeedInConstructionZone\":\"EMPTY_TAG\"},\"speed\":615},{\"type\":{\"vehicleMinSpeed\":\"EMPTY_TAG\"},\"speed\":1170}]}],\"dWidth\":123,\"dElevation\":234}},{\"delta\":{\"node-LatLon\":{\"lon\":-1050468440,\"lat\":405722280}}},{\"delta\":{\"node-LatLon\":{\"lon\":-1050465900,\"lat\":405721130}}},{\"delta\":{\"node-LatLon\":{\"lon\":-1050462430,\"lat\":405719100}}},{\"delta\":{\"node-LatLon\":{\"lon\":-1050459360,\"lat\":405716750}}},{\"delta\":{\"node-LatLon\":{\"lon\":-1050456740,\"lat\":405714220}}},{\"delta\":{\"node-LatLon\":{\"lon\":-1050454500,\"lat\":405711310}}},{\"delta\":{\"node-LatLon\":{\"lon\":-1050452350,\"lat\":405707240}}},{\"delta\":{\"node-LatLon\":{\"lon\":-1050451130,\"lat\":405702930}}},{\"delta\":{\"node-LatLon\":{\"lon\":-1050450870,\"lat\":405698480}}}]}}}}},\"direction\":\"1111111111111111\",\"id\":{\"region\":0,\"id\":33},\"anchor\":{\"lat\":405730680,\"long\":-1050490160,\"elevation\":15009}}]},\"doNotUse4\":0,\"doNotUse3\":0,\"url\":\"null\",\"startYear\":2017,\"startTime\":420802,\"tcontent\":{\"genericSign\":{\"SEQUENCE\":[{\"item\":{\"itis\":7425}}]}}}]}}}");
     Assertions.assertEquals(expectedTID.toString(), inputTID.toString());
     JSONObject timObject = new JSONObject();
-    timObject.put(TravelerMessageFromHumanToAsnConverter.TRAVELER_INFORMATION,
-        JsonUtils.toJSONObject(inputTID.toString()));
-    Assertions.assertNotNull(XML.toString(timObject));
+    timObject.put(TravelerMessageFromHumanToAsnConverter.TRAVELER_INFORMATION, JsonUtils.toJSONObject(inputTID.toString()));
+    assertNotNull(XML.toString(timObject));
   }
 
   @Test
-  void testGeometryUnavailable() throws JsonUtilsException,
-      TravelerMessageFromHumanToAsnConverter.NoncompliantFieldsException {
+  void testGeometryUnavailable() throws JsonUtilsException, TravelerMessageFromHumanToAsnConverter.NoncompliantFieldsException,
+      TravelerMessageFromHumanToAsnConverter.InvalidNodeLatLonOffsetException {
     ObjectNode inputTID = JsonUtils.toObjectNode(
         "{\"request\":{\"rsus\":[{\"rsuIndex\":\"10\",\"rsuTarget\":\"127.0.0.3\",\"rsuUsername\":\"v3user\",\"rsuPassword\":\"password\",\"rsuRetries\":\"1\",\"rsuTimeout\":\"1000\"}],\"snmp\":{\"rsuid\":\"00000083\",\"msgid\":\"31\",\"mode\":\"1\",\"channel\":\"178\",\"interval\":\"2\",\"deliverystart\":\"2017-06-01T17:47:11-05:00\",\"deliverystop\":\"2018-01-01T17:47:11-05:15\",\"enable\":\"1\",\"status\":\"4\"},\"sdw\":{\"ttl\":\"oneweek\",\"serviceRegion\":{\"nwCorner\":{\"latitude\":\"44.998459\",\"longitude\":\"-111.040817\"},\"seCorner\":{\"latitude\":\"41.104674\",\"longitude\":\"-104.111312\"}}}}, \"tim\": { \"msgCnt\": \"13\", \"timeStamp\": \"2017-03-13T01:07:11-05:00\", \"packetID\": \"1\", \"urlB\": \"null\", \"dataframes\": [ { \"doNotUse1\": 0, \"frameType\": \"unknown\", \"msgId\": \"roadSignID\", \"position\": { \"latitude\": \"41.678473\", \"longitude\": \"-108.782775\", \"elevation\": \"917.1432\" }, \"viewAngle\": \"1010101010101010\", \"mutcd\": \"5\", \"crc\": \"0000\", \"startDateTime\": \"2017-12-01T17:47:11-05:00\", \"durationTime\": \"22\", \"priority\": \"0\", \"doNotUse2\": 0, \"regions\": [ { \"name\": \"bob\", \"regulatorID\": \"23\", \"segmentID\": \"33\", \"anchorPosition\": { \"latitude\": \"41.678473\", \"longitude\": \"-108.782775\", \"elevation\": \"917.1432\" }, \"laneWidth\": \"7\", \"directionality\": \"0\", \"closedPath\": \"false\", \"direction\": \"1010101010101010\", \"description\": \"geometry\", \"geometry\": { \"direction\": \"1010101010101010\", \"extent\": \"1\", \"laneWidth\": \"33\", \"circle\": { \"position\": { \"latitude\": \"41.678473\", \"longitude\": \"-108.782775\", \"elevation\": \"917.1432\" }, \"radius\": \"15\", \"units\": \"7\" } } } ], \"doNotUse4\": 0, \"doNotUse3\": 0, \"content\": \"speedLimit\", \"items\": [ \"250\" ], \"url\": \"null\" } ] }}");
     TravelerMessageFromHumanToAsnConverter.convertTravelerInputDataToEncodableTim(inputTID);
@@ -116,14 +112,13 @@ class TravelerMessageFromHumanToAsnConverterTest {
     Assertions.assertEquals(expectedTID.toString(), inputTID.toString());
 
     JSONObject timObject = new JSONObject();
-    timObject.put(TravelerMessageFromHumanToAsnConverter.TRAVELER_INFORMATION,
-        JsonUtils.toJSONObject(inputTID.toString()));
-    Assertions.assertNotNull(XML.toString(timObject));
+    timObject.put(TravelerMessageFromHumanToAsnConverter.TRAVELER_INFORMATION, JsonUtils.toJSONObject(inputTID.toString()));
+    assertNotNull(XML.toString(timObject));
   }
 
   @Test
-  void testGeometryExitServiceForward() throws JsonUtilsException,
-      TravelerMessageFromHumanToAsnConverter.NoncompliantFieldsException {
+  void testGeometryExitServiceForward() throws JsonUtilsException, TravelerMessageFromHumanToAsnConverter.NoncompliantFieldsException,
+      TravelerMessageFromHumanToAsnConverter.InvalidNodeLatLonOffsetException {
     ObjectNode inputTID = JsonUtils.toObjectNode(
         "{\"request\":{\"rsus\":[{\"rsuIndex\":\"10\",\"rsuTarget\":\"127.0.0.3\",\"rsuUsername\":\"v3user\",\"rsuPassword\":\"password\",\"rsuRetries\":\"1\",\"rsuTimeout\":\"1000\"}],\"snmp\":{\"rsuid\":\"00000083\",\"msgid\":\"31\",\"mode\":\"1\",\"channel\":\"178\",\"interval\":\"2\",\"deliverystart\":\"2017-06-01T17:47:11-05:00\",\"deliverystop\":\"2018-01-01T17:47:11-05:15\",\"enable\":\"1\",\"status\":\"4\"},\"sdw\":{\"ttl\":\"oneweek\",\"serviceRegion\":{\"nwCorner\":{\"latitude\":\"44.998459\",\"longitude\":\"-111.040817\"},\"seCorner\":{\"latitude\":\"41.104674\",\"longitude\":\"-104.111312\"}}}}, \"tim\": { \"msgCnt\": \"13\", \"timeStamp\": \"2017-03-13T01:07:11-05:00\", \"packetID\": \"1\", \"urlB\": \"null\", \"dataframes\": [ { \"doNotUse1\": 0, \"frameType\": \"0\", \"msgId\": \"roadSignID\", \"position\": { \"latitude\": \"41.678473\", \"longitude\": \"-108.782775\", \"elevation\": \"917.1432\" }, \"viewAngle\": \"1010101010101010\", \"mutcd\": \"5\", \"crc\": \"0000\", \"startDateTime\": \"2017-12-01T17:47:11-05:00\", \"durationTime\": \"22\", \"priority\": \"0\", \"doNotUse2\": 0, \"regions\": [ { \"name\": \"bob\", \"regulatorID\": \"23\", \"segmentID\": \"33\", \"anchorPosition\": { \"latitude\": \"41.678473\", \"longitude\": \"-108.782775\", \"elevation\": \"917.1432\" }, \"laneWidth\": \"7\", \"directionality\": \"1\", \"closedPath\": \"false\", \"direction\": \"1010101010101010\", \"description\": \"geometry\", \"geometry\": { \"direction\": \"1010101010101010\", \"extent\": \"1\", \"laneWidth\": \"33\", \"circle\": { \"position\": { \"latitude\": \"41.678473\", \"longitude\": \"-108.782775\", \"elevation\": \"917.1432\" }, \"radius\": \"15\", \"units\": \"7\" } } } ], \"doNotUse4\": 0, \"doNotUse3\": 0, \"content\": \"exitService\", \"items\": [ \"250\" ], \"url\": \"null\" } ] }}");
     TravelerMessageFromHumanToAsnConverter.convertTravelerInputDataToEncodableTim(inputTID);
@@ -133,14 +128,13 @@ class TravelerMessageFromHumanToAsnConverterTest {
     Assertions.assertEquals(expectedTID.toString(), inputTID.toString());
 
     JSONObject timObject = new JSONObject();
-    timObject.put(TravelerMessageFromHumanToAsnConverter.TRAVELER_INFORMATION,
-        JsonUtils.toJSONObject(inputTID.toString()));
-    Assertions.assertNotNull(XML.toString(timObject));
+    timObject.put(TravelerMessageFromHumanToAsnConverter.TRAVELER_INFORMATION, JsonUtils.toJSONObject(inputTID.toString()));
+    assertNotNull(XML.toString(timObject));
   }
 
   @Test
-  void testGeometryAdvisoryReverse() throws JsonUtilsException,
-      TravelerMessageFromHumanToAsnConverter.NoncompliantFieldsException {
+  void testGeometryAdvisoryReverse() throws JsonUtilsException, TravelerMessageFromHumanToAsnConverter.NoncompliantFieldsException,
+      TravelerMessageFromHumanToAsnConverter.InvalidNodeLatLonOffsetException {
     ObjectNode inputTID = JsonUtils.toObjectNode(
         "{\"request\":{\"rsus\":[{\"rsuIndex\":\"10\",\"rsuTarget\":\"127.0.0.3\",\"rsuUsername\":\"v3user\",\"rsuPassword\":\"password\",\"rsuRetries\":\"1\",\"rsuTimeout\":\"1000\"}],\"snmp\":{\"rsuid\":\"00000083\",\"msgid\":\"31\",\"mode\":\"1\",\"channel\":\"178\",\"interval\":\"2\",\"deliverystart\":\"2017-06-01T17:47:11-05:00\",\"deliverystop\":\"2018-01-01T17:47:11-05:15\",\"enable\":\"1\",\"status\":\"4\"},\"sdw\":{\"ttl\":\"oneweek\",\"serviceRegion\":{\"nwCorner\":{\"latitude\":\"44.998459\",\"longitude\":\"-111.040817\"},\"seCorner\":{\"latitude\":\"41.104674\",\"longitude\":\"-104.111312\"}}}}, \"tim\": { \"msgCnt\": \"13\", \"timeStamp\": \"2017-03-13T01:07:11-05:00\", \"packetID\": \"1\", \"urlB\": \"null\", \"dataframes\": [ { \"doNotUse1\": 0, \"frameType\": \"roadSignage\", \"msgId\": \"roadSignID\", \"position\": { \"latitude\": \"41.678473\", \"longitude\": \"-108.782775\", \"elevation\": \"917.1432\" }, \"viewAngle\": \"1010101010101010\", \"mutcd\": \"5\", \"crc\": \"0000\", \"startDateTime\": \"2017-12-01T17:47:11-05:00\", \"durationTime\": \"22\", \"priority\": \"0\", \"doNotUse2\": 0, \"regions\": [ { \"name\": \"bob\", \"regulatorID\": \"23\", \"segmentID\": \"33\", \"anchorPosition\": { \"latitude\": \"41.678473\", \"longitude\": \"-108.782775\", \"elevation\": \"917.1432\" }, \"laneWidth\": \"7\", \"directionality\": \"2\", \"closedPath\": \"false\", \"direction\": \"1010101010101010\", \"description\": \"geometry\", \"geometry\": { \"direction\": \"1010101010101010\", \"extent\": \"1\", \"laneWidth\": \"33\", \"circle\": { \"position\": { \"latitude\": \"41.678473\", \"longitude\": \"-108.782775\", \"elevation\": \"917.1432\" }, \"radius\": \"15\", \"units\": \"7\" } } } ], \"doNotUse4\": 0, \"doNotUse3\": 0, \"content\": \"advisory\", \"items\": [ \"250\" ], \"url\": \"null\" } ] }}");
     TravelerMessageFromHumanToAsnConverter.convertTravelerInputDataToEncodableTim(inputTID);
@@ -150,30 +144,28 @@ class TravelerMessageFromHumanToAsnConverterTest {
     Assertions.assertEquals(expectedTID.toString(), inputTID.toString());
 
     JSONObject timObject = new JSONObject();
-    timObject.put(TravelerMessageFromHumanToAsnConverter.TRAVELER_INFORMATION,
-        JsonUtils.toJSONObject(inputTID.toString()));
-    Assertions.assertNotNull(XML.toString(timObject));
+    timObject.put(TravelerMessageFromHumanToAsnConverter.TRAVELER_INFORMATION, JsonUtils.toJSONObject(inputTID.toString()));
+    assertNotNull(XML.toString(timObject));
   }
 
   @Test
-  void testRoadSignIDWorkzone() throws JsonUtilsException,
-      TravelerMessageFromHumanToAsnConverter.NoncompliantFieldsException {
+  void testRoadSignIDWorkzone() throws JsonUtilsException, TravelerMessageFromHumanToAsnConverter.NoncompliantFieldsException,
+      TravelerMessageFromHumanToAsnConverter.InvalidNodeLatLonOffsetException {
     ObjectNode inputTID = JsonUtils.toObjectNode(
-        "{\"request\":{\"rsus\":[{\"rsuIndex\":\"10\",\"rsuTarget\":\"127.0.0.3\",\"rsuUsername\":\"v3user\",\"rsuPassword\":\"password\",\"rsuRetries\":\"1\",\"rsuTimeout\":\"1000\"}],\"snmp\":{\"rsuid\":\"00000083\",\"msgid\":\"31\",\"mode\":\"1\",\"channel\":\"178\",\"interval\":\"2\",\"deliverystart\":\"2017-06-01T17:47:11-05:00\",\"deliverystop\":\"2018-01-01T17:47:11-05:15\",\"enable\":\"1\",\"status\":\"4\"},\"sdw\":{\"ttl\":\"oneweek\",\"serviceRegion\":{\"nwCorner\":{\"latitude\":\"44.998459\",\"longitude\":\"-111.040817\"},\"seCorner\":{\"latitude\":\"41.104674\",\"longitude\":\"-104.111312\"}}}},\"tim\":{\"msgCnt\": \"2\", \"timeStamp\": \"2017-08-03T22:25:36.297Z\", \"urlB\": \"null\", \"packetID\": \"EC9C236B0000000000\", \"dataframes\": [ { \"startDateTime\": \"2017-08-02T22:25:00.000Z\", \"durationTime\": 1, \"doNotUse1\": 0, \"frameType\": \"commercialSignage\", \"msgId\": { \"roadSignID\": { \"position\": { \"latitude\": \"41.678473\", \"longitude\": \"-108.782775\", \"elevation\": \"917.1432\" }, \"viewAngle\": \"1010101010101010\", \"mutcdCode\": \"warning\", \"crc\": \"0000\" } }, \"priority\": \"0\", \"doNotUse2\": 0, \"regions\": [ { \"name\": \"Testing TIM\", \"regulatorID\": \"0\", \"segmentID\": \"33\", \"anchorPosition\": { \"latitude\": \"41.2500807\", \"longitude\": \"-111.0093847\", \"elevation\": \"2020.6969900289998\" }, \"laneWidth\": \"7\", \"directionality\": \"3\", \"closedPath\": \"false\", \"description\": \"path\", \"path\": { \"scale\": \"0\", \"type\": \"ll\", \"nodes\": [ {\"nodeLong\":\"0.0002047\",\"nodeLat\":\"-0.0002048\",\"delta\":\"node-LL\",\"attributes\":{\"localNode\":[\"stopLine\",\"roundedCapStyleA\",\"roundedCapStyleB\",\"mergePoint\",\"divergePoint\",\"downstreamStopLine\",\"downstreamStartNode\",\"closedToTraffic\",\"safeIsland\",\"curbPresentAtStepOff\",\"hydrantPresent\",\"reserved\"],\"disabled\":[\"reserved\",\"doNotBlock\",\"whiteLine\",\"mergingLaneLeft\",\"mergingLaneRight\",\"curbOnLeft\",\"curbOnRight\",\"loadingzoneOnLeft\",\"loadingzoneOnRight\",\"turnOutPointOnLeft\",\"turnOutPointOnRight\"],\"enabled\":[\"adjacentParkingOnLeft\",\"adjacentParkingOnRight\",\"adjacentBikeLaneOnLeft\"],\"data\":[{\"pathEndPointAngle\":123},{\"laneCrownPointCenter\":12.3},{\"laneCrownPointLeft\":\"23.4\"},{\"laneCrownPointRight\":34.5},{\"laneAngle\":\"1.23\"},{\"speedLimits\":[{\"type\":\"2\",\"speed\":\"12.3\"},{\"type\":\"maxSpeedInSchoolZone\",\"speed\":\"23.4\"},{\"type\":3,\"speed\":12.3},{\"type\":\"vehicleMinSpeed\",\"speed\":23.4}]}],\"dWidth\":\"1.23\",\"dElevation\":\"2.34\"}}, { \"nodeLong\": \"0.0030974\", \"nodeLat\": \"0.0014568\", \"delta\": \"node-LL3\" }, { \"nodeLong\": \"0.0030983\", \"nodeLat\": \"0.0014559\", \"delta\": \"node-LL3\" }, { \"nodeLong\": \"0.0030980\", \"nodeLat\": \"0.0014563\", \"delta\": \"node-LL3\" }, { \"nodeLong\": \"0.0030982\", \"nodeLat\": \"0.0014562\", \"delta\": \"node-LL3\" } ] }, \"direction\": \"0000000000001010\" } ], \"doNotUse4\": 0, \"doNotUse3\": 0, \"content\": \"workZone\", \"items\": [ \"513\" ], \"url\": \"null\" } ] }}");
+        "{\"request\":{\"rsus\":[{\"rsuIndex\":\"10\",\"rsuTarget\":\"127.0.0.3\",\"rsuUsername\":\"v3user\",\"rsuPassword\":\"password\",\"rsuRetries\":\"1\",\"rsuTimeout\":\"1000\"}],\"snmp\":{\"rsuid\":\"00000083\",\"msgid\":\"31\",\"mode\":\"1\",\"channel\":\"178\",\"interval\":\"2\",\"deliverystart\":\"2017-06-01T17:47:11-05:00\",\"deliverystop\":\"2018-01-01T17:47:11-05:15\",\"enable\":\"1\",\"status\":\"4\"},\"sdw\":{\"ttl\":\"oneweek\",\"serviceRegion\":{\"nwCorner\":{\"latitude\":\"44.998459\",\"longitude\":\"-111.040817\"},\"seCorner\":{\"latitude\":\"41.104674\",\"longitude\":\"-104.111312\"}}}},\"tim\":{\"msgCnt\": \"2\", \"timeStamp\": \"2017-08-03T22:25:36.297Z\", \"urlB\": \"null\", \"packetID\": \"EC9C236B0000000000\", \"dataframes\": [ { \"startDateTime\": \"2017-08-02T22:25:00.000Z\", \"durationTime\": 1, \"doNotUse1\": 0, \"frameType\": \"commercialSignage\", \"msgId\": { \"roadSignID\": { \"position\": { \"latitude\": \"41.678473\", \"longitude\": \"-108.782775\", \"elevation\": \"917.1432\" }, \"viewAngle\": \"1010101010101010\", \"mutcdCode\": \"warning\", \"crc\": \"0000\" } }, \"priority\": \"0\", \"doNotUse2\": 0, \"regions\": [ { \"name\": \"Testing TIM\", \"regulatorID\": \"0\", \"segmentID\": \"33\", \"anchorPosition\": { \"latitude\": \"41.2500807\", \"longitude\": \"-111.0093847\", \"elevation\": \"2020.6969900289998\" }, \"laneWidth\": \"7\", \"directionality\": \"3\", \"closedPath\": \"false\", \"description\": \"path\", \"path\": { \"scale\": \"0\", \"type\": \"ll\", \"nodes\": [ {\"nodeLong\":\"0.0002047\",\"nodeLat\":\"-0.0002047\",\"delta\":\"node-LL\",\"attributes\":{\"localNode\":[\"stopLine\",\"roundedCapStyleA\",\"roundedCapStyleB\",\"mergePoint\",\"divergePoint\",\"downstreamStopLine\",\"downstreamStartNode\",\"closedToTraffic\",\"safeIsland\",\"curbPresentAtStepOff\",\"hydrantPresent\",\"reserved\"],\"disabled\":[\"reserved\",\"doNotBlock\",\"whiteLine\",\"mergingLaneLeft\",\"mergingLaneRight\",\"curbOnLeft\",\"curbOnRight\",\"loadingzoneOnLeft\",\"loadingzoneOnRight\",\"turnOutPointOnLeft\",\"turnOutPointOnRight\"],\"enabled\":[\"adjacentParkingOnLeft\",\"adjacentParkingOnRight\",\"adjacentBikeLaneOnLeft\"],\"data\":[{\"pathEndPointAngle\":123},{\"laneCrownPointCenter\":12.3},{\"laneCrownPointLeft\":\"23.4\"},{\"laneCrownPointRight\":34.5},{\"laneAngle\":\"1.23\"},{\"speedLimits\":[{\"type\":\"2\",\"speed\":\"12.3\"},{\"type\":\"maxSpeedInSchoolZone\",\"speed\":\"23.4\"},{\"type\":3,\"speed\":12.3},{\"type\":\"vehicleMinSpeed\",\"speed\":23.4}]}],\"dWidth\":\"1.23\",\"dElevation\":\"2.34\"}}, { \"nodeLong\": \"0.0030974\", \"nodeLat\": \"0.0014568\", \"delta\": \"node-LL3\" }, { \"nodeLong\": \"0.0030983\", \"nodeLat\": \"0.0014559\", \"delta\": \"node-LL3\" }, { \"nodeLong\": \"0.0030980\", \"nodeLat\": \"0.0014563\", \"delta\": \"node-LL3\" }, { \"nodeLong\": \"0.0030982\", \"nodeLat\": \"0.0014562\", \"delta\": \"node-LL3\" } ] }, \"direction\": \"0000000000001010\" } ], \"doNotUse4\": 0, \"doNotUse3\": 0, \"content\": \"workZone\", \"items\": [ \"513\" ], \"url\": \"null\" } ] }}");
     TravelerMessageFromHumanToAsnConverter.convertTravelerInputDataToEncodableTim(inputTID);
 
     ObjectNode expectedTID = JsonUtils.toObjectNode(
-        "{\"request\":{\"rsus\":[{\"rsuIndex\":\"10\",\"rsuTarget\":\"127.0.0.3\",\"rsuUsername\":\"v3user\",\"rsuPassword\":\"password\",\"rsuRetries\":\"1\",\"rsuTimeout\":\"1000\"}],\"snmp\":{\"rsuid\":\"00000083\",\"msgid\":\"31\",\"mode\":\"1\",\"channel\":\"178\",\"interval\":\"2\",\"deliverystart\":\"2017-06-01T17:47:11-05:00\",\"deliverystop\":\"2018-01-01T17:47:11-05:15\",\"enable\":\"1\",\"status\":\"4\"},\"sdw\":{\"ttl\":\"oneweek\",\"serviceRegion\":{\"nwCorner\":{\"latitude\":\"44.998459\",\"longitude\":\"-111.040817\"},\"seCorner\":{\"latitude\":\"41.104674\",\"longitude\":\"-104.111312\"}}}},\"tim\":{\"msgCnt\":\"2\",\"timeStamp\":309505,\"urlB\":\"null\",\"packetID\":\"EC9C236B0000000000\",\"dataFrames\":{\"TravelerDataFrame\":[{\"durationTime\":1,\"doNotUse1\":0,\"frameType\":{\"commercialSignage\":\"EMPTY_TAG\"},\"msgId\":{\"roadSignID\":{\"position\":{\"lat\":416784730,\"long\":-1087827750,\"elevation\":9171},\"viewAngle\":\"1010101010101010\",\"mutcdCode\":{\"warning\":\"EMPTY_TAG\"},\"crc\":\"0000\"}},\"priority\":\"0\",\"doNotUse2\":0,\"regions\":{\"GeographicalPath\":[{\"name\":\"Testing TIM\",\"laneWidth\":700,\"directionality\":{\"both\":\"EMPTY_TAG\"},\"closedPath\":\"BOOLEAN_OBJECT_FALSE\",\"description\":{\"path\":{\"scale\":\"0\",\"offset\":{\"ll\":{\"nodes\":{\"NodeLL\":[{\"delta\":{\"node-LL1\":{\"lat\":-2048,\"lon\":2047}}},{\"delta\":{\"node-LL3\":{\"lat\":14568,\"lon\":30974}}},{\"delta\":{\"node-LL3\":{\"lat\":14559,\"lon\":30983}}},{\"delta\":{\"node-LL3\":{\"lat\":14563,\"lon\":30980}}},{\"delta\":{\"node-LL3\":{\"lat\":14562,\"lon\":30982}}}]}}}}},\"direction\":\"0000000000001010\",\"id\":{\"region\":0,\"id\":33},\"anchor\":{\"lat\":412500807,\"long\":-1110093847,\"elevation\":20207}}]},\"doNotUse4\":0,\"doNotUse3\":0,\"url\":\"null\",\"startYear\":2017,\"startTime\":308065,\"tcontent\":{\"workZone\":{\"SEQUENCE\":[{\"item\":{\"itis\":513}}]}}}]}}}");
+        "{\"request\":{\"rsus\":[{\"rsuIndex\":\"10\",\"rsuTarget\":\"127.0.0.3\",\"rsuUsername\":\"v3user\",\"rsuPassword\":\"password\",\"rsuRetries\":\"1\",\"rsuTimeout\":\"1000\"}],\"snmp\":{\"rsuid\":\"00000083\",\"msgid\":\"31\",\"mode\":\"1\",\"channel\":\"178\",\"interval\":\"2\",\"deliverystart\":\"2017-06-01T17:47:11-05:00\",\"deliverystop\":\"2018-01-01T17:47:11-05:15\",\"enable\":\"1\",\"status\":\"4\"},\"sdw\":{\"ttl\":\"oneweek\",\"serviceRegion\":{\"nwCorner\":{\"latitude\":\"44.998459\",\"longitude\":\"-111.040817\"},\"seCorner\":{\"latitude\":\"41.104674\",\"longitude\":\"-104.111312\"}}}},\"tim\":{\"msgCnt\":\"2\",\"timeStamp\":309505,\"urlB\":\"null\",\"packetID\":\"EC9C236B0000000000\",\"dataFrames\":{\"TravelerDataFrame\":[{\"durationTime\":1,\"doNotUse1\":0,\"frameType\":{\"commercialSignage\":\"EMPTY_TAG\"},\"msgId\":{\"roadSignID\":{\"position\":{\"lat\":416784730,\"long\":-1087827750,\"elevation\":9171},\"viewAngle\":\"1010101010101010\",\"mutcdCode\":{\"warning\":\"EMPTY_TAG\"},\"crc\":\"0000\"}},\"priority\":\"0\",\"doNotUse2\":0,\"regions\":{\"GeographicalPath\":[{\"name\":\"Testing TIM\",\"laneWidth\":700,\"directionality\":{\"both\":\"EMPTY_TAG\"},\"closedPath\":\"BOOLEAN_OBJECT_FALSE\",\"description\":{\"path\":{\"scale\":\"0\",\"offset\":{\"ll\":{\"nodes\":{\"NodeLL\":[{\"delta\":{\"node-LL1\":{\"lat\":-2047,\"lon\":2047}}},{\"delta\":{\"node-LL3\":{\"lat\":14568,\"lon\":30974}}},{\"delta\":{\"node-LL3\":{\"lat\":14559,\"lon\":30983}}},{\"delta\":{\"node-LL3\":{\"lat\":14563,\"lon\":30980}}},{\"delta\":{\"node-LL3\":{\"lat\":14562,\"lon\":30982}}}]}}}}},\"direction\":\"0000000000001010\",\"id\":{\"region\":0,\"id\":33},\"anchor\":{\"lat\":412500807,\"long\":-1110093847,\"elevation\":20207}}]},\"doNotUse4\":0,\"doNotUse3\":0,\"url\":\"null\",\"startYear\":2017,\"startTime\":308065,\"tcontent\":{\"workZone\":{\"SEQUENCE\":[{\"item\":{\"itis\":513}}]}}}]}}}");
     Assertions.assertEquals(expectedTID.toString(), inputTID.toString());
     JSONObject timObject = new JSONObject();
-    timObject.put(TravelerMessageFromHumanToAsnConverter.TRAVELER_INFORMATION,
-        JsonUtils.toJSONObject(inputTID.toString()));
-    Assertions.assertNotNull(XML.toString(timObject));
+    timObject.put(TravelerMessageFromHumanToAsnConverter.TRAVELER_INFORMATION, JsonUtils.toJSONObject(inputTID.toString()));
+    assertNotNull(XML.toString(timObject));
   }
 
   @Test
-  void testGeometryBothGenericSign() throws JsonUtilsException,
-      TravelerMessageFromHumanToAsnConverter.NoncompliantFieldsException {
+  void testGeometryBothGenericSign() throws JsonUtilsException, TravelerMessageFromHumanToAsnConverter.NoncompliantFieldsException,
+      TravelerMessageFromHumanToAsnConverter.InvalidNodeLatLonOffsetException {
     ObjectNode inputTID = JsonUtils.toObjectNode(
         "{\"request\":{\"rsus\":[{\"rsuIndex\":\"10\",\"rsuTarget\":\"127.0.0.3\",\"rsuUsername\":\"v3user\",\"rsuPassword\":\"password\",\"rsuRetries\":\"1\",\"rsuTimeout\":\"1000\"}],\"snmp\":{\"rsuid\":\"00000083\",\"msgid\":\"31\",\"mode\":\"1\",\"channel\":\"178\",\"interval\":\"2\",\"deliverystart\":\"2017-06-01T17:47:11-05:00\",\"deliverystop\":\"2018-01-01T17:47:11-05:15\",\"enable\":\"1\",\"status\":\"4\"},\"sdw\":{\"ttl\":\"oneweek\",\"serviceRegion\":{\"nwCorner\":{\"latitude\":\"44.998459\",\"longitude\":\"-111.040817\"},\"seCorner\":{\"latitude\":\"41.104674\",\"longitude\":\"-104.111312\"}}}}, \"tim\": { \"msgCnt\": \"13\", \"timeStamp\": \"2017-03-13T01:07:11-05:00\", \"packetID\": \"1\", \"urlB\": \"null\", \"dataframes\": [ { \"doNotUse1\": 0, \"frameType\": \"0\", \"msgId\": \"roadSignID\", \"position\": { \"latitude\": \"41.678473\", \"longitude\": \"-108.782775\", \"elevation\": \"917.1432\" }, \"viewAngle\": \"1010101010101010\", \"mutcd\": \"5\", \"crc\": \"0000\", \"startDateTime\": \"2017-12-01T17:47:11-05:00\", \"durationTime\": \"22\", \"priority\": \"0\", \"doNotUse2\": 0, \"regions\": [ { \"name\": \"bob\", \"regulatorID\": \"23\", \"segmentID\": \"33\", \"anchorPosition\": { \"latitude\": \"41.678473\", \"longitude\": \"-108.782775\", \"elevation\": \"917.1432\" }, \"laneWidth\": \"7\", \"directionality\": \"3\", \"closedPath\": \"false\", \"direction\": \"1010101010101010\", \"description\": \"geometry\", \"geometry\": { \"direction\": \"1010101010101010\", \"extent\": \"1\", \"laneWidth\": \"33\", \"circle\": { \"position\": { \"latitude\": \"41.678473\", \"longitude\": \"-108.782775\", \"elevation\": \"917.1432\" }, \"radius\": \"15\", \"units\": \"7\" } } } ], \"doNotUse4\": 0, \"doNotUse3\": 0, \"content\": \"genericSign\", \"items\": [ \"250\" ], \"url\": \"null\" } ] }}");
     TravelerMessageFromHumanToAsnConverter.convertTravelerInputDataToEncodableTim(inputTID);
@@ -183,14 +175,13 @@ class TravelerMessageFromHumanToAsnConverterTest {
     Assertions.assertEquals(expectedTID.toString(), inputTID.toString());
 
     JSONObject timObject = new JSONObject();
-    timObject.put(TravelerMessageFromHumanToAsnConverter.TRAVELER_INFORMATION,
-        JsonUtils.toJSONObject(inputTID.toString()));
-    Assertions.assertNotNull(XML.toString(timObject));
+    timObject.put(TravelerMessageFromHumanToAsnConverter.TRAVELER_INFORMATION, JsonUtils.toJSONObject(inputTID.toString()));
+    assertNotNull(XML.toString(timObject));
   }
 
   @Test
-  void testPathSpeedLimit() throws JsonUtilsException,
-      TravelerMessageFromHumanToAsnConverter.NoncompliantFieldsException {
+  void testPathSpeedLimit() throws JsonUtilsException, TravelerMessageFromHumanToAsnConverter.NoncompliantFieldsException,
+      TravelerMessageFromHumanToAsnConverter.InvalidNodeLatLonOffsetException {
     ObjectNode inputTID = JsonUtils.toObjectNode(
         "{\"request\":{\"rsus\":[{\"rsuIndex\":\"10\",\"rsuTarget\":\"127.0.0.3\",\"rsuUsername\":\"v3user\",\"rsuPassword\":\"password\",\"rsuRetries\":\"1\",\"rsuTimeout\":\"1000\"}],\"snmp\":{\"rsuid\":\"00000083\",\"msgid\":\"31\",\"mode\":\"1\",\"channel\":\"178\",\"interval\":\"2\",\"deliverystart\":\"2017-06-01T17:47:11-05:00\",\"deliverystop\":\"2018-01-01T17:47:11-05:15\",\"enable\":\"1\",\"status\":\"4\"},\"sdw\":{\"ttl\":\"oneweek\",\"serviceRegion\":{\"nwCorner\":{\"latitude\":\"44.998459\",\"longitude\":\"-111.040817\"},\"seCorner\":{\"latitude\":\"41.104674\",\"longitude\":\"-104.111312\"}}}},\"tim\":{\"msgCnt\": \"1\", \"timeStamp\": \"2017-08-03T22:25:36.297Z\", \"urlB\": \"null\", \"packetID\": \"EC9C236B0000000000\", \"dataframes\": [ { \"startDateTime\": \"2017-08-02T22:25:00.000Z\", \"durationTime\": 1, \"doNotUse1\": 0, \"frameType\": \"advisory\", \"msgId\": { \"roadSignID\": { \"position\": { \"latitude\": \"41.678473\", \"longitude\": \"-108.782775\", \"elevation\": \"917.1432\" }, \"viewAngle\": \"1010101010101010\", \"mutcdCode\": \"warning\", \"crc\": \"0000\" } }, \"priority\": \"0\", \"doNotUse2\": 0, \"regions\": [ { \"name\": \"Testing TIM\", \"regulatorID\": \"0\", \"segmentID\": \"33\", \"anchorPosition\": { \"latitude\": \"41.2500807\", \"longitude\": \"-111.0093847\", \"elevation\": \"2020.6969900289998\" }, \"laneWidth\": \"7\", \"directionality\": \"3\", \"closedPath\": \"false\", \"description\": \"path\", \"path\": { \"scale\": \"0\", \"type\": \"ll\", \"nodes\": [ { \"nodeLong\": \"0.0031024\", \"nodeLat\": \"0.0014506\", \"delta\": \"node-LL3\",\"attributes\":{\"localNode\":[\"stopLine\",\"roundedCapStyleA\",\"roundedCapStyleB\",\"mergePoint\",\"divergePoint\",\"downstreamStopLine\",\"downstreamStartNode\",\"closedToTraffic\",\"safeIsland\",\"curbPresentAtStepOff\",\"hydrantPresent\",\"reserved\"],\"disabled\":[\"reserved\",\"doNotBlock\",\"whiteLine\",\"mergingLaneLeft\",\"mergingLaneRight\",\"curbOnLeft\",\"curbOnRight\",\"loadingzoneOnLeft\",\"loadingzoneOnRight\",\"turnOutPointOnLeft\",\"turnOutPointOnRight\"],\"enabled\":[\"adjacentParkingOnLeft\",\"adjacentParkingOnRight\",\"adjacentBikeLaneOnLeft\"],\"data\":[{\"pathEndPointAngle\":\"123\"},{\"laneCrownPointCenter\":\"111\"},{\"laneCrownPointLeft\":\"5.5\"}],\"dWidth\":\"33\",\"dElevation\":\"500\"} }, { \"nodeLong\": \"0.0030974\", \"nodeLat\": \"0.0014568\", \"delta\": \"node-LL3\" }, { \"nodeLong\": \"0.0030983\", \"nodeLat\": \"0.0014559\", \"delta\": \"node-LL3\" }, { \"nodeLong\": \"0.0030980\", \"nodeLat\": \"0.0014563\", \"delta\": \"node-LL3\" }, { \"nodeLong\": \"0.0030982\", \"nodeLat\": \"0.0014562\", \"delta\": \"node-LL3\" } ] }, \"direction\": \"0000000000001010\" } ], \"doNotUse4\": 0, \"doNotUse3\": 0, \"content\": \"speedLimit\", \"items\": [ \"513\" ], \"url\": \"null\" } ] }}");
     TravelerMessageFromHumanToAsnConverter.convertTravelerInputDataToEncodableTim(inputTID);
@@ -199,25 +190,18 @@ class TravelerMessageFromHumanToAsnConverterTest {
         "{\"request\":{\"rsus\":[{\"rsuIndex\":\"10\",\"rsuTarget\":\"127.0.0.3\",\"rsuUsername\":\"v3user\",\"rsuPassword\":\"password\",\"rsuRetries\":\"1\",\"rsuTimeout\":\"1000\"}],\"snmp\":{\"rsuid\":\"00000083\",\"msgid\":\"31\",\"mode\":\"1\",\"channel\":\"178\",\"interval\":\"2\",\"deliverystart\":\"2017-06-01T17:47:11-05:00\",\"deliverystop\":\"2018-01-01T17:47:11-05:15\",\"enable\":\"1\",\"status\":\"4\"},\"sdw\":{\"ttl\":\"oneweek\",\"serviceRegion\":{\"nwCorner\":{\"latitude\":\"44.998459\",\"longitude\":\"-111.040817\"},\"seCorner\":{\"latitude\":\"41.104674\",\"longitude\":\"-104.111312\"}}}},\"tim\":{\"msgCnt\":\"1\",\"timeStamp\":309505,\"urlB\":\"null\",\"packetID\":\"EC9C236B0000000000\",\"dataFrames\":{\"TravelerDataFrame\":[{\"durationTime\":1,\"doNotUse1\":0,\"frameType\":{\"advisory\":\"EMPTY_TAG\"},\"msgId\":{\"roadSignID\":{\"position\":{\"lat\":416784730,\"long\":-1087827750,\"elevation\":9171},\"viewAngle\":\"1010101010101010\",\"mutcdCode\":{\"warning\":\"EMPTY_TAG\"},\"crc\":\"0000\"}},\"priority\":\"0\",\"doNotUse2\":0,\"regions\":{\"GeographicalPath\":[{\"name\":\"Testing TIM\",\"laneWidth\":700,\"directionality\":{\"both\":\"EMPTY_TAG\"},\"closedPath\":\"BOOLEAN_OBJECT_FALSE\",\"description\":{\"path\":{\"scale\":\"0\",\"offset\":{\"ll\":{\"nodes\":{\"NodeLL\":[{\"delta\":{\"node-LL3\":{\"lat\":14506,\"lon\":31024}}},{\"delta\":{\"node-LL3\":{\"lat\":14568,\"lon\":30974}}},{\"delta\":{\"node-LL3\":{\"lat\":14559,\"lon\":30983}}},{\"delta\":{\"node-LL3\":{\"lat\":14563,\"lon\":30980}}},{\"delta\":{\"node-LL3\":{\"lat\":14562,\"lon\":30982}}}]}}}}},\"direction\":\"0000000000001010\",\"id\":{\"region\":0,\"id\":33},\"anchor\":{\"lat\":412500807,\"long\":-1110093847,\"elevation\":20207}}]},\"doNotUse4\":0,\"doNotUse3\":0,\"url\":\"null\",\"startYear\":2017,\"startTime\":308065,\"tcontent\":{\"speedLimit\":{\"SEQUENCE\":[{\"item\":{\"itis\":513}}]}}}]}}}");
     Assertions.assertEquals(expectedTID.toString(), inputTID.toString());
     JSONObject timObject = new JSONObject();
-    timObject.put(TravelerMessageFromHumanToAsnConverter.TRAVELER_INFORMATION,
-        JsonUtils.toJSONObject(inputTID.toString()));
-    Assertions.assertNotNull(XML.toString(timObject));
+    timObject.put(TravelerMessageFromHumanToAsnConverter.TRAVELER_INFORMATION, JsonUtils.toJSONObject(inputTID.toString()));
+    assertNotNull(XML.toString(timObject));
   }
 
   @Test
   void testTranslateISOTimeStampToMinuteOfYear() {
-    Assertions.assertEquals(232800,
-        TravelerMessageFromHumanToAsnConverter.translateISOTimeStampToMinuteOfYear(
-            "2018-06-11T16:00:00.000Z"));
+    Assertions.assertEquals(232800, TravelerMessageFromHumanToAsnConverter.translateISOTimeStampToMinuteOfYear("2018-06-11T16:00:00.000Z"));
 
-    Assertions.assertEquals(232800,
-        TravelerMessageFromHumanToAsnConverter.translateISOTimeStampToMinuteOfYear(
-            "2018-06-11T10:00-06:00"));
+    Assertions.assertEquals(232800, TravelerMessageFromHumanToAsnConverter.translateISOTimeStampToMinuteOfYear("2018-06-11T10:00-06:00"));
 
     // Test for invalid timestamp
-    Assertions.assertEquals(527040,
-        TravelerMessageFromHumanToAsnConverter.translateISOTimeStampToMinuteOfYear(
-            "2018-15-44T25:66:77.999Z"));
+    Assertions.assertEquals(527040, TravelerMessageFromHumanToAsnConverter.translateISOTimeStampToMinuteOfYear("2018-15-44T25:66:77.999Z"));
   }
 
   @Test
@@ -249,7 +233,7 @@ class TravelerMessageFromHumanToAsnConverterTest {
     String itisCode = "123";
     String itis = "itis";
     ObjectNode expectedItisNode = JsonUtils.newNode().put(itis, Integer.parseInt(itisCode));
-    ObjectNode expecteditem = (ObjectNode) JsonUtils.newNode().set("item", expectedItisNode);
+    ObjectNode expecteditem = JsonUtils.newNode().set("item", expectedItisNode);
 
     // build ITIS code
     JsonNode actualItem = TravelerMessageFromHumanToAsnConverter.buildItem(itisCode);
@@ -269,8 +253,8 @@ class TravelerMessageFromHumanToAsnConverterTest {
   }
 
   @Test
-  void testOldRegionWithShapePointSetWithNodeList() throws JsonUtilsException,
-      TravelerMessageFromHumanToAsnConverter.NoncompliantFieldsException {
+  void testOldRegionWithShapePointSetWithNodeList() throws JsonUtilsException, TravelerMessageFromHumanToAsnConverter.NoncompliantFieldsException,
+      TravelerMessageFromHumanToAsnConverter.InvalidNodeLatLonOffsetException {
     ObjectNode inputTID = JsonUtils.toObjectNode(
         "{\"request\":{\"rsus\":[{\"rsuIndex\":\"10\",\"rsuTarget\":\"127.0.0.3\",\"rsuUsername\":\"v3user\",\"rsuPassword\":\"password\",\"rsuRetries\":\"1\",\"rsuTimeout\":\"1000\"}],\"snmp\":{\"rsuid\":\"00000083\",\"msgid\":\"31\",\"mode\":\"1\",\"channel\":\"178\",\"interval\":\"2\",\"deliverystart\":\"2017-06-01T17:47:11-05:00\",\"deliverystop\":\"2018-01-01T17:47:11-05:15\",\"enable\":\"1\",\"status\":\"4\"},\"sdw\":{\"ttl\":\"oneweek\",\"serviceRegion\":{\"nwCorner\":{\"latitude\":\"44.998459\",\"longitude\":\"-111.040817\"},\"seCorner\":{\"latitude\":\"41.104674\",\"longitude\":\"-104.111312\"}}}},\"tim\":{\"msgCnt\":\"13\",\"timeStamp\":\"2017-03-13T01:07:11-05:00\",\"packetID\":\"EC9C236B0000000000\",\"urlB\":\"null\",\"dataframes\":[{\"doNotUse1\":0,\"frameType\":\"advisory\",\"msgId\":{\"roadSignID\":{\"position\":{\"latitude\":\"41.678473\",\"longitude\":\"-108.782775\",\"elevation\":\"917.1432\"},\"viewAngle\":\"1010101010101010\",\"mutcdCode\":\"warning\",\"crc\":\"0000\"}},\"startDateTime\":\"2017-12-01T17:47:11-05:00\",\"durationTime\":\"22\",\"priority\":\"0\",\"doNotUse2\":0,\"regions\":[{\"name\":\"bob\",\"regulatorID\":\"23\",\"segmentID\":\"33\",\"anchorPosition\":{\"latitude\":\"41.678473\",\"longitude\":\"-108.782775\",\"elevation\":\"917.1432\"},\"laneWidth\":\"7\",\"directionality\":\"3\",\"closedPath\":\"false\",\"direction\":\"1010101010101010\",\"description\":\"oldRegion\",\"oldRegion\":{\"direction\":\"1010101010101010\",\"extent\":\"1\",\"area\":{\"shapePointSet\":{\"anchor\":{\"latitude\":\"41.678473\",\"longitude\":\"-108.782775\",\"elevation\":\"917.1432\"},\"laneWidth\":\"33\",\"directionality\":\"3\",\"nodeList\":{\"nodes\":[{\"x\":\"-5.12\",\"y\":\"5.11\",\"delta\":\"node-XY\"},{\"x\":\"-10.24\",\"y\":\"10.23\",\"delta\":\"node-XY\"},{\"x\":\"-20.48\",\"y\":\"20.47\",\"delta\":\"node-XY\"},{\"x\":\"-40.96\",\"y\":\"40.95\",\"delta\":\"node-XY\"},{\"x\":\"-81.92\",\"y\":\"81.91\",\"delta\":\"node-XY\"},{\"x\":\"-327.68\",\"y\":\"327.67\",\"delta\":\"node-XY\"},{\"nodeLong\":\"-105.045087\",\"nodeLat\":\"40.569848\",\"delta\":\"node-LatLon\"}]}}}}}],\"doNotUse4\":0,\"doNotUse3\":0,\"content\":\"exitService\",\"items\":[\"125\",\"some text\",\"250\",\"'98765\"],\"url\":\"null\"}]}}");
     TravelerMessageFromHumanToAsnConverter.convertTravelerInputDataToEncodableTim(inputTID);
@@ -280,14 +264,14 @@ class TravelerMessageFromHumanToAsnConverterTest {
     Assertions.assertEquals(expectedTID.toString(), inputTID.toString());
 
     JSONObject timObject = new JSONObject();
-    timObject.put(TravelerMessageFromHumanToAsnConverter.TRAVELER_INFORMATION,
-        JsonUtils.toJSONObject(inputTID.toString()));
-    Assertions.assertNotNull(XML.toString(timObject));
+    timObject.put(TravelerMessageFromHumanToAsnConverter.TRAVELER_INFORMATION, JsonUtils.toJSONObject(inputTID.toString()));
+    assertNotNull(XML.toString(timObject));
   }
 
   @Test
-  void testOldRegionWithShapePointSetWithComputedLanesSmall() throws JsonUtilsException,
-      TravelerMessageFromHumanToAsnConverter.NoncompliantFieldsException {
+  void testOldRegionWithShapePointSetWithComputedLanesSmall()
+      throws JsonUtilsException, TravelerMessageFromHumanToAsnConverter.NoncompliantFieldsException,
+      TravelerMessageFromHumanToAsnConverter.InvalidNodeLatLonOffsetException {
     ObjectNode inputTID = JsonUtils.toObjectNode(
         "{\"request\":{\"rsus\":[{\"rsuIndex\":\"10\",\"rsuTarget\":\"127.0.0.3\",\"rsuUsername\":\"v3user\",\"rsuPassword\":\"password\",\"rsuRetries\":\"1\",\"rsuTimeout\":\"1000\"}],\"snmp\":{\"rsuid\":\"00000083\",\"msgid\":\"31\",\"mode\":\"1\",\"channel\":\"178\",\"interval\":\"2\",\"deliverystart\":\"2017-06-01T17:47:11-05:00\",\"deliverystop\":\"2018-01-01T17:47:11-05:15\",\"enable\":\"1\",\"status\":\"4\"},\"sdw\":{\"ttl\":\"oneweek\",\"serviceRegion\":{\"nwCorner\":{\"latitude\":\"44.998459\",\"longitude\":\"-111.040817\"},\"seCorner\":{\"latitude\":\"41.104674\",\"longitude\":\"-104.111312\"}}}},\"tim\":{\"msgCnt\":\"13\",\"timeStamp\":\"2017-03-13T01:07:11-05:00\",\"packetID\":\"EC9C236B0000000000\",\"urlB\":\"null\",\"dataframes\":[{\"doNotUse1\":0,\"frameType\":\"advisory\",\"msgId\":{\"roadSignID\":{\"position\":{\"latitude\":\"41.678473\",\"longitude\":\"-108.782775\",\"elevation\":\"917.1432\"},\"viewAngle\":\"1010101010101010\",\"mutcdCode\":\"warning\",\"crc\":\"0000\"}},\"startDateTime\":\"2017-12-01T17:47:11-05:00\",\"durationTime\":\"22\",\"priority\":\"0\",\"doNotUse2\":0,\"regions\":[{\"name\":\"bob\",\"regulatorID\":\"23\",\"segmentID\":\"33\",\"anchorPosition\":{\"latitude\":\"41.678473\",\"longitude\":\"-108.782775\",\"elevation\":\"917.1432\"},\"laneWidth\":\"7\",\"directionality\":\"3\",\"closedPath\":\"false\",\"direction\":\"1010101010101010\",\"description\":\"oldRegion\",\"oldRegion\":{\"direction\":\"1010101010101010\",\"extent\":\"1\",\"area\":{\"shapePointSet\":{\"anchor\":{\"latitude\":\"41.678473\",\"longitude\":\"-108.782775\",\"elevation\":\"917.1432\"},\"laneWidth\":\"33\",\"directionality\":\"3\",\"nodeList\":{\"computed\":{\"referenceLaneId\":\"123\",\"offsetXaxis\":\"111\",\"offsetYaxis\":\"111\",\"rotateXY\":\"123.45\",\"scaleXaxis\":\"123.45\",\"scaleYaxis\":\"123.45\"}}}}}}],\"doNotUse4\":0,\"doNotUse3\":0,\"content\":\"exitService\",\"items\":[\"125\",\"some text\",\"250\",\"'98765\"],\"url\":\"null\"}]}}");
     TravelerMessageFromHumanToAsnConverter.convertTravelerInputDataToEncodableTim(inputTID);
@@ -297,14 +281,14 @@ class TravelerMessageFromHumanToAsnConverterTest {
     Assertions.assertEquals(expectedTID.toString(), inputTID.toString());
 
     JSONObject timObject = new JSONObject();
-    timObject.put(TravelerMessageFromHumanToAsnConverter.TRAVELER_INFORMATION,
-        JsonUtils.toJSONObject(inputTID.toString()));
-    Assertions.assertNotNull(XML.toString(timObject));
+    timObject.put(TravelerMessageFromHumanToAsnConverter.TRAVELER_INFORMATION, JsonUtils.toJSONObject(inputTID.toString()));
+    assertNotNull(XML.toString(timObject));
   }
 
   @Test
-  void testOldRegionWithShapePointSetWithComputedLanesLarge() throws JsonUtilsException,
-      TravelerMessageFromHumanToAsnConverter.NoncompliantFieldsException {
+  void testOldRegionWithShapePointSetWithComputedLanesLarge()
+      throws JsonUtilsException, TravelerMessageFromHumanToAsnConverter.NoncompliantFieldsException,
+      TravelerMessageFromHumanToAsnConverter.InvalidNodeLatLonOffsetException {
     ObjectNode inputTID = JsonUtils.toObjectNode(
         "{\"request\":{\"rsus\":[{\"rsuIndex\":\"10\",\"rsuTarget\":\"127.0.0.3\",\"rsuUsername\":\"v3user\",\"rsuPassword\":\"password\",\"rsuRetries\":\"1\",\"rsuTimeout\":\"1000\"}],\"snmp\":{\"rsuid\":\"00000083\",\"msgid\":\"31\",\"mode\":\"1\",\"channel\":\"178\",\"interval\":\"2\",\"deliverystart\":\"2017-06-01T17:47:11-05:00\",\"deliverystop\":\"2018-01-01T17:47:11-05:15\",\"enable\":\"1\",\"status\":\"4\"},\"sdw\":{\"ttl\":\"oneweek\",\"serviceRegion\":{\"nwCorner\":{\"latitude\":\"44.998459\",\"longitude\":\"-111.040817\"},\"seCorner\":{\"latitude\":\"41.104674\",\"longitude\":\"-104.111312\"}}}},\"tim\":{\"msgCnt\":\"13\",\"timeStamp\":\"2017-03-13T01:07:11-05:00\",\"packetID\":\"EC9C236B0000000000\",\"urlB\":\"null\",\"dataframes\":[{\"doNotUse1\":0,\"frameType\":\"advisory\",\"msgId\":{\"roadSignID\":{\"position\":{\"latitude\":\"41.678473\",\"longitude\":\"-108.782775\",\"elevation\":\"917.1432\"},\"viewAngle\":\"1010101010101010\",\"mutcdCode\":\"warning\",\"crc\":\"0000\"}},\"startDateTime\":\"2017-12-01T17:47:11-05:00\",\"durationTime\":\"22\",\"priority\":\"0\",\"doNotUse2\":0,\"regions\":[{\"name\":\"bob\",\"regulatorID\":\"23\",\"segmentID\":\"33\",\"anchorPosition\":{\"latitude\":\"41.678473\",\"longitude\":\"-108.782775\",\"elevation\":\"917.1432\"},\"laneWidth\":\"7\",\"directionality\":\"3\",\"closedPath\":\"false\",\"direction\":\"1010101010101010\",\"description\":\"oldRegion\",\"oldRegion\":{\"direction\":\"1010101010101010\",\"extent\":\"1\",\"area\":{\"shapePointSet\":{\"anchor\":{\"latitude\":\"41.678473\",\"longitude\":\"-108.782775\",\"elevation\":\"917.1432\"},\"laneWidth\":\"33\",\"directionality\":\"3\",\"nodeList\":{\"computed\":{\"referenceLaneId\":\"123\",\"offsetXaxis\":\"11111\",\"offsetYaxis\":\"11111\",\"rotateXY\":\"123.45\",\"scaleXaxis\":\"123.45\",\"scaleYaxis\":\"123.45\"}}}}}}],\"doNotUse4\":0,\"doNotUse3\":0,\"content\":\"exitService\",\"items\":[\"125\",\"some text\",\"250\",\"'98765\"],\"url\":\"null\"}]}}");
     TravelerMessageFromHumanToAsnConverter.convertTravelerInputDataToEncodableTim(inputTID);
@@ -314,14 +298,13 @@ class TravelerMessageFromHumanToAsnConverterTest {
     Assertions.assertEquals(expectedTID.toString(), inputTID.toString());
 
     JSONObject timObject = new JSONObject();
-    timObject.put(TravelerMessageFromHumanToAsnConverter.TRAVELER_INFORMATION,
-        JsonUtils.toJSONObject(inputTID.toString()));
-    Assertions.assertNotNull(XML.toString(timObject));
+    timObject.put(TravelerMessageFromHumanToAsnConverter.TRAVELER_INFORMATION, JsonUtils.toJSONObject(inputTID.toString()));
+    assertNotNull(XML.toString(timObject));
   }
 
   @Test
-  void testOldRegionWithCircle() throws JsonUtilsException,
-      TravelerMessageFromHumanToAsnConverter.NoncompliantFieldsException {
+  void testOldRegionWithCircle() throws JsonUtilsException, TravelerMessageFromHumanToAsnConverter.NoncompliantFieldsException,
+      TravelerMessageFromHumanToAsnConverter.InvalidNodeLatLonOffsetException {
     ObjectNode inputTID = JsonUtils.toObjectNode(
         "{\"request\":{\"rsus\":[{\"rsuIndex\":\"10\",\"rsuTarget\":\"127.0.0.3\",\"rsuUsername\":\"v3user\",\"rsuPassword\":\"password\",\"rsuRetries\":\"1\",\"rsuTimeout\":\"1000\"}],\"snmp\":{\"rsuid\":\"00000083\",\"msgid\":\"31\",\"mode\":\"1\",\"channel\":\"178\",\"interval\":\"2\",\"deliverystart\":\"2017-06-01T17:47:11-05:00\",\"deliverystop\":\"2018-01-01T17:47:11-05:15\",\"enable\":\"1\",\"status\":\"4\"},\"sdw\":{\"ttl\":\"oneweek\",\"serviceRegion\":{\"nwCorner\":{\"latitude\":\"44.998459\",\"longitude\":\"-111.040817\"},\"seCorner\":{\"latitude\":\"41.104674\",\"longitude\":\"-104.111312\"}}}},\"tim\":{\"msgCnt\":\"13\",\"timeStamp\":\"2017-03-13T01:07:11-05:00\",\"packetID\":\"EC9C236B0000000000\",\"urlB\":\"null\",\"dataframes\":[{\"doNotUse1\":0,\"frameType\":\"advisory\",\"msgId\":{\"roadSignID\":{\"position\":{\"latitude\":\"41.678473\",\"longitude\":\"-108.782775\",\"elevation\":\"917.1432\"},\"viewAngle\":\"1010101010101010\",\"mutcdCode\":\"warning\",\"crc\":\"0000\"}},\"startDateTime\":\"2017-12-01T17:47:11-05:00\",\"durationTime\":\"22\",\"priority\":\"0\",\"doNotUse2\":0,\"regions\":[{\"name\":\"bob\",\"regulatorID\":\"23\",\"segmentID\":\"33\",\"anchorPosition\":{\"latitude\":\"41.678473\",\"longitude\":\"-108.782775\",\"elevation\":\"917.1432\"},\"laneWidth\":\"7\",\"directionality\":\"3\",\"closedPath\":\"false\",\"direction\":\"1010101010101010\",\"description\":\"oldRegion\",\"oldRegion\":{\"direction\":\"1010101010101010\",\"extent\":\"1\",\"area\":{\"circle\":{\"center\":{\"latitude\":\"41.678473\",\"longitude\":\"-108.782775\",\"elevation\":\"917.1432\"},\"radius\":\"2048\",\"units\":\"centimeter\"}}}}],\"doNotUse4\":0,\"doNotUse3\":0,\"content\":\"advisory\",\"items\":[\"125\",\"some text\",\"250\",\"'98765\"],\"url\":\"null\"}]}}");
     TravelerMessageFromHumanToAsnConverter.convertTravelerInputDataToEncodableTim(inputTID);
@@ -331,14 +314,13 @@ class TravelerMessageFromHumanToAsnConverterTest {
     Assertions.assertEquals(expectedTID.toString(), inputTID.toString());
 
     JSONObject timObject = new JSONObject();
-    timObject.put(TravelerMessageFromHumanToAsnConverter.TRAVELER_INFORMATION,
-        JsonUtils.toJSONObject(inputTID.toString()));
-    Assertions.assertNotNull(XML.toString(timObject));
+    timObject.put(TravelerMessageFromHumanToAsnConverter.TRAVELER_INFORMATION, JsonUtils.toJSONObject(inputTID.toString()));
+    assertNotNull(XML.toString(timObject));
   }
 
   @Test
-  void testOldRegionWithRegionPointSet() throws JsonUtilsException,
-      TravelerMessageFromHumanToAsnConverter.NoncompliantFieldsException {
+  void testOldRegionWithRegionPointSet() throws JsonUtilsException, TravelerMessageFromHumanToAsnConverter.NoncompliantFieldsException,
+      TravelerMessageFromHumanToAsnConverter.InvalidNodeLatLonOffsetException {
     ObjectNode inputTID = JsonUtils.toObjectNode(
         "{\"request\":{\"rsus\":[{\"rsuIndex\":\"10\",\"rsuTarget\":\"127.0.0.3\",\"rsuUsername\":\"v3user\",\"rsuPassword\":\"password\",\"rsuRetries\":\"1\",\"rsuTimeout\":\"1000\"}],\"snmp\":{\"rsuid\":\"00000083\",\"msgid\":\"31\",\"mode\":\"1\",\"channel\":\"178\",\"interval\":\"2\",\"deliverystart\":\"2017-06-01T17:47:11-05:00\",\"deliverystop\":\"2018-01-01T17:47:11-05:15\",\"enable\":\"1\",\"status\":\"4\"},\"sdw\":{\"ttl\":\"oneweek\",\"serviceRegion\":{\"nwCorner\":{\"latitude\":\"44.998459\",\"longitude\":\"-111.040817\"},\"seCorner\":{\"latitude\":\"41.104674\",\"longitude\":\"-104.111312\"}}}},\"tim\":{\"msgCnt\":\"13\",\"timeStamp\":\"2017-03-13T01:07:11-05:00\",\"packetID\":\"EC9C236B0000000000\",\"urlB\":\"null\",\"dataframes\":[{\"doNotUse1\":0,\"frameType\":\"advisory\",\"msgId\":{\"roadSignID\":{\"position\":{\"latitude\":\"41.678473\",\"longitude\":\"-108.782775\",\"elevation\":\"917.1432\"},\"viewAngle\":\"1010101010101010\",\"mutcdCode\":\"warning\",\"crc\":\"0000\"}},\"startDateTime\":\"2017-12-01T17:47:11-05:00\",\"durationTime\":\"22\",\"priority\":\"0\",\"doNotUse2\":0,\"regions\":[{\"name\":\"bob\",\"regulatorID\":\"23\",\"segmentID\":\"33\",\"anchorPosition\":{\"latitude\":\"41.678473\",\"longitude\":\"-108.782775\",\"elevation\":\"917.1432\"},\"laneWidth\":\"7\",\"directionality\":\"3\",\"closedPath\":\"false\",\"direction\":\"1010101010101010\",\"description\":\"oldRegion\",\"oldRegion\":{\"direction\":\"1010101010101010\",\"extent\":\"1\",\"area\":{\"regionPointSet\":{\"anchor\":{\"latitude\":\"41.678473\",\"longitude\":\"-108.782775\",\"elevation\":\"917.1432\"},\"scale\":\"0\",\"nodeList\":[{\"xOffset\":\"-0.003\",\"yOffset\":\"0.003\",\"zOffset\":\"0\"},{\"xOffset\":\"-0.002\",\"yOffset\":\"0.002\",\"zOffset\":\"0\"},{\"xOffset\":\"-0.001\",\"yOffset\":\"0.001\",\"zOffset\":\"0\"}]}}}}],\"doNotUse4\":0,\"doNotUse3\":0,\"content\":\"advisory\",\"items\":[\"125\",\"some text\",\"250\",\"'98765\"],\"url\":\"null\"}]}}");
     TravelerMessageFromHumanToAsnConverter.convertTravelerInputDataToEncodableTim(inputTID);
@@ -348,14 +330,12 @@ class TravelerMessageFromHumanToAsnConverterTest {
     Assertions.assertEquals(expectedTID.toString(), inputTID.toString());
 
     JSONObject timObject = new JSONObject();
-    timObject.put(TravelerMessageFromHumanToAsnConverter.TRAVELER_INFORMATION,
-        JsonUtils.toJSONObject(inputTID.toString()));
-    Assertions.assertNotNull(XML.toString(timObject));
+    timObject.put(TravelerMessageFromHumanToAsnConverter.TRAVELER_INFORMATION, JsonUtils.toJSONObject(inputTID.toString()));
+    assertNotNull(XML.toString(timObject));
   }
 
   @Test
-  void ensureComplianceWithJ2735Revision2024_noOldFields()
-      throws TravelerMessageFromHumanToAsnConverter.NoncompliantFieldsException {
+  void ensureComplianceWithJ2735Revision2024_noOldFields() throws TravelerMessageFromHumanToAsnConverter.NoncompliantFieldsException {
     ObjectNode dataFrame = JsonNodeFactory.instance.objectNode();
     dataFrame.put("doNotUse1", 0);
     dataFrame.put("doNotUse2", 0);
@@ -482,4 +462,240 @@ class TravelerMessageFromHumanToAsnConverterTest {
     });
   }
 
+  @Test
+  void transformNodeLL_LLTypeSpecified() throws JsonUtilsException, TravelerMessageFromHumanToAsnConverter.InvalidNodeLatLonOffsetException {
+    // prepare
+    ObjectNode node = JsonNodeFactory.instance.objectNode();
+    node.put("nodeLong", "0.0031024");
+    node.put("nodeLat", "0.0014506");
+    node.put("delta", "node-LL3");
+
+    // execute
+    ObjectNode result = TravelerMessageFromHumanToAsnConverter.transformNodeLL(node);
+
+    // verify
+    String expectedJson = "{\"delta\":{\"node-LL3\":{\"lat\":14506,\"lon\":31024}}}";
+    ObjectNode expected = JsonUtils.toObjectNode(expectedJson);
+
+    Assertions.assertEquals(expected.toString(), result.toString());
+  }
+
+  @Test
+  void transformNodeLL_LLTypeNotSpecified() throws JsonUtilsException, TravelerMessageFromHumanToAsnConverter.InvalidNodeLatLonOffsetException {
+    // prepare
+    ObjectNode node = JsonNodeFactory.instance.objectNode();
+    node.put("nodeLong", "-0.0008192");
+    node.put("nodeLat", "-0.0013123");
+    node.put("delta", "node-LL");
+
+    // execute
+    ObjectNode result = TravelerMessageFromHumanToAsnConverter.transformNodeLL(node);
+
+    // verify
+    String expectedJson = "{\"delta\":{\"node-LL3\":{\"lat\":-13123,\"lon\":-8192}}}";
+    ObjectNode expected = JsonUtils.toObjectNode(expectedJson);
+
+    Assertions.assertEquals(expected.toString(), result.toString());
+  }
+
+  long LL_1_MINIMUM_MICRO_DEGREES = TravelerMessageFromHumanToAsnConverter.NODE_LL1_LIMIT * -1;
+  long LL_2_MINIMUM_MICRO_DEGREES = TravelerMessageFromHumanToAsnConverter.NODE_LL2_LIMIT * -1;
+  long LL_3_MINIMUM_MICRO_DEGREES = TravelerMessageFromHumanToAsnConverter.NODE_LL3_LIMIT * -1;
+  long LL_4_MINIMUM_MICRO_DEGREES = TravelerMessageFromHumanToAsnConverter.NODE_LL4_LIMIT * -1;
+  long LL_5_MINIMUM_MICRO_DEGREES = TravelerMessageFromHumanToAsnConverter.NODE_LL5_LIMIT * -1;
+  long LL_6_MINIMUM_MICRO_DEGREES = TravelerMessageFromHumanToAsnConverter.NODE_LL6_LIMIT * -1;
+
+  @Test
+  void getNodeOffsetPointLLType_WhenLatLonWithinLL1Constraints_ShouldReturnGetNodeLLType1()
+      throws TravelerMessageFromHumanToAsnConverter.InvalidNodeLatLonOffsetException {
+    long transformedLat = -1500L; // within LL1 constraints
+    long transformedLong = -1500L; // within LL1 constraints
+    String selection = TravelerMessageFromHumanToAsnConverter.getNodeOffsetPointLLType(transformedLat, transformedLong);
+
+    Assertions.assertEquals(TravelerMessageFromHumanToAsnConverter.NODE_LL1, selection,
+        "Expected node-LL1 for latitude and longitude within LL1 constraints, " + "but got " + selection + " instead.");
+  }
+
+  @Test
+  void getNodeOffsetPointLLType_WhenLatOutsideLL1ConstraintAndLonAtLL1Boundary_ShouldReturnGetNodeLLType2()
+      throws TravelerMessageFromHumanToAsnConverter.InvalidNodeLatLonOffsetException {
+    long transformedLat = LL_1_MINIMUM_MICRO_DEGREES - 1; // outside LL1 constraints
+    long transformedLong = LL_1_MINIMUM_MICRO_DEGREES; // at LL1 boundary
+    String selection = TravelerMessageFromHumanToAsnConverter.getNodeOffsetPointLLType(transformedLat, transformedLong);
+
+    Assertions.assertEquals(TravelerMessageFromHumanToAsnConverter.NODE_LL2, selection,
+        "Expected node-LL2 when latitude exceeds LL1 constraints and longitude is at LL1 boundary, " + "but got " + selection + " instead.");
+  }
+
+  @Test
+  void getNodeOffsetPointLLType_WhenLonOutsideLL1ConstraintAndLatAtLL1Boundary_ShouldReturnGetNodeLLType2()
+      throws TravelerMessageFromHumanToAsnConverter.InvalidNodeLatLonOffsetException {
+    long transformedLat = LL_1_MINIMUM_MICRO_DEGREES; // at LL1 boundary
+    long transformedLong = LL_1_MINIMUM_MICRO_DEGREES - 1; // outside LL1 constraints
+    String selection = TravelerMessageFromHumanToAsnConverter.getNodeOffsetPointLLType(transformedLat, transformedLong);
+
+    Assertions.assertEquals(TravelerMessageFromHumanToAsnConverter.NODE_LL2, selection,
+        "Expected node-LL2 when longitude exceeds LL1 constraints and latitude is at LL1 boundary, " + "but got " + selection + " instead.");
+  }
+
+  @Test
+  void getNodeOffsetPointLLType_WhenLatAndLonWithinLL2Constraints_ShouldReturnGetNodeLLType2()
+      throws TravelerMessageFromHumanToAsnConverter.InvalidNodeLatLonOffsetException {
+    long transformedLat = -6000; // within LL2 constraints
+    long transformedLong = -6000; // within LL2 constraints
+    String selection = TravelerMessageFromHumanToAsnConverter.getNodeOffsetPointLLType(transformedLat, transformedLong);
+
+    Assertions.assertEquals(TravelerMessageFromHumanToAsnConverter.NODE_LL2, selection,
+        "Expected node-LL2 for latitude and longitude within LL2 constraints, " + "but got " + selection + " instead.");
+  }
+
+  @Test
+  void getNodeOffsetPointLLType_WhenLatOutsideLL2ConstraintAndLonAtLL2Boundary_ShouldReturnGetNodeLLType3()
+      throws TravelerMessageFromHumanToAsnConverter.InvalidNodeLatLonOffsetException {
+    long transformedLat = LL_2_MINIMUM_MICRO_DEGREES - 1; // outside LL2 constraints
+    long transformedLong = LL_2_MINIMUM_MICRO_DEGREES; // at LL2 boundary
+    String selection = TravelerMessageFromHumanToAsnConverter.getNodeOffsetPointLLType(transformedLat, transformedLong);
+
+    Assertions.assertEquals(TravelerMessageFromHumanToAsnConverter.NODE_LL3, selection,
+        "Expected node-LL3 when latitude exceeds LL2 constraints and longitude is at LL2 boundary, " + "but got " + selection + " instead.");
+  }
+
+  @Test
+  void getNodeOffsetPointLLType_WhenLonOutsideLL2ConstraintAndLatAtLL2Boundary_ShouldReturnGetNodeLLType3()
+      throws TravelerMessageFromHumanToAsnConverter.InvalidNodeLatLonOffsetException {
+    long transformedLat = LL_2_MINIMUM_MICRO_DEGREES; // at LL2 boundary
+    long transformedLong = LL_2_MINIMUM_MICRO_DEGREES - 1; // outside LL2 constraints
+    String selection = TravelerMessageFromHumanToAsnConverter.getNodeOffsetPointLLType(transformedLat, transformedLong);
+
+    Assertions.assertEquals(TravelerMessageFromHumanToAsnConverter.NODE_LL3, selection,
+        "Expected node-LL3 when longitude exceeds LL2 constraints and latitude is at LL2 boundary, " + "but got " + selection + " instead.");
+  }
+
+  @Test
+  void getNodeOffsetPointLLType_WhenLatAndLonWithinLL3Constraints_ShouldReturnGetNodeLLType3()
+      throws TravelerMessageFromHumanToAsnConverter.InvalidNodeLatLonOffsetException {
+    long transformedLat = -25000; // within LL3 constraints
+    long transformedLong = -25000; // within LL3 constraints
+    String selection = TravelerMessageFromHumanToAsnConverter.getNodeOffsetPointLLType(transformedLat, transformedLong);
+
+    Assertions.assertEquals(TravelerMessageFromHumanToAsnConverter.NODE_LL3, selection,
+        "Expected node-LL3 for latitude and longitude within LL3 constraints, " + "but got " + selection + " instead.");
+  }
+
+  @Test
+  void getNodeOffsetPointLLType_WhenLatOutsideLL3ConstraintAndLonAtLL3Boundary_ShouldReturnGetNodeLLType4()
+      throws TravelerMessageFromHumanToAsnConverter.InvalidNodeLatLonOffsetException {
+    long transformedLat = LL_3_MINIMUM_MICRO_DEGREES - 1; // outside LL3 constraints
+    long transformedLong = LL_3_MINIMUM_MICRO_DEGREES; // at LL3 boundary
+    String selection = TravelerMessageFromHumanToAsnConverter.getNodeOffsetPointLLType(transformedLat, transformedLong);
+
+    Assertions.assertEquals(TravelerMessageFromHumanToAsnConverter.NODE_LL4, selection,
+        "Expected node-LL4 when latitude exceeds LL3 constraints and longitude is at LL3 boundary, " + "but got " + selection + " instead.");
+  }
+
+  @Test
+  void getNodeOffsetPointLLType_WhenLonOutsideLL3ConstraintAndLatAtLL3Boundary_ShouldReturnGetNodeLLType4()
+      throws TravelerMessageFromHumanToAsnConverter.InvalidNodeLatLonOffsetException {
+    long transformedLat = LL_3_MINIMUM_MICRO_DEGREES; // at LL3 boundary
+    long transformedLong = LL_3_MINIMUM_MICRO_DEGREES - 1; // outside LL3 constraints
+    String selection = TravelerMessageFromHumanToAsnConverter.getNodeOffsetPointLLType(transformedLat, transformedLong);
+
+    Assertions.assertEquals(TravelerMessageFromHumanToAsnConverter.NODE_LL4, selection,
+        "Expected node-LL4 when longitude exceeds LL3 constraints and latitude is at LL3 boundary, " + "but got " + selection + " instead.");
+  }
+
+  @Test
+  void getNodeOffsetPointLLType_WhenLatAndLonWithinLL4Constraints_ShouldReturnGetNodeLLType4()
+      throws TravelerMessageFromHumanToAsnConverter.InvalidNodeLatLonOffsetException {
+    long transformedLat = -125000; // within LL4 constraints
+    long transformedLong = -125000; // within LL4 constraints
+    String selection = TravelerMessageFromHumanToAsnConverter.getNodeOffsetPointLLType(transformedLat, transformedLong);
+
+    Assertions.assertEquals(TravelerMessageFromHumanToAsnConverter.NODE_LL4, selection,
+        "Expected node-LL4 for latitude and longitude within LL4 constraints, " + "but got " + selection + " instead.");
+  }
+
+  @Test
+  void getNodeOffsetPointLLType_WhenLatOutsideLL4ConstraintAndLonAtLL4Boundary_ShouldReturnGetNodeLLType5()
+      throws TravelerMessageFromHumanToAsnConverter.InvalidNodeLatLonOffsetException {
+    long transformedLat = LL_4_MINIMUM_MICRO_DEGREES - 1; // outside LL4 constraints
+    long transformedLong = LL_4_MINIMUM_MICRO_DEGREES; // at LL4 boundary
+    String selection = TravelerMessageFromHumanToAsnConverter.getNodeOffsetPointLLType(transformedLat, transformedLong);
+
+    Assertions.assertEquals(TravelerMessageFromHumanToAsnConverter.NODE_LL5, selection,
+        "Expected node-LL5 when latitude exceeds LL4 constraints and longitude is at LL4 boundary, " + "but got " + selection + " instead.");
+  }
+
+  @Test
+  void getNodeOffsetPointLLType_WhenLonOutsideLL4ConstraintAndLatAtLL4Boundary_ShouldReturnGetNodeLLType5()
+      throws TravelerMessageFromHumanToAsnConverter.InvalidNodeLatLonOffsetException {
+    long transformedLat = LL_4_MINIMUM_MICRO_DEGREES; // at LL4 boundary
+    long transformedLong = LL_4_MINIMUM_MICRO_DEGREES - 1; // outside LL4 constraints
+    String selection = TravelerMessageFromHumanToAsnConverter.getNodeOffsetPointLLType(transformedLat, transformedLong);
+
+    Assertions.assertEquals(TravelerMessageFromHumanToAsnConverter.NODE_LL5, selection,
+        "Expected node-LL5 when longitude exceeds LL4 constraints and latitude is at LL4 boundary, " + "but got " + selection + " instead.");
+  }
+
+  @Test
+  void getNodeOffsetPointLLType_WhenLatAndLonWithinLL5Constraints_ShouldReturnGetNodeLLType5()
+      throws TravelerMessageFromHumanToAsnConverter.InvalidNodeLatLonOffsetException {
+    long transformedLat = -2000000L; // within LL5 constraints
+    long transformedLong = -2000000L; // within LL5 constraints
+    String selection = TravelerMessageFromHumanToAsnConverter.getNodeOffsetPointLLType(transformedLat, transformedLong);
+
+    Assertions.assertEquals(TravelerMessageFromHumanToAsnConverter.NODE_LL5, selection,
+        "Expected node-LL5 for latitude and longitude within LL5 constraints, " + "but got " + selection + " instead.");
+  }
+
+  @Test
+  void getNodeOffsetPointLLType_WhenLatOutsideLL5ConstraintAndLonAtLL5Boundary_ShouldReturnGetNodeLLType6()
+      throws TravelerMessageFromHumanToAsnConverter.InvalidNodeLatLonOffsetException {
+    long transformedLat = LL_5_MINIMUM_MICRO_DEGREES - 1; // outside LL5 constraints
+    long transformedLong = LL_5_MINIMUM_MICRO_DEGREES; // at LL5 boundary
+    String selection = TravelerMessageFromHumanToAsnConverter.getNodeOffsetPointLLType(transformedLat, transformedLong);
+
+    Assertions.assertEquals(TravelerMessageFromHumanToAsnConverter.NODE_LL6, selection,
+        "Expected node-LL6 when latitude exceeds LL5 constraints and longitude is at LL5 boundary, " + "but got " + selection + " instead.");
+  }
+
+  @Test
+  void getNodeOffsetPointLLType_WhenLonOutsideLL5ConstraintAndLatAtLL5Boundary_ShouldReturnGetNodeLLType6()
+      throws TravelerMessageFromHumanToAsnConverter.InvalidNodeLatLonOffsetException {
+    long transformedLat = LL_5_MINIMUM_MICRO_DEGREES; // at LL5 boundary
+    long transformedLong = LL_5_MINIMUM_MICRO_DEGREES - 1; // outside LL5 constraints
+    String selection = TravelerMessageFromHumanToAsnConverter.getNodeOffsetPointLLType(transformedLat, transformedLong);
+
+    Assertions.assertEquals(TravelerMessageFromHumanToAsnConverter.NODE_LL6, selection,
+        "Expected node-LL6 when longitude exceeds LL5 constraints and latitude is at LL5 boundary, " + "but got " + selection + " instead.");
+  }
+
+  @Test
+  void getNodeOffsetPointLLType_WhenLatAndLonWithinLL6Constraints_ShouldReturnGetNodeLLType6()
+      throws TravelerMessageFromHumanToAsnConverter.InvalidNodeLatLonOffsetException {
+    long transformedLat = -8000000L; // within LL6 constraints
+    long transformedLong = -8000000L; // within LL6 constraints
+    String selection = TravelerMessageFromHumanToAsnConverter.getNodeOffsetPointLLType(transformedLat, transformedLong);
+
+    Assertions.assertEquals(TravelerMessageFromHumanToAsnConverter.NODE_LL6, selection,
+        "Expected node-LL6 for latitude and longitude within LL6 constraints, " + "but got " + selection + " instead.");
+  }
+
+  @Test
+  void getNodeOffsetPointLLType_WhenLatOutsideLL6ConstraintAndLonAtLL6Boundary_ShouldThrowException() {
+    long transformedLat = LL_6_MINIMUM_MICRO_DEGREES - 1; // outside LL6 constraints
+    long transformedLong = LL_6_MINIMUM_MICRO_DEGREES; // at LL6 boundary
+    assertThrows(TravelerMessageFromHumanToAsnConverter.InvalidNodeLatLonOffsetException.class, () -> {
+      TravelerMessageFromHumanToAsnConverter.getNodeOffsetPointLLType(transformedLat, transformedLong);
+    });
+  }
+
+  @Test
+  void getNodeOffsetPointLLType_WhenLonOutsideLL6ConstraintAndLatAtLL6Boundary_ShouldThrowException() {
+    long transformedLat = LL_6_MINIMUM_MICRO_DEGREES; // at LL6 boundary
+    long transformedLong = LL_6_MINIMUM_MICRO_DEGREES - 1; // outside LL6 constraints
+    assertThrows(TravelerMessageFromHumanToAsnConverter.InvalidNodeLatLonOffsetException.class, () -> {
+      TravelerMessageFromHumanToAsnConverter.getNodeOffsetPointLLType(transformedLat, transformedLong);
+    });
+  }
 }

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/traveler/TimDepositController.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/traveler/TimDepositController.java
@@ -286,6 +286,12 @@ public class TimDepositController {
       return ResponseEntity.status(HttpStatus.BAD_REQUEST)
           .body(
               JsonUtils.jsonKeyValue(ERRSTR, errMsg));
+    } catch (TravelerMessageFromHumanToAsnConverter.InvalidNodeLatLonOffsetException e) {
+        String errMsg = "Invalid node lat/lon offset in TIM: " + e.getMessage();
+        log.error(errMsg);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(
+                JsonUtils.jsonKeyValue(ERRSTR, errMsg));
     }
 
     try {

--- a/jpo-ode-svcs/src/test/java/us/dot/its/jpo/ode/traveler/TimDepositControllerTest.java
+++ b/jpo-ode-svcs/src/test/java/us/dot/its/jpo/ode/traveler/TimDepositControllerTest.java
@@ -116,7 +116,7 @@ class TimDepositControllerTest {
   void failedObjectNodeConversionShouldReturnConvertingError(@Capturing
                                                              TravelerMessageFromHumanToAsnConverter capturingTravelerMessageFromHumanToAsnConverter)
       throws JsonUtilsException,
-      TravelerMessageFromHumanToAsnConverter.NoncompliantFieldsException {
+      TravelerMessageFromHumanToAsnConverter.NoncompliantFieldsException, TravelerMessageFromHumanToAsnConverter.InvalidNodeLatLonOffsetException {
 
     new Expectations() {
 

--- a/jpo-ode-svcs/src/test/java/us/dot/its/jpo/ode/traveler/TimTransmogrifierTest.java
+++ b/jpo-ode-svcs/src/test/java/us/dot/its/jpo/ode/traveler/TimTransmogrifierTest.java
@@ -282,7 +282,7 @@ class TimTransmogrifierTest {
   @Test
   void testConvertToXML_VerifyPositionElementNotInCircleElementAfterConversion()
       throws IOException, JsonUtilsException, XmlUtilsException, ParseException,
-      TravelerMessageFromHumanToAsnConverter.NoncompliantFieldsException {
+      TravelerMessageFromHumanToAsnConverter.NoncompliantFieldsException, TravelerMessageFromHumanToAsnConverter.InvalidNodeLatLonOffsetException {
     // prepare
     String timRequestContainingCircleGeometry = new String(Files.readAllBytes(Paths.get(
         "src/test/resources/us/dot/its/jpo/ode/traveler/timRequestContainingCircleGeometry.json")));

--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,13 @@
             <compilerArgs>
               <arg>-Xlint:deprecation</arg>
             </compilerArgs>
+            <annotationProcessorPaths>
+              <path>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+                <version>1.18.30</version>
+              </path>
+            </annotationProcessorPaths>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
# PR Details
## Description
## Problem
Given a latitude delta of -0.0013123 and a longitude delta of -0.0008192, the ODE is currently selecting the node-LL2 type, which corresponds to the DF_Node-LL-28B dataframe. However, this dataframe is insufficient for these values, as it consists of two DE_OffsetLL-B14 data elements, each constrained to 14 bits, allowing only values between -8192 and 8191.

The selection of the NodeLL type occurs within the nodeOffsetPointLL method of the TravelerMessageFromHumanToAsnConverter class.

### Root Cause  
The `transformNodeLL` method, which calls `nodeOffsetPointLL`, was given the following input:  

```json
{
  "nodeLong": "-0.0008192",
  "nodeLat": "-0.0013123",
  "delta": "node-LL"
}
```  

The method relied on complex bitwise logic with nested expressions but lacked proper parentheses to enforce a single `X AND Y` condition at the top level. Instead, the logic was structured as `X AND Y OR Z`, leading to incorrect behavior. This caused `node-LL2` to be incorrectly selected when the latitude was out of range and the longitude was at the boundary, resulting in unsupported latitude and longitude values.

## Solution  
The `nodeOffsetPointLL` method has been renamed to `getNodeOffsetPointLLType` for clarity. It now uses straightforward numerical comparisons to check whether latitude and longitude offsets fall within the specified ranges for different LL types, rather than relying on complex bitwise logic.  

Since the J2735 specification explicitly defines these numerical constraints, using bitwise operations was unnecessary, added complexity, reduced readability, and increased the risk of errors. Switching to direct numerical comparisons simplifies the implementation and improves maintainability.

Additionally, the custom exception `InvalidNodeLatLonOffsetException` has been introduced to improve code clarity.

## Related Issue
No related GitHub issue.

## Motivation and Context
Accurate selection of NodeLL types is crucial for correctly encoding latitude and longitude offsets in compliance with the J2735 specification. An incorrect selection can lead to encoding failures and data loss, impacting the integrity of geospatial information used by downstream systems.

In this case, the system incorrectly selected node-LL2, which corresponds to the DF_Node-LL-28B dataframe. This structure, constrained by 14-bit offsets, was insufficient to represent the given latitude and longitude values, resulting in an inability to encode the data properly. The issue stemmed from flawed bitwise logic that misapplied constraints, particularly when values were near boundary conditions.

To resolve this, the logic has been refactored to use direct numerical comparisons against the defined J2735 constraints. This approach eliminates unnecessary complexity, improves readability, and ensures that the NodeLL types are chosen, preventing encoding failures and data loss.

## How Has This Been Tested?  
### Unit Testing
Unit tests have been added for the `determineNodeOffsetPointLLType` method to verify the correct selection of each LL type. The tests cover the following scenarios:  
- Latitude and longitude are within range → should select LL1 (example).  
- Longitude is at the boundary, and latitude is out of range → should select LL2 (example).  
- Latitude is at the boundary, and longitude is out of range → should select LL2 (example).
- Latitude or longitude is outside all boundaries → should throw exception

### Local Testing
The system was started using `docker compose up --build`, and TIM requests were sent to the `/tim` endpoint.  
- Setting the latitude/longitude offset to `-8388608` correctly triggered the `InvalidNodeLatLonOffsetException`.  
- Setting the latitude/longitude offset to a valid value within the specified constraints did not trigger the exception.

## Types of changes
- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:
- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
