### PR TITLE
Fix Signature Header Stripping

### DIFF
--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/kafka/listeners/asn1/Asn1EncodedDataRouter.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/kafka/listeners/asn1/Asn1EncodedDataRouter.java
@@ -263,7 +263,11 @@ public class Asn1EncodedDataRouter {
 
     sendToRsus(request, encodedTimWithoutHeaders);
     depositToFilteredTopic(metadataJson, encodedTimWithoutHeaders);
-    publishForSecondEncoding(request, encodedTimWithoutHeaders);
+    if (dataSigningEnabledSDW) {
+      publishForSecondEncoding(request, bytesToSend);
+    } else {
+      publishForSecondEncoding(request, encodedTimWithoutHeaders);
+    }
   }
 
   private void depositToTimCertExpirationTopic(JSONObject metadataJson, SignatureResultModel signedResponse, int maxDurationTime) {
@@ -441,6 +445,7 @@ public class Asn1EncodedDataRouter {
     try {
       log.debug("Publishing message for round 2 encoding");
       String asdPackagedTim = packageSignedTimIntoAsd(request, encodedTimWithoutHeaders);
+      // log.debug("ASD Packaged TIM for round 2 encoding: {}", asdPackagedTim);
       kafkaTemplate.send(asn1CoderTopics.getEncoderInput(), asdPackagedTim);
     } catch (Exception e) {
       log.error("Error packaging ASD for round 2 encoding", e);

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/kafka/listeners/asn1/Asn1EncodedDataRouter.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/kafka/listeners/asn1/Asn1EncodedDataRouter.java
@@ -445,7 +445,6 @@ public class Asn1EncodedDataRouter {
     try {
       log.debug("Publishing message for round 2 encoding");
       String asdPackagedTim = packageSignedTimIntoAsd(request, encodedTimWithoutHeaders);
-      // log.debug("ASD Packaged TIM for round 2 encoding: {}", asdPackagedTim);
       kafkaTemplate.send(asn1CoderTopics.getEncoderInput(), asdPackagedTim);
     } catch (Exception e) {
       log.error("Error packaging ASD for round 2 encoding", e);


### PR DESCRIPTION
# PR Details
## Description

This change adds additional logic when publishing a TIM for second-round encoding to ensure the TIM is signed if signing is enabled for SDX-deposit TIMs.

## Related Issue

There is no related issue for this fix. This issue was noticed after the latest Q2 ODE release was deployed to CDOT's test and prod environments.

## Motivation and Context

This change ensures that signed TIMs are correctly deposited to the SDX when signing is enabled.

## How Has This Been Tested?

This change was tested in the CDOT test environment and is currently deployed.

## Types of changes

- [ X ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X ] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/develop/docs/contributing_guide.md) 
- [ ] I have added tests to cover my changes.
- [ X ] All new and existing tests passed.
